### PR TITLE
fix: handle null arrays in OpenAI-compatible API responses

### DIFF
--- a/crates/provider/src/openai/chat_completions.rs
+++ b/crates/provider/src/openai/chat_completions.rs
@@ -70,7 +70,7 @@ impl OpenAIProvider {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(super) struct OpenAIChatCompletionResponse {
     id: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default_vec")]
     choices: Vec<OpenAIChatCompletionChoice>,
     #[serde(default)]
     created: Option<u64>,
@@ -132,16 +132,26 @@ pub(super) struct OpenAIChatCompletionMessage {
     refusal: Option<String>,
     #[serde(default)]
     role: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default_vec")]
     annotations: Vec<OpenAIChatCompletionAnnotation>,
     #[serde(default)]
     audio: Option<OpenAIChatCompletionAudio>,
     #[serde(default)]
     function_call: Option<OpenAIChatCompletionFunctionCall>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default_vec")]
     tool_calls: Vec<OpenAIChatCompletionMessageToolCall>,
     #[serde(default)]
     reasoning_content: Option<String>,
+}
+
+fn deserialize_null_as_default_vec<'de, D, T>(
+    deserializer: D,
+) -> std::result::Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    Option::<Vec<T>>::deserialize(deserializer).map(|v| v.unwrap_or_default())
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/provider/src/openai/chat_completions/stream.rs
+++ b/crates/provider/src/openai/chat_completions/stream.rs
@@ -598,8 +598,18 @@ struct ChatCompletionStreamDelta {
     reasoning_content: Option<String>,
     #[serde(default)]
     refusal: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default_vec")]
     tool_calls: Vec<ChatCompletionStreamToolCallDelta>,
+}
+
+fn deserialize_null_as_default_vec<'de, D, T>(
+    deserializer: D,
+) -> std::result::Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    Option::<Vec<T>>::deserialize(deserializer).map(|v| v.unwrap_or_default())
 }
 
 #[derive(Debug, Default, Deserialize)]


### PR DESCRIPTION
## Summary
Fixes parsing errors when OpenAI-compatible APIs return 
ull for array fields instead of an empty array or omitting the field.

## Problem
NVIDIA NIM and other OpenAI-compatible APIs return 
ull for 	ool_calls, nnotations, and choices fields when they have no content. This caused serde deserialization to fail with:
`
invalid type: null, expected a sequence at line 1 column 138
`

## Solution
Added deserialize_null_as_default_vec helper that treats 
ull as an empty array [] for Vec fields.

## Files Changed
- crates/provider/src/openai/chat_completions.rs - 3 fields fixed
- crates/provider/src/openai/chat_completions/stream.rs - 1 field fixed

## Testing
- All existing tests pass
- Tested with NVIDIA NIM API (meta/llama-3.1-8b-instruct)