### PR TITLE
feat: emit plan items for update_plan

### DIFF
--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -487,21 +488,34 @@ pub async fn query(
         };
 
         let results = orchestrator.execute_batch(&tool_calls, &tool_ctx).await;
+        let tool_names_by_id: HashMap<_, _> = tool_calls
+            .iter()
+            .map(|tool_call| (tool_call.id.clone(), tool_call.name.clone()))
+            .collect();
 
         // Build tool result message (user role, per Anthropic API convention)
-        // 1.4: Apply micro-compact to large tool results
+        // 1.4: Apply micro-compact to large tool results, except for successful
+        // canonical plan updates that become first-class plan items downstream.
         let result_content: Vec<ContentBlock> = results
             .into_iter()
             .map(|r| {
-                let compacted_content = micro_compact(r.output.content.clone());
+                let content = if matches!(
+                    tool_names_by_id.get(&r.tool_use_id).map(String::as_str),
+                    Some("update_plan")
+                ) && !r.output.is_error
+                {
+                    r.output.content.clone()
+                } else {
+                    micro_compact(r.output.content.clone())
+                };
                 emit(QueryEvent::ToolResult {
                     tool_use_id: r.tool_use_id.clone(),
-                    content: compacted_content.clone(),
+                    content: content.clone(),
                     is_error: r.output.is_error,
                 });
                 ContentBlock::ToolResult {
                     tool_use_id: r.tool_use_id,
-                    content: compacted_content,
+                    content,
                     is_error: r.output.is_error,
                 }
             })

--- a/crates/core/tests/update_plan_compaction.rs
+++ b/crates/core/tests/update_plan_compaction.rs
@@ -1,0 +1,172 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::Stream;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+use clawcr_core::{ContentBlock, Message, Model, SessionConfig, SessionState, TurnConfig, query};
+use clawcr_provider::{
+    ModelRequest, ModelResponse, ResponseContent, StopReason, StreamEvent, Usage,
+};
+use clawcr_tools::{Tool, ToolOrchestrator, ToolOutput, ToolRegistry};
+
+struct UpdatePlanToolUseProvider {
+    requests: AtomicUsize,
+}
+
+#[async_trait]
+impl clawcr_provider::ModelProviderSDK for UpdatePlanToolUseProvider {
+    async fn completion(&self, _request: ModelRequest) -> Result<ModelResponse> {
+        unreachable!("tests stream responses only")
+    }
+
+    async fn completion_stream(
+        &self,
+        _request: ModelRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent>> + Send>>> {
+        let request_number = self.requests.fetch_add(1, Ordering::SeqCst);
+
+        let events = if request_number == 0 {
+            vec![
+                Ok(StreamEvent::ContentBlockStart {
+                    index: 0,
+                    content: ResponseContent::ToolUse {
+                        id: "tool-1".into(),
+                        name: "update_plan".into(),
+                        input: json!({ "plan": [] }),
+                    },
+                }),
+                Ok(StreamEvent::InputJsonDelta {
+                    index: 0,
+                    partial_json: r#"{"plan":[]}"#.into(),
+                }),
+                Ok(StreamEvent::MessageDone {
+                    response: ModelResponse {
+                        id: "resp-1".into(),
+                        content: vec![ResponseContent::ToolUse {
+                            id: "tool-1".into(),
+                            name: "update_plan".into(),
+                            input: json!({ "plan": [] }),
+                        }],
+                        stop_reason: Some(StopReason::ToolUse),
+                        usage: Usage::default(),
+                        metadata: Default::default(),
+                    },
+                }),
+            ]
+        } else {
+            vec![Ok(StreamEvent::MessageDone {
+                response: ModelResponse {
+                    id: "resp-2".into(),
+                    content: vec![ResponseContent::Text("done".into())],
+                    stop_reason: Some(StopReason::EndTurn),
+                    usage: Usage::default(),
+                    metadata: Default::default(),
+                },
+            })]
+        };
+
+        Ok(Box::pin(futures::stream::iter(events)))
+    }
+
+    fn name(&self) -> &str {
+        "update-plan-tool-use-provider"
+    }
+}
+
+struct OversizedUpdatePlanErrorTool;
+
+#[async_trait]
+impl Tool for OversizedUpdatePlanErrorTool {
+    fn name(&self) -> &str {
+        "update_plan"
+    }
+
+    fn description(&self) -> &str {
+        "A test-only update_plan tool that emits an oversized error."
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "plan": { "type": "array" }
+            },
+            "required": ["plan"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        _ctx: &clawcr_tools::ToolContext,
+        _input: serde_json::Value,
+    ) -> Result<ToolOutput> {
+        Ok(ToolOutput::error(
+            "oversized update_plan error ".repeat(512),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn errored_update_plan_results_still_micro_compact() {
+    let mut registry = ToolRegistry::new();
+    registry.register(Arc::new(OversizedUpdatePlanErrorTool));
+    let registry = Arc::new(registry);
+    let orchestrator = ToolOrchestrator::new(Arc::clone(&registry));
+    let provider = UpdatePlanToolUseProvider {
+        requests: AtomicUsize::new(0),
+    };
+    let mut session = SessionState::new(SessionConfig::default(), std::env::temp_dir());
+    session.push_message(Message::user("update the plan"));
+
+    query(
+        &mut session,
+        &TurnConfig {
+            model: Model::default(),
+            thinking_selection: None,
+        },
+        &provider,
+        registry,
+        &orchestrator,
+        None,
+    )
+    .await
+    .expect("query should complete");
+
+    let tool_result_message = session
+        .messages
+        .iter()
+        .find(|message| {
+            message
+                .content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::ToolResult { .. }))
+        })
+        .expect("tool_result message should be appended");
+    let tool_result_blocks = tool_result_message
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::ToolResult {
+                content, is_error, ..
+            } => Some((content, is_error)),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(tool_result_blocks.len(), 1);
+    let (content, is_error) = tool_result_blocks[0];
+    assert_eq!(*is_error, true);
+    assert!(
+        content.contains("...[truncated]"),
+        "errored update_plan results should still be micro-compacted"
+    );
+    assert!(
+        content.len() < "oversized update_plan error ".repeat(512).len(),
+        "errored update_plan content should shrink after compaction"
+    );
+}

--- a/crates/server/src/persistence.rs
+++ b/crates/server/src/persistence.rs
@@ -307,10 +307,12 @@ impl ReplayState {
 
         let mut replayed_messages = self.messages;
         let mut replayed_history_items = self.history_items;
+        let mut tool_names_by_id = HashMap::new();
         for pending_item in ordered_items {
             apply_turn_item(
                 &mut replayed_messages,
                 &mut replayed_history_items,
+                &mut tool_names_by_id,
                 pending_item.turn_item,
             );
         }
@@ -399,9 +401,10 @@ struct ReplayHistoryItem {
 fn apply_turn_item(
     messages: &mut Vec<Message>,
     history_items: &mut Vec<crate::SessionHistoryItem>,
+    tool_names_by_id: &mut HashMap<String, String>,
     item: TurnItem,
 ) {
-    if let Some(history_item) = history_item_from_turn_item(&item) {
+    if let Some(history_item) = replay_history_item_from_turn_item(&item, tool_names_by_id) {
         history_items.push(history_item);
     }
     match item {
@@ -415,25 +418,28 @@ fn apply_turn_item(
             tool_call_id,
             tool_name,
             input,
-        }) => match messages.last_mut() {
-            Some(message) if message.role == Role::Assistant => {
-                message.content.push(ContentBlock::ToolUse {
-                    id: tool_call_id,
-                    name: tool_name,
-                    input,
-                });
-            }
-            _ => {
-                messages.push(Message {
-                    role: Role::Assistant,
-                    content: vec![ContentBlock::ToolUse {
+        }) => {
+            tool_names_by_id.insert(tool_call_id.clone(), tool_name.clone());
+            match messages.last_mut() {
+                Some(message) if message.role == Role::Assistant => {
+                    message.content.push(ContentBlock::ToolUse {
                         id: tool_call_id,
                         name: tool_name,
                         input,
-                    }],
-                });
+                    });
+                }
+                _ => {
+                    messages.push(Message {
+                        role: Role::Assistant,
+                        content: vec![ContentBlock::ToolUse {
+                            id: tool_call_id,
+                            name: tool_name,
+                            input,
+                        }],
+                    });
+                }
             }
-        },
+        }
         TurnItem::ToolResult(ToolResultItem {
             tool_call_id,
             output,
@@ -469,17 +475,39 @@ fn apply_turn_item(
                 }
             }
         }
-        TurnItem::Plan(TextItem { text })
-        | TurnItem::Reasoning(TextItem { text })
+        TurnItem::Reasoning(TextItem { text })
         | TurnItem::WebSearch(TextItem { text })
         | TurnItem::ImageGeneration(TextItem { text })
         | TurnItem::ContextCompaction(TextItem { text })
         | TurnItem::HookPrompt(TextItem { text }) => {
             messages.push(Message::assistant_text(text));
         }
+        // Plan items are replay-visible transcript data, but they are not part of the
+        // provider-facing tool-call/result conversation state used for subsequent turns.
+        TurnItem::Plan(_) => {}
         TurnItem::ToolProgress(_)
         | TurnItem::ApprovalRequest(_)
         | TurnItem::ApprovalDecision(_) => {}
+    }
+}
+
+fn replay_history_item_from_turn_item(
+    item: &TurnItem,
+    tool_names_by_id: &HashMap<String, String>,
+) -> Option<crate::SessionHistoryItem> {
+    match item {
+        TurnItem::ToolResult(ToolResultItem {
+            tool_call_id,
+            is_error,
+            ..
+        }) if matches!(
+            tool_names_by_id.get(tool_call_id).map(String::as_str),
+            Some("update_plan")
+        ) && !is_error =>
+        {
+            None
+        }
+        other => history_item_from_turn_item(other),
     }
 }
 
@@ -616,6 +644,27 @@ pub(crate) fn build_item_record(
     turn_status: Option<TurnStatus>,
     worklog: Option<Worklog>,
 ) -> ItemRecord {
+    build_item_record_with_output_items(
+        session_id,
+        turn_id,
+        item_id,
+        seq,
+        vec![item],
+        turn_status,
+        worklog,
+    )
+}
+
+/// Creates one canonical persisted item record from normalized output payloads.
+pub(crate) fn build_item_record_with_output_items(
+    session_id: SessionId,
+    turn_id: TurnId,
+    item_id: clawcr_core::ItemId,
+    seq: u64,
+    output_items: Vec<TurnItem>,
+    turn_status: Option<TurnStatus>,
+    worklog: Option<Worklog>,
+) -> ItemRecord {
     ItemRecord {
         id: item_id,
         session_id,
@@ -626,7 +675,7 @@ pub(crate) fn build_item_record(
         turn_status,
         sibling_turn_ids: Vec::new(),
         input_items: Vec::new(),
-        output_items: vec![item],
+        output_items,
         worklog,
         error: None,
         schema_version: 1,

--- a/crates/server/src/runtime.rs
+++ b/crates/server/src/runtime.rs
@@ -34,6 +34,8 @@ use crate::{
     titles::{build_title_generation_request, derive_provisional_title, normalize_generated_title},
 };
 
+mod plan;
+
 pub struct ServerRuntime {
     metadata: InitializeResult,
     deps: ServerRuntimeDependencies,
@@ -42,6 +44,11 @@ pub struct ServerRuntime {
     connections: Mutex<HashMap<u64, ConnectionRuntime>>,
     active_tasks: Mutex<HashMap<SessionId, tokio::task::AbortHandle>>,
     next_connection_id: AtomicU64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HistoryVisibility {
+    Visible,
 }
 
 impl ServerRuntime {
@@ -1005,6 +1012,7 @@ impl ServerRuntime {
             let mut assistant_item_seq = None;
             let mut assistant_text = String::new();
             let mut latest_usage: Option<TurnUsage> = None;
+            let mut tool_names_by_id = HashMap::new();
             let mut usage_base: Option<(usize, usize)> = None;
             while let Some(event) = event_rx.recv().await {
                 match event {
@@ -1063,10 +1071,12 @@ impl ServerRuntime {
                                         "title": "Assistant",
                                         "text": assistant_text,
                                     }),
+                                    HistoryVisibility::Visible,
                                 )
                                 .await;
                             assistant_text.clear();
                         }
+                        tool_names_by_id.insert(id.clone(), name.clone());
                         runtime
                             .emit_turn_item(
                                 session_id,
@@ -1090,23 +1100,36 @@ impl ServerRuntime {
                         content,
                         is_error,
                     } => {
-                        runtime
-                            .emit_turn_item(
-                                session_id,
-                                turn_for_events.turn_id,
-                                ItemKind::ToolResult,
-                                TurnItem::ToolResult(ToolResultItem {
-                                    tool_call_id: tool_use_id.clone(),
-                                    output: serde_json::Value::String(content.clone()),
-                                    is_error,
-                                }),
-                                serde_json::json!({
-                                    "tool_use_id": tool_use_id,
-                                    "content": content,
-                                    "is_error": is_error,
-                                }),
-                            )
-                            .await;
+                        let tool_name = tool_names_by_id.remove(&tool_use_id);
+                        if matches!(tool_name.as_deref(), Some("update_plan")) && !is_error {
+                            runtime
+                                .emit_plan_update(
+                                    session_id,
+                                    turn_for_events.turn_id,
+                                    &turn_for_events,
+                                    &tool_use_id,
+                                    &content,
+                                )
+                                .await;
+                        } else {
+                            runtime
+                                .emit_turn_item(
+                                    session_id,
+                                    turn_for_events.turn_id,
+                                    ItemKind::ToolResult,
+                                    TurnItem::ToolResult(ToolResultItem {
+                                        tool_call_id: tool_use_id.clone(),
+                                        output: serde_json::Value::String(content.clone()),
+                                        is_error,
+                                    }),
+                                    serde_json::json!({
+                                        "tool_use_id": tool_use_id,
+                                        "content": content,
+                                        "is_error": is_error,
+                                    }),
+                                )
+                                .await;
+                        }
                     }
                     QueryEvent::UsageDelta {
                         input_tokens,
@@ -1149,6 +1172,11 @@ impl ServerRuntime {
                                 base.0 + usage.input_tokens as usize;
                             session.summary.total_output_tokens =
                                 base.1 + usage.output_tokens as usize;
+                            if let Some(active_turn) = session.active_turn.as_mut()
+                                && active_turn.turn_id == turn_for_events.turn_id
+                            {
+                                active_turn.usage = Some(usage.clone());
+                            }
                         }
                         let _ = runtime
                             .broadcast_event(ServerEvent::TurnUsageUpdated(
@@ -1177,6 +1205,7 @@ impl ServerRuntime {
                             text: assistant_text.clone(),
                         }),
                         serde_json::json!({ "title": "Assistant", "text": assistant_text }),
+                        HistoryVisibility::Visible,
                     )
                     .await;
             }
@@ -1492,6 +1521,26 @@ impl ServerRuntime {
         turn_item: TurnItem,
         payload: serde_json::Value,
     ) {
+        self.emit_turn_item_with_history_visibility(
+            session_id,
+            turn_id,
+            item_kind,
+            turn_item,
+            payload,
+            HistoryVisibility::Visible,
+        )
+        .await;
+    }
+
+    async fn emit_turn_item_with_history_visibility(
+        &self,
+        session_id: SessionId,
+        turn_id: TurnId,
+        item_kind: ItemKind,
+        turn_item: TurnItem,
+        payload: serde_json::Value,
+        history_visibility: HistoryVisibility,
+    ) {
         let (item_id, item_seq) = self
             .start_item(session_id, turn_id, item_kind.clone(), payload.clone())
             .await;
@@ -1503,6 +1552,7 @@ impl ServerRuntime {
             item_kind.clone(),
             turn_item,
             payload.clone(),
+            history_visibility,
         )
         .await;
     }
@@ -1578,6 +1628,7 @@ impl ServerRuntime {
         item_kind: ItemKind,
         turn_item: TurnItem,
         payload: serde_json::Value,
+        history_visibility: HistoryVisibility,
     ) {
         self.persist_item(
             session_id,
@@ -1587,6 +1638,7 @@ impl ServerRuntime {
             turn_item,
             Some(TurnStatus::Running),
             None,
+            history_visibility,
         )
         .await;
         self.emit_item_completed(session_id, turn_id, item_id, item_kind, payload)
@@ -1602,11 +1654,14 @@ impl ServerRuntime {
         turn_item: TurnItem,
         turn_status: Option<TurnStatus>,
         worklog: Option<Worklog>,
+        history_visibility: HistoryVisibility,
     ) {
         if let Some(session_arc) = self.sessions.lock().await.get(&session_id).cloned() {
             let record = {
                 let mut session = session_arc.lock().await;
-                if let Some(history_item) = history_item_from_turn_item(&turn_item) {
+                if history_visibility == HistoryVisibility::Visible
+                    && let Some(history_item) = history_item_from_turn_item(&turn_item)
+                {
                     session.history_items.push(history_item);
                 }
                 session.record.clone()
@@ -1637,6 +1692,29 @@ impl ServerRuntime {
             return item_seq;
         }
         1
+    }
+
+    async fn current_turn_summary(
+        &self,
+        session_id: SessionId,
+        turn_id: TurnId,
+        fallback: &TurnSummary,
+    ) -> TurnSummary {
+        let Some(session_arc) = self.sessions.lock().await.get(&session_id).cloned() else {
+            return fallback.clone();
+        };
+        let session = session_arc.lock().await;
+        if let Some(active_turn) = session.active_turn.as_ref()
+            && active_turn.turn_id == turn_id
+        {
+            return active_turn.clone();
+        }
+        if let Some(latest_turn) = session.latest_turn.as_ref()
+            && latest_turn.turn_id == turn_id
+        {
+            return latest_turn.clone();
+        }
+        fallback.clone()
     }
 
     async fn subscribe_connection_to_session(

--- a/crates/server/src/runtime/plan.rs
+++ b/crates/server/src/runtime/plan.rs
@@ -1,0 +1,91 @@
+use clawcr_core::{SessionId, TextItem, ToolResultItem, TurnId, TurnItem, TurnStatus};
+use tracing::warn;
+
+use super::ServerRuntime;
+use crate::persistence::build_item_record_with_output_items;
+use crate::projection::history_item_from_turn_item;
+use crate::{EventContext, ItemDeltaKind, ItemDeltaPayload, ItemKind, ServerEvent, TurnSummary};
+
+impl ServerRuntime {
+    pub(super) async fn emit_plan_update(
+        &self,
+        session_id: SessionId,
+        turn_id: TurnId,
+        turn: &TurnSummary,
+        tool_use_id: &str,
+        content: &str,
+    ) {
+        let (item_id, item_seq) = self
+            .start_item(
+                session_id,
+                turn_id,
+                ItemKind::Plan,
+                serde_json::json!({
+                    "title": "Plan",
+                    "text": "",
+                    "tool_use_id": tool_use_id,
+                }),
+            )
+            .await;
+        self.broadcast_event(ServerEvent::ItemDelta {
+            delta_kind: ItemDeltaKind::PlanDelta,
+            payload: ItemDeltaPayload {
+                context: EventContext {
+                    session_id,
+                    turn_id: Some(turn_id),
+                    item_id: Some(item_id),
+                    seq: 0,
+                },
+                delta: content.to_string(),
+                stream_index: None,
+                channel: None,
+            },
+        })
+        .await;
+        let plan_item = TurnItem::Plan(TextItem {
+            text: content.to_string(),
+        });
+        let tool_result_item = TurnItem::ToolResult(ToolResultItem {
+            tool_call_id: tool_use_id.to_string(),
+            output: serde_json::Value::String(content.to_string()),
+            is_error: false,
+        });
+        if let Some(session_arc) = self.sessions.lock().await.get(&session_id).cloned() {
+            let record = {
+                let mut session = session_arc.lock().await;
+                if let Some(history_item) = history_item_from_turn_item(&plan_item) {
+                    session.history_items.push(history_item);
+                }
+                session.record.clone()
+            };
+            if let Some(record) = record {
+                let item = build_item_record_with_output_items(
+                    session_id,
+                    turn_id,
+                    item_id,
+                    item_seq,
+                    vec![tool_result_item, plan_item.clone()],
+                    Some(TurnStatus::Running),
+                    None,
+                );
+                if let Err(error) = self.rollout_store.append_item(&record, item) {
+                    warn!(session_id = %session_id, error = %error, "failed to persist item line");
+                }
+            }
+        }
+        self.emit_item_completed(
+            session_id,
+            turn_id,
+            item_id,
+            ItemKind::Plan,
+            serde_json::json!({ "title": "Plan", "text": content, "tool_use_id": tool_use_id }),
+        )
+        .await;
+        let current_turn = self.current_turn_summary(session_id, turn_id, turn).await;
+        self.broadcast_event(ServerEvent::TurnPlanUpdated(crate::TurnEventPayload {
+            session_id,
+            turn: current_turn,
+        }))
+        .await;
+    }
+}

--- a/crates/server/tests/plan_integration.rs
+++ b/crates/server/tests/plan_integration.rs
@@ -1,0 +1,824 @@
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use futures::stream;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::sync::mpsc;
+use tokio::time::{Duration, timeout};
+
+use clawcr_core::{PresetModelCatalog, RolloutLine, SessionId, TextItem, ToolResultItem, TurnItem};
+use clawcr_provider::{
+    ModelProviderSDK, ModelRequest, ModelResponse, RequestContent, RequestMessage, ResponseContent,
+    ResponseMetadata, StopReason, StreamEvent, Usage,
+};
+use clawcr_server::{
+    ClientTransportKind, ServerRuntime, ServerRuntimeDependencies, SessionHistoryItemKind,
+    SuccessResponse,
+};
+use clawcr_tools::{ToolRegistry, register_builtin_tools};
+
+struct ToolThenReplyProvider {
+    final_text: &'static str,
+    follow_up_text: &'static str,
+    stream_requests: Mutex<Vec<ModelRequest>>,
+    stream_calls: AtomicUsize,
+    tool_input: serde_json::Value,
+    tool_name: &'static str,
+}
+
+impl ToolThenReplyProvider {
+    fn new(
+        tool_name: &'static str,
+        tool_input: serde_json::Value,
+        final_text: &'static str,
+        follow_up_text: &'static str,
+    ) -> Self {
+        Self {
+            final_text,
+            follow_up_text,
+            stream_requests: Mutex::new(Vec::new()),
+            stream_calls: AtomicUsize::new(0),
+            tool_input,
+            tool_name,
+        }
+    }
+
+    fn stream_requests(&self) -> Vec<ModelRequest> {
+        self.stream_requests
+            .lock()
+            .expect("stream requests lock")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl ModelProviderSDK for ToolThenReplyProvider {
+    async fn completion(&self, _request: ModelRequest) -> Result<ModelResponse> {
+        Ok(ModelResponse {
+            id: "title-1".into(),
+            content: vec![ResponseContent::Text("Generated plan test title".into())],
+            stop_reason: Some(StopReason::EndTurn),
+            usage: Usage::default(),
+            metadata: ResponseMetadata::default(),
+        })
+    }
+
+    async fn completion_stream(
+        &self,
+        request: ModelRequest,
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<StreamEvent>> + Send>>> {
+        self.stream_requests
+            .lock()
+            .expect("stream requests lock")
+            .push(request);
+        let call_index = self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        if call_index == 0 {
+            let tool_input = self.tool_input.clone();
+            let tool_name = self.tool_name.to_string();
+            return Ok(Box::pin(stream::iter(vec![
+                Ok(StreamEvent::ContentBlockStart {
+                    index: 0,
+                    content: ResponseContent::ToolUse {
+                        id: "tool-1".into(),
+                        name: tool_name.clone(),
+                        input: json!({}),
+                    },
+                }),
+                Ok(StreamEvent::InputJsonDelta {
+                    index: 0,
+                    partial_json: tool_input.to_string(),
+                }),
+                Ok(StreamEvent::ContentBlockStop { index: 0 }),
+                Ok(StreamEvent::MessageDone {
+                    response: ModelResponse {
+                        id: "resp-tool".into(),
+                        content: vec![ResponseContent::ToolUse {
+                            id: "tool-1".into(),
+                            name: tool_name,
+                            input: tool_input,
+                        }],
+                        stop_reason: Some(StopReason::ToolUse),
+                        usage: Usage::default(),
+                        metadata: ResponseMetadata::default(),
+                    },
+                }),
+            ])));
+        }
+
+        let text = if call_index == 1 {
+            self.final_text
+        } else {
+            self.follow_up_text
+        };
+
+        Ok(Box::pin(stream::iter(vec![
+            Ok(StreamEvent::TextDelta {
+                index: 0,
+                text: text.into(),
+            }),
+            Ok(StreamEvent::MessageDone {
+                response: ModelResponse {
+                    id: "resp-final".into(),
+                    content: vec![ResponseContent::Text(text.into())],
+                    stop_reason: Some(StopReason::EndTurn),
+                    usage: Usage::default(),
+                    metadata: ResponseMetadata::default(),
+                },
+            }),
+        ])))
+    }
+
+    fn name(&self) -> &str {
+        "tool-then-reply-provider"
+    }
+}
+
+#[tokio::test]
+async fn update_plan_emits_plan_events_and_persists_plan_items() -> Result<()> {
+    let data_root = TempDir::new()?;
+    let plan = json!([
+        {
+            "status": "completed",
+            "step": "Inspect runtime"
+        },
+        {
+            "status": "in_progress",
+            "step": "Emit plan item"
+        }
+    ]);
+    let plan_input = json!({
+        "explanation": "Tracking server work",
+        "plan": plan
+    });
+    let expected_plan_text = format!(
+        "Tracking server work\n\n{}",
+        serde_json::to_string_pretty(plan_input["plan"].as_array().expect("plan array"))?
+    );
+    let runtime = build_runtime(
+        data_root.path(),
+        Arc::new(ToolThenReplyProvider::new(
+            "update_plan",
+            plan_input,
+            "Plan updated.",
+            "Follow-up completed.",
+        )),
+    );
+    let (connection_id, mut notifications_rx) = initialize_connection(&runtime).await?;
+    let session_id = start_session(&runtime, connection_id, data_root.path()).await?;
+
+    start_turn(&runtime, connection_id, session_id, "track the rollout").await?;
+    let notifications = collect_notifications_until_turn_completed(&mut notifications_rx).await?;
+
+    let plan_started_index = notifications
+        .iter()
+        .position(|value| {
+            value.get("method") == Some(&json!("item/started"))
+                && value["params"]["item"]["item_kind"] == json!("plan")
+        })
+        .context("plan item/started notification")?;
+    let plan_delta_index = notifications
+        .iter()
+        .position(|value| value.get("method") == Some(&json!("item/plan/delta")))
+        .context("plan delta notification")?;
+    let plan_completed_index = notifications
+        .iter()
+        .position(|value| {
+            value.get("method") == Some(&json!("item/completed"))
+                && value["params"]["item"]["item_kind"] == json!("plan")
+        })
+        .context("plan item/completed notification")?;
+    let turn_plan_updated_index = notifications
+        .iter()
+        .position(|value| value.get("method") == Some(&json!("turn/plan/updated")))
+        .context("turn/plan/updated notification")?;
+    let turn_usage_updated = notifications
+        .iter()
+        .find(|value| value.get("method") == Some(&json!("turn/usage/updated")))
+        .context("turn/usage/updated notification")?;
+
+    assert!(plan_started_index < plan_delta_index);
+    assert!(plan_delta_index < plan_completed_index);
+    assert!(plan_completed_index < turn_plan_updated_index);
+    assert_eq!(
+        notifications[plan_started_index]["params"]["item"]["payload"],
+        json!({ "title": "Plan", "text": "", "tool_use_id": "tool-1" })
+    );
+    assert_eq!(
+        notifications[plan_delta_index]["params"]["payload"]["delta"],
+        json!(expected_plan_text)
+    );
+    assert_eq!(
+        notifications[plan_completed_index]["params"]["item"]["payload"],
+        json!({ "title": "Plan", "text": expected_plan_text, "tool_use_id": "tool-1" })
+    );
+    assert!(
+        !notifications.iter().any(|value| {
+            value.get("method") == Some(&json!("item/completed"))
+                && value["params"]["item"]["item_kind"] == json!("tool_result")
+                && value["params"]["item"]["payload"]["tool_use_id"] == json!("tool-1")
+        }),
+        "successful update_plan must not emit a live tool_result item"
+    );
+    assert_eq!(
+        notifications[turn_plan_updated_index]["params"]["turn"]["usage"],
+        turn_usage_updated["params"]["usage"]
+    );
+
+    let rollout_lines = read_rollout_lines(data_root.path())?;
+    let persisted_outputs = rollout_lines
+        .iter()
+        .find_map(|line| match line {
+            RolloutLine::Item(item_line)
+                if item_line.item.output_items.iter().any(|item| {
+                    item == &TurnItem::Plan(TextItem {
+                        text: expected_plan_text.clone(),
+                    })
+                }) =>
+            {
+                Some(item_line.item.output_items.clone())
+            }
+            _ => None,
+        })
+        .context("expected rollout to persist a plan item")?;
+    assert_eq!(
+        persisted_outputs,
+        vec![
+            TurnItem::ToolResult(ToolResultItem {
+                tool_call_id: "tool-1".into(),
+                output: serde_json::Value::String(expected_plan_text.clone()),
+                is_error: false,
+            }),
+            TurnItem::Plan(TextItem {
+                text: expected_plan_text.clone(),
+            }),
+        ],
+        "successful update_plan persistence must keep replay and visible outputs in one item record"
+    );
+    let resumed = resume_session(&runtime, connection_id, session_id, 4).await?;
+    assert!(contains_history_item(
+        &resumed.history_items,
+        SessionHistoryItemKind::Assistant,
+        &expected_plan_text
+    ));
+    assert!(
+        !contains_history_item(
+            &resumed.history_items,
+            SessionHistoryItemKind::ToolResult,
+            &expected_plan_text
+        ),
+        "successful update_plan tool results must stay out of user-facing resume history"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_plan_replay_preserves_tool_result_prompt_shape_after_reload() -> Result<()> {
+    let data_root = TempDir::new()?;
+    let plan = json!([
+        {
+            "status": "completed",
+            "step": "Inspect runtime"
+        },
+        {
+            "status": "in_progress",
+            "step": "Emit plan item"
+        }
+    ]);
+    let plan_input = json!({
+        "explanation": "Tracking server work",
+        "plan": plan
+    });
+    let expected_plan_text = format!(
+        "Tracking server work\n\n{}",
+        serde_json::to_string_pretty(plan_input["plan"].as_array().expect("plan array"))?
+    );
+    let provider = Arc::new(ToolThenReplyProvider::new(
+        "update_plan",
+        plan_input,
+        "Plan updated.",
+        "Follow-up completed.",
+    ));
+    let runtime = build_runtime(data_root.path(), provider.clone());
+    let (connection_id, mut notifications_rx) = initialize_connection(&runtime).await?;
+    let session_id = start_session(&runtime, connection_id, data_root.path()).await?;
+
+    start_turn(&runtime, connection_id, session_id, "track the rollout").await?;
+    let _ = collect_notifications_until_turn_completed(&mut notifications_rx).await?;
+
+    let rebuilt_runtime = build_runtime(data_root.path(), provider.clone());
+    rebuilt_runtime.load_persisted_sessions().await?;
+    let (rebuilt_connection_id, mut rebuilt_notifications_rx) =
+        initialize_connection(&rebuilt_runtime).await?;
+    let rebuilt_resume =
+        resume_session(&rebuilt_runtime, rebuilt_connection_id, session_id, 4).await?;
+
+    assert!(contains_history_item(
+        &rebuilt_resume.history_items,
+        SessionHistoryItemKind::Assistant,
+        &expected_plan_text
+    ));
+    assert!(
+        !contains_history_item(
+            &rebuilt_resume.history_items,
+            SessionHistoryItemKind::ToolResult,
+            &expected_plan_text
+        ),
+        "rebuilt resume history must not duplicate successful update_plan output as a tool result"
+    );
+
+    start_turn(
+        &rebuilt_runtime,
+        rebuilt_connection_id,
+        session_id,
+        "continue after reload",
+    )
+    .await?;
+    let _ = collect_notifications_until_turn_completed(&mut rebuilt_notifications_rx).await?;
+
+    let stream_requests = provider.stream_requests();
+    let follow_up_request = stream_requests
+        .last()
+        .context("expected follow-up stream request after reload")?;
+
+    assert!(contains_tool_use(
+        &follow_up_request.messages,
+        "tool-1",
+        "update_plan"
+    ));
+    assert!(contains_tool_result(
+        &follow_up_request.messages,
+        "tool-1",
+        &expected_plan_text
+    ));
+    assert!(
+        !contains_assistant_text(&follow_up_request.messages, &expected_plan_text),
+        "replayed plan items must not be injected into provider-facing assistant text history"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_plan_preserves_large_plan_text_without_micro_compaction() -> Result<()> {
+    let data_root = TempDir::new()?;
+    let large_step = "wire raw plan persistence ".repeat(512);
+    let plan = json!([
+        {
+            "status": "in_progress",
+            "step": large_step
+        }
+    ]);
+    let plan_input = json!({
+        "explanation": "Tracking large server work",
+        "plan": plan
+    });
+    let expected_plan_text = format!(
+        "Tracking large server work\n\n{}",
+        serde_json::to_string_pretty(plan_input["plan"].as_array().expect("plan array"))?
+    );
+    assert!(expected_plan_text.len() > 10_000);
+    let provider = Arc::new(ToolThenReplyProvider::new(
+        "update_plan",
+        plan_input,
+        "Plan updated.",
+        "Follow-up completed.",
+    ));
+    let runtime = build_runtime(data_root.path(), provider.clone());
+    let (connection_id, mut notifications_rx) = initialize_connection(&runtime).await?;
+    let session_id = start_session(&runtime, connection_id, data_root.path()).await?;
+
+    start_turn(&runtime, connection_id, session_id, "track a large rollout").await?;
+    let notifications = collect_notifications_until_turn_completed(&mut notifications_rx).await?;
+
+    let plan_delta_notification = notifications
+        .iter()
+        .find(|value| value.get("method") == Some(&json!("item/plan/delta")))
+        .context("plan delta notification")?;
+    assert_eq!(
+        plan_delta_notification["params"]["payload"]["delta"],
+        json!(expected_plan_text)
+    );
+    assert!(
+        !plan_delta_notification["params"]["payload"]["delta"]
+            .as_str()
+            .is_some_and(|delta| delta.contains("...[truncated]")),
+        "successful update_plan plan text must stay lossless"
+    );
+
+    let rollout_lines = read_rollout_lines(data_root.path())?;
+    assert!(
+        rollout_lines.iter().any(|line| matches!(
+            line,
+            RolloutLine::Item(item_line)
+                if item_line.item.output_items == vec![
+                    TurnItem::ToolResult(ToolResultItem {
+                        tool_call_id: "tool-1".into(),
+                        output: serde_json::Value::String(expected_plan_text.clone()),
+                        is_error: false,
+                    }),
+                    TurnItem::Plan(TextItem {
+                        text: expected_plan_text.clone(),
+                    }),
+                ]
+        )),
+        "expected rollout to persist the full untruncated plan payload"
+    );
+
+    let follow_up_request = provider
+        .stream_requests()
+        .last()
+        .cloned()
+        .context("expected follow-up stream request")?;
+    assert!(contains_tool_result(
+        &follow_up_request.messages,
+        "tool-1",
+        &expected_plan_text
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn errored_update_plan_stays_on_tool_result_path() -> Result<()> {
+    let data_root = TempDir::new()?;
+    let invalid_plan_input = json!({
+        "plan": [
+            {
+                "status": "in_progress",
+                "step": "One"
+            },
+            {
+                "status": "in_progress",
+                "step": "Two"
+            }
+        ]
+    });
+    let expected_error = "At most one step can be in_progress at a time.";
+    let runtime = build_runtime(
+        data_root.path(),
+        Arc::new(ToolThenReplyProvider::new(
+            "update_plan",
+            invalid_plan_input,
+            "Plan rejected.",
+            "Follow-up completed.",
+        )),
+    );
+    let (connection_id, mut notifications_rx) = initialize_connection(&runtime).await?;
+    let session_id = start_session(&runtime, connection_id, data_root.path()).await?;
+
+    start_turn(&runtime, connection_id, session_id, "track the rollout").await?;
+    let notifications = collect_notifications_until_turn_completed(&mut notifications_rx).await?;
+
+    assert!(
+        !notifications
+            .iter()
+            .any(|value| value.get("method") == Some(&json!("item/plan/delta"))),
+        "errored update_plan must not emit plan deltas"
+    );
+    assert!(
+        !notifications
+            .iter()
+            .any(|value| value.get("method") == Some(&json!("turn/plan/updated"))),
+        "errored update_plan must not emit turn/plan/updated"
+    );
+    let tool_result_notification = notifications
+        .iter()
+        .find(|value| {
+            value.get("method") == Some(&json!("item/completed"))
+                && value["params"]["item"]["item_kind"] == json!("tool_result")
+                && value["params"]["item"]["payload"]["tool_use_id"] == json!("tool-1")
+        })
+        .context("errored update_plan tool_result notification")?;
+    assert_eq!(
+        tool_result_notification["params"]["item"]["payload"]["content"],
+        json!(expected_error)
+    );
+    let resumed = resume_session(&runtime, connection_id, session_id, 4).await?;
+    assert!(contains_history_item(
+        &resumed.history_items,
+        SessionHistoryItemKind::Error,
+        expected_error
+    ));
+    assert!(
+        !contains_history_item(
+            &resumed.history_items,
+            SessionHistoryItemKind::Assistant,
+            expected_error
+        ),
+        "errored update_plan must not create a plan history item"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn non_plan_tools_keep_generic_tool_result_items() -> Result<()> {
+    let data_root = TempDir::new()?;
+    let todos = json!([
+        {
+            "id": "todo-1",
+            "status": "pending",
+            "step": "Keep generic tool result"
+        }
+    ]);
+    let tool_input = json!({ "todos": todos });
+    let expected_output =
+        serde_json::to_string_pretty(tool_input["todos"].as_array().expect("todos array"))?;
+    let runtime = build_runtime(
+        data_root.path(),
+        Arc::new(ToolThenReplyProvider::new(
+            "todowrite",
+            tool_input,
+            "Todo recorded.",
+            "Follow-up completed.",
+        )),
+    );
+    let (connection_id, mut notifications_rx) = initialize_connection(&runtime).await?;
+    let session_id = start_session(&runtime, connection_id, data_root.path()).await?;
+
+    start_turn(&runtime, connection_id, session_id, "record the todo").await?;
+    let notifications = collect_notifications_until_turn_completed(&mut notifications_rx).await?;
+
+    let tool_result_notification = notifications
+        .iter()
+        .find(|value| {
+            value.get("method") == Some(&json!("item/completed"))
+                && value["params"]["item"]["item_kind"] == json!("tool_result")
+                && value["params"]["item"]["payload"]["tool_use_id"] == json!("tool-1")
+        })
+        .context("generic tool_result item notification")?;
+    assert_eq!(
+        tool_result_notification["params"]["item"]["payload"]["content"],
+        json!(expected_output)
+    );
+    assert!(
+        !notifications
+            .iter()
+            .any(|value| value.get("method") == Some(&json!("item/plan/delta"))),
+        "non-plan tools must not emit plan deltas"
+    );
+    assert!(
+        !notifications
+            .iter()
+            .any(|value| value.get("method") == Some(&json!("turn/plan/updated"))),
+        "non-plan tools must not emit turn/plan/updated"
+    );
+
+    let rollout_lines = read_rollout_lines(data_root.path())?;
+    assert!(
+        rollout_lines.iter().any(|line| matches!(
+            line,
+            RolloutLine::Item(item_line)
+                if item_line.item.output_items.iter().any(|item| {
+                    item == &TurnItem::ToolResult(ToolResultItem {
+                        tool_call_id: "tool-1".into(),
+                        output: serde_json::Value::String(expected_output.clone()),
+                        is_error: false,
+                    })
+                })
+        )),
+        "expected rollout to persist a generic tool_result item"
+    );
+
+    Ok(())
+}
+
+fn build_runtime(data_root: &Path, provider: Arc<dyn ModelProviderSDK>) -> Arc<ServerRuntime> {
+    let mut registry = ToolRegistry::new();
+    register_builtin_tools(&mut registry);
+    ServerRuntime::new(
+        data_root.to_path_buf(),
+        ServerRuntimeDependencies::new(
+            provider,
+            Arc::new(registry),
+            "test-model".to_string(),
+            Arc::new(PresetModelCatalog::default()),
+        ),
+    )
+}
+
+async fn initialize_connection(
+    runtime: &Arc<ServerRuntime>,
+) -> Result<(u64, mpsc::UnboundedReceiver<serde_json::Value>)> {
+    let (notifications_tx, notifications_rx) = mpsc::unbounded_channel();
+    let connection_id = runtime
+        .register_connection(ClientTransportKind::Stdio, notifications_tx)
+        .await;
+    let initialize_response = runtime
+        .handle_incoming(
+            connection_id,
+            json!({
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "client_name": "test",
+                    "client_version": "1.0.0",
+                    "transport": "stdio",
+                    "supports_streaming": true,
+                    "supports_binary_images": false,
+                    "opt_out_notification_methods": []
+                }
+            }),
+        )
+        .await
+        .context("initialize response")?;
+    let response: SuccessResponse<clawcr_server::InitializeResult> =
+        serde_json::from_value(initialize_response)?;
+    assert_eq!(response.result.server_name, "clawcr-server");
+
+    let _ = runtime
+        .handle_incoming(connection_id, json!({ "method": "initialized" }))
+        .await;
+    Ok((connection_id, notifications_rx))
+}
+
+async fn start_session(
+    runtime: &Arc<ServerRuntime>,
+    connection_id: u64,
+    cwd: &Path,
+) -> Result<SessionId> {
+    let response = runtime
+        .handle_incoming(
+            connection_id,
+            json!({
+                "id": 2,
+                "method": "session/start",
+                "params": {
+                    "cwd": cwd,
+                    "ephemeral": false,
+                    "title": "Plan integration",
+                    "model": "test-model"
+                }
+            }),
+        )
+        .await
+        .context("session/start response")?;
+    let result: SuccessResponse<clawcr_server::SessionStartResult> =
+        serde_json::from_value(response)?;
+    Ok(result.result.session_id)
+}
+
+async fn start_turn(
+    runtime: &Arc<ServerRuntime>,
+    connection_id: u64,
+    session_id: SessionId,
+    text: &str,
+) -> Result<()> {
+    let response = runtime
+        .handle_incoming(
+            connection_id,
+            json!({
+                "id": 3,
+                "method": "turn/start",
+                "params": {
+                    "session_id": session_id,
+                    "input": [{ "type": "text", "text": text }],
+                    "model": null,
+                    "sandbox": null,
+                    "approval_policy": null,
+                    "cwd": null
+                }
+            }),
+        )
+        .await
+        .context("turn/start response")?;
+    let _: SuccessResponse<clawcr_server::TurnStartResult> = serde_json::from_value(response)?;
+    Ok(())
+}
+
+async fn collect_notifications_until_turn_completed(
+    notifications_rx: &mut mpsc::UnboundedReceiver<serde_json::Value>,
+) -> Result<Vec<serde_json::Value>> {
+    timeout(Duration::from_secs(5), async {
+        let mut notifications = Vec::new();
+        while let Some(value) = notifications_rx.recv().await {
+            let is_turn_completed = value.get("method") == Some(&json!("turn/completed"));
+            notifications.push(value);
+            if is_turn_completed {
+                return Ok(notifications);
+            }
+        }
+        anyhow::bail!("notification channel closed before turn/completed")
+    })
+    .await
+    .context("timed out waiting for turn/completed")?
+}
+
+async fn resume_session(
+    runtime: &Arc<ServerRuntime>,
+    connection_id: u64,
+    session_id: SessionId,
+    request_id: u64,
+) -> Result<clawcr_server::SessionResumeResult> {
+    let response = runtime
+        .handle_incoming(
+            connection_id,
+            json!({
+                "id": request_id,
+                "method": "session/resume",
+                "params": {
+                    "session_id": session_id
+                }
+            }),
+        )
+        .await
+        .context("session/resume response")?;
+    Ok(
+        serde_json::from_value::<SuccessResponse<clawcr_server::SessionResumeResult>>(response)?
+            .result,
+    )
+}
+
+fn read_rollout_lines(data_root: &Path) -> Result<Vec<RolloutLine>> {
+    let mut rollout_paths = Vec::new();
+    collect_rollout_paths(&data_root.join("sessions"), &mut rollout_paths)?;
+    let rollout_path = rollout_paths
+        .into_iter()
+        .next()
+        .context("expected one rollout file")?;
+    let contents = std::fs::read_to_string(&rollout_path)
+        .with_context(|| format!("read rollout file {}", rollout_path.display()))?;
+    contents
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).context("parse rollout line"))
+        .collect()
+}
+
+fn collect_rollout_paths(root: &Path, paths: &mut Vec<PathBuf>) -> Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+
+    for entry in std::fs::read_dir(root)
+        .with_context(|| format!("read rollout directory {}", root.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rollout_paths(&path, paths)?;
+        } else if path.extension().and_then(|value| value.to_str()) == Some("jsonl") {
+            paths.push(path);
+        }
+    }
+
+    Ok(())
+}
+
+fn contains_tool_use(messages: &[RequestMessage], tool_use_id: &str, tool_name: &str) -> bool {
+    messages.iter().any(|message| {
+        message.content.iter().any(|content| {
+            matches!(
+                content,
+                RequestContent::ToolUse { id, name, .. }
+                    if id == tool_use_id && name == tool_name
+            )
+        })
+    })
+}
+
+fn contains_tool_result(
+    messages: &[RequestMessage],
+    tool_use_id: &str,
+    expected_text: &str,
+) -> bool {
+    messages.iter().any(|message| {
+        message.content.iter().any(|content| {
+            matches!(
+                content,
+                RequestContent::ToolResult {
+                    tool_use_id: id,
+                    content,
+                    ..
+                } if id == tool_use_id && content == expected_text
+            )
+        })
+    })
+}
+
+fn contains_assistant_text(messages: &[RequestMessage], expected_text: &str) -> bool {
+    messages.iter().any(|message| {
+        message.role == "assistant"
+            && message.content.iter().any(
+                |content| matches!(content, RequestContent::Text { text } if text == expected_text),
+            )
+    })
+}
+
+fn contains_history_item(
+    history_items: &[clawcr_server::SessionHistoryItem],
+    kind: SessionHistoryItemKind,
+    body: &str,
+) -> bool {
+    history_items
+        .iter()
+        .any(|item| item.kind == kind && item.body == body)
+}

--- a/crates/tui/src/events.rs
+++ b/crates/tui/src/events.rs
@@ -94,6 +94,13 @@ pub(crate) enum WorkerEvent {
         /// Whether the preview was truncated for display.
         truncated: bool,
     },
+    /// A plan update completed.
+    PlanUpdated {
+        /// Stable identifier used to match the corresponding tool call.
+        tool_use_id: String,
+        /// Canonical plan text shown in the transcript.
+        text: String,
+    },
     /// Live usage update for the active turn.
     UsageUpdated {
         /// Total input tokens accumulated in the session.

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -20,4 +20,7 @@ pub use events::SavedModelEntry;
 pub use terminal::TerminalMode;
 
 #[cfg(test)]
+mod plan_tests;
+
+#[cfg(test)]
 mod tests;

--- a/crates/tui/src/plan_tests.rs
+++ b/crates/tui/src/plan_tests.rs
@@ -1,0 +1,88 @@
+use std::path::PathBuf;
+
+use clawcr_core::{Model, PresetModelCatalog};
+use clawcr_provider::ProviderFamily;
+use pretty_assertions::assert_eq;
+
+use crate::app::TuiApp;
+use crate::events::{TranscriptItemKind, WorkerEvent};
+use crate::input::InputBuffer;
+use crate::worker::QueryWorkerHandle;
+
+fn test_app() -> TuiApp {
+    TuiApp {
+        model: "test-model".to_string(),
+        provider: ProviderFamily::Anthropic,
+        cwd: PathBuf::from("."),
+        transcript: Vec::new(),
+        input: InputBuffer::new(),
+        status_message: "Ready".to_string(),
+        busy: false,
+        spinner_index: 0,
+        scroll: 0,
+        follow_output: true,
+        turn_count: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        slash_selection: 0,
+        pending_status_index: None,
+        pending_assistant_index: None,
+        worker: QueryWorkerHandle::stub(),
+        model_catalog: PresetModelCatalog::new(vec![Model {
+            slug: "test-model".to_string(),
+            display_name: "Test Model".to_string(),
+            provider_family: ProviderFamily::Anthropic,
+            thinking_capability: clawcr_core::ThinkingCapability::Toggle,
+            ..Model::default()
+        }]),
+        saved_models: vec![],
+        show_model_onboarding: false,
+        onboarding_announced: false,
+        onboarding_custom_model_pending: false,
+        onboarding_prompt: None,
+        onboarding_prompt_history: Vec::new(),
+        onboarding_base_url_pending: false,
+        onboarding_api_key_pending: false,
+        onboarding_selected_model: None,
+        onboarding_selected_model_is_custom: false,
+        onboarding_selected_base_url: None,
+        onboarding_selected_api_key: None,
+        aux_panel: None,
+        aux_panel_selection: 0,
+        thinking_selection: None,
+        pending_tool_items: std::collections::HashMap::new(),
+        last_ctrl_c_at: None,
+        paste_burst: crate::paste_burst::PasteBurst::default(),
+        should_quit: false,
+        inline_mode: false,
+        terminal_width: 80,
+        inline_assistant_stream_open: false,
+        inline_assistant_pending_line: String::new(),
+        inline_assistant_header_emitted: false,
+        pending_inline_history: Vec::new(),
+    }
+}
+
+#[tokio::test]
+async fn plan_updates_append_assistant_item_and_clear_pending_tool_state() {
+    let mut app = test_app();
+
+    app.handle_worker_event(WorkerEvent::ToolCall {
+        tool_use_id: "tool-1".to_string(),
+        summary: "update_plan: Tracking runtime work".to_string(),
+        detail: None,
+    });
+    app.handle_worker_event(WorkerEvent::PlanUpdated {
+        tool_use_id: "tool-1".to_string(),
+        text: "Tracking runtime work\n\n[\n  {\n    \"status\": \"in_progress\",\n    \"step\": \"Wire live plan output\"\n  }\n]".to_string(),
+    });
+
+    assert!(app.pending_tool_items.is_empty());
+    assert_eq!(app.transcript.len(), 2);
+    assert_eq!(app.transcript[0].kind, TranscriptItemKind::ToolCall);
+    assert_eq!(app.transcript[1].kind, TranscriptItemKind::Assistant);
+    assert_eq!(
+        app.transcript[1].body,
+        "Tracking runtime work\n\n[\n  {\n    \"status\": \"in_progress\",\n    \"step\": \"Wire live plan output\"\n  }\n]"
+    );
+}

--- a/crates/tui/src/worker.rs
+++ b/crates/tui/src/worker.rs
@@ -637,9 +637,9 @@ fn completed_agent_message_text(payload: &ItemEventPayload) -> Option<String> {
 }
 
 fn handle_completed_item(payload: ItemEventPayload, event_tx: &mpsc::UnboundedSender<WorkerEvent>) {
-    // Only tool lifecycle items need special handling here; other item kinds are
-    // intentionally ignored because they are either streamed separately or not
-    // shown in the TUI transcript.
+    // Tool lifecycle items and plan completions need special handling here; other
+    // item kinds are intentionally ignored because they are streamed separately
+    // or not shown in the TUI transcript.
     match payload.item {
         ItemEnvelope {
             item_kind: ItemKind::ToolCall,
@@ -686,6 +686,23 @@ fn handle_completed_item(payload: ItemEventPayload, event_tx: &mpsc::UnboundedSe
                 is_error,
                 truncated: false,
             });
+        }
+        ItemEnvelope {
+            item_kind: ItemKind::Plan,
+            payload,
+            ..
+        } => {
+            let tool_use_id = payload
+                .get("tool_use_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let text = payload
+                .get("text")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let _ = event_tx.send(WorkerEvent::PlanUpdated { tool_use_id, text });
         }
         _ => {}
     }

--- a/crates/tui/src/worker_events.rs
+++ b/crates/tui/src/worker_events.rs
@@ -138,6 +138,29 @@ impl TuiApp {
                     "Tool completed".to_string()
                 };
             }
+            WorkerEvent::PlanUpdated { tool_use_id, text } => {
+                self.close_inline_assistant_stream();
+                self.pending_tool_items.remove(&tool_use_id);
+                self.transcript.push(TranscriptItem::new(
+                    TranscriptItemKind::Assistant,
+                    String::new(),
+                    text.clone(),
+                ));
+                if self.follow_output {
+                    self.scroll = 0;
+                }
+                if self.inline_mode {
+                    self.emit_inline_item(&TranscriptItem::new(
+                        TranscriptItemKind::Assistant,
+                        String::new(),
+                        text,
+                    ));
+                }
+                if self.busy {
+                    self.show_turn_status_line("Thinking");
+                }
+                self.status_message = "Plan updated".to_string();
+            }
             WorkerEvent::UsageUpdated {
                 total_input_tokens,
                 total_output_tokens,

--- a/docs/work-items-plan-item-events.md
+++ b/docs/work-items-plan-item-events.md
@@ -1,0 +1,53 @@
+# Plan Item Events
+
+## Goal
+
+Implement the spec-defined plan item and plan update events for successful `update_plan` tool executions so the server emits first-class `Plan` items instead of treating plan updates as only generic tool results.
+
+## Why
+
+`docs/spec-conversation.md` defines `TurnItem::Plan(PlanItem)` as a first-class persisted item kind.
+
+`docs/spec-server-api.md` requires:
+
+- `turn/plan/updated` as a required turn notification
+- `item/plan/delta` as a minimum item delta notification
+- explicit `plan` item support in the item taxonomy
+
+The current runtime already defines the protocol types for these events and item kinds, but a successful `update_plan` tool call is only surfaced as `ToolCall` + `ToolResult`. That leaves the plan portion of the spec partially implemented.
+
+## Changes
+
+- Detect successful `update_plan` tool results in the server turn event loop.
+- Continue emitting the existing `ToolCall` item for the tool invocation.
+- Emit a first-class `Plan` item for the successful plan output.
+- Emit an `item/plan/delta` notification for the plan text before the plan item completes.
+- Emit `turn/plan/updated` after the plan item is completed.
+- Keep non-plan tool results and errored `update_plan` executions on the existing `ToolResult` path.
+
+## Files Affected
+
+- `crates/server/src/runtime.rs`
+- `crates/server/src/runtime/plan.rs`
+- `crates/server/tests/plan_integration.rs`
+
+## Task List
+
+1. Update the turn event handling in `crates/server/src/runtime.rs`.
+2. Track tool-use ids to tool names while streaming query events so the runtime can recognize which `ToolResult` came from `update_plan`.
+3. For a successful `update_plan` result:
+4. Start a `Plan` item with an empty initial text payload.
+5. Emit one `item/plan/delta` notification containing the full plan text.
+6. Persist the successful update as one item record containing replay-facing `ToolResult` and visible `TurnItem::Plan(TextItem { text: ... })`, then complete the live item as `plan`.
+7. Emit `turn/plan/updated` for the owning turn after the plan item completes.
+8. Preserve the existing `ToolResult` behavior for every other tool result, including errored `update_plan` results.
+9. Add an integration test that drives a turn through an `update_plan` tool call and asserts:
+10. the runtime emits `item/started` / `item/plan/delta` / `item/completed` for a `plan` item
+11. the runtime emits `turn/plan/updated`
+12. the persisted or resumed turn history includes a `Plan` item instead of relying only on a generic tool result
+13. Add a regression assertion that a non-plan tool result still emits the existing `ToolResult` item path.
+
+## Verification
+
+- `cargo test --package clawcr-server --test plan_integration`
+- `cargo test --package clawcr-server --test protocol_contract`


### PR DESCRIPTION
## Summary
- emit first-class plan items and item/plan/delta notifications for successful update_plan tool results
- emit turn/plan/updated after the plan item completes while keeping non-plan tool results on the generic tool_result path
- add integration coverage for both the plan-specific path and the generic tool-result regression path

## Testing
- cargo test --package clawcr-server --test plan_integration
- cargo test --package clawcr-server --test protocol_contract