### PR TITLE
chore: fix clippy warnings across workspace

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -40,14 +40,23 @@ async fn main() -> Result<()> {
     match cli.command {
         Some(Command::Server(args)) => run_server_process(args).await,
         Some(Command::Onboard) => {
-            run_agent(true, cli.no_alt_screen, cli.log_level.map(LogLevel::as_str), cli.model.as_deref()).await
+            run_agent(
+                true,
+                cli.no_alt_screen,
+                cli.log_level.map(LogLevel::as_str),
+                cli.model.as_deref(),
+            )
+            .await
         }
         Some(Command::Prompt { input }) => {
-            run_prompt(&input, cli.model.as_deref(), cli.log_level.map(LogLevel::as_str)).await
+            run_prompt(
+                &input,
+                cli.model.as_deref(),
+                cli.log_level.map(LogLevel::as_str),
+            )
+            .await
         }
-        Some(Command::Doctor) => {
-            run_doctor().await
-        }
+        Some(Command::Doctor) => run_doctor().await,
         None => {
             run_agent(
                 false,
@@ -142,7 +151,11 @@ impl LogLevel {
     }
 }
 
-async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Option<&str>) -> Result<()> {
+async fn run_prompt(
+    input: &str,
+    model_override: Option<&str>,
+    _log_level: Option<&str>,
+) -> Result<()> {
     use clawcr_core::{SessionConfig, SessionState, default_base_instructions};
     use clawcr_tools::{ToolOrchestrator, ToolRegistry};
 
@@ -156,10 +169,8 @@ async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Optio
     }
 
     let home_dir = find_clawcr_home()?;
-    let provider = clawcr_server::load_server_provider(
-        &home_dir.join("config.toml"),
-        Some(&resolved.model),
-    )?;
+    let provider =
+        clawcr_server::load_server_provider(&home_dir.join("config.toml"), Some(&resolved.model))?;
 
     let mut session_state = SessionState::new(SessionConfig::default(), cwd.clone());
     session_state.push_message(clawcr_core::Message::user(input.to_string()));
@@ -199,11 +210,16 @@ async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Optio
     match result {
         Ok(()) => {
             let reply = session_state.messages.iter().rev().find_map(|m| {
-                if m.role != clawcr_core::Role::Assistant { return None; }
-                m.content.iter().filter_map(|block| match block {
-                    clawcr_core::ContentBlock::Text { text } => Some(text.as_str()),
-                    _ => None,
-                }).next()
+                if m.role != clawcr_core::Role::Assistant {
+                    return None;
+                }
+                m.content
+                    .iter()
+                    .filter_map(|block| match block {
+                        clawcr_core::ContentBlock::Text { text } => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .next()
             });
             match reply {
                 Some(text) => println!("{}", text),
@@ -219,15 +235,15 @@ async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Optio
 }
 
 async fn run_doctor() -> Result<()> {
-    use std::process::Command;
     use colored::Colorize;
+    use std::process::Command;
 
     println!("{}", "=== Claw CR Doctor ===".bold());
     println!();
 
     let mut all_ok = true;
 
-    println!("{} {}", "✓".green().bold(), "Rust toolchain:");
+    println!("{} Rust toolchain:", "✓".green().bold());
     let rustc = Command::new("rustc").arg("--version").output();
     match rustc {
         Ok(output) => {
@@ -241,7 +257,7 @@ async fn run_doctor() -> Result<()> {
     }
     println!();
 
-    println!("{} {}", "✓".green().bold(), "Config home (CLAWCR_HOME):");
+    println!("{} Config home (CLAWCR_HOME):", "✓".green().bold());
     match find_clawcr_home() {
         Ok(home) => {
             println!("  {}", home.display());
@@ -253,7 +269,7 @@ async fn run_doctor() -> Result<()> {
     }
     println!();
 
-    println!("{} {}", "✓".green().bold(), "Config file:");
+    println!("{} Config file:", "✓".green().bold());
     if let Ok(home) = find_clawcr_home() {
         let config_path = home.join("config.toml");
         if config_path.exists() {
@@ -265,27 +281,33 @@ async fn run_doctor() -> Result<()> {
                 println!("  {} api_key or base_url missing", "!".yellow());
                 all_ok = false;
             }
-            let model_line = content.lines()
-                .find(|l| l.starts_with("model"));
+            let model_line = content.lines().find(|l| l.starts_with("model"));
             if let Some(line) = model_line {
                 println!("  default model: {}", line.trim());
             } else {
                 println!("  {} no default model set", "!".yellow());
             }
         } else {
-            println!("  {} not found at {}", "missing".yellow(), config_path.display());
+            println!(
+                "  {} not found at {}",
+                "missing".yellow(),
+                config_path.display()
+            );
             println!("  Run `clawcr onboard` to create it.");
             all_ok = false;
         }
     }
     println!();
 
-    println!("{} {}", "✓".green().bold(), "Provider resolution:");
+    println!("{} Provider resolution:", "✓".green().bold());
     match resolve_provider_settings() {
         Ok(resolved) => {
             println!("  provider:   {}", resolved.provider_id);
             println!("  model:      {}", resolved.model);
-            println!("  base_url:   {}", resolved.base_url.unwrap_or("default".into()));
+            println!(
+                "  base_url:   {}",
+                resolved.base_url.unwrap_or("default".into())
+            );
             println!("  wire_api:   {:?}", resolved.wire_api);
             if resolved.api_key.is_some() {
                 println!("  api_key:    {} (set)", "✓".green());
@@ -301,7 +323,7 @@ async fn run_doctor() -> Result<()> {
     }
     println!();
 
-    println!("{} {}", "✓".green().bold(), "Model catalog:");
+    println!("{} Model catalog:", "✓".green().bold());
     match clawcr_core::PresetModelCatalog::load() {
         Ok(catalog) => {
             let count = catalog.into_inner().len();
@@ -317,7 +339,10 @@ async fn run_doctor() -> Result<()> {
     if all_ok {
         println!("{}", "All checks passed. Ready to use!".green().bold());
     } else {
-        println!("{}", "Some checks failed. See above for details.".yellow().bold());
+        println!(
+            "{}",
+            "Some checks failed. See above for details.".yellow().bold()
+        );
         std::process::exit(1);
     }
 
@@ -356,6 +381,7 @@ mod tests {
     fn cli_logging_overrides_is_empty_without_log_level() {
         let cli = Cli {
             command: None,
+            model: None,
             no_alt_screen: false,
             log_level: None,
         };
@@ -370,6 +396,7 @@ mod tests {
     fn cli_logging_overrides_sets_logging_level() {
         let cli = Cli {
             command: None,
+            model: None,
             no_alt_screen: false,
             log_level: Some(LogLevel::Debug),
         };

--- a/crates/core/src/model_catalog.rs
+++ b/crates/core/src/model_catalog.rs
@@ -75,7 +75,7 @@ pub fn load_builtin_model_presets() -> Result<Vec<ModelPreset>, PresetModelCatal
 /// Loads the built-in model list bundled with the crate.
 pub fn load_builtin_models() -> Result<Vec<Model>, PresetModelCatalogError> {
     let mut presets = load_builtin_model_presets()?;
-    presets.sort_by(|left, right| right.priority.cmp(&left.priority));
+    presets.sort_by_key(|right| std::cmp::Reverse(right.priority));
     Ok(presets.into_iter().map(Model::from).collect())
 }
 

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -236,7 +236,7 @@ fn load_prompt_md(cwd: &std::path::Path) -> Option<String> {
 fn build_system_prompt(base_instructions: &str) -> String {
     let mut sections = Vec::new();
     if !base_instructions.is_empty() {
-        sections.push(format!("{}", base_instructions.to_string()));
+        sections.push(base_instructions.to_string());
     }
     sections.join("\n\n")
 }
@@ -310,7 +310,7 @@ const INITIAL_RETRY_BACKOFF_MS: u64 = 250;
 
 /// TODO: The body of `query` is too lengthy, we should move out `stream lop` out, I am
 /// not sure whether we should do this.
-
+///
 /// The recursive agent loop — the beating heart of the runtime.
 ///
 /// The implementation refers to Claude Code's `query.ts`. It drives

--- a/crates/protocol/src/model.rs
+++ b/crates/protocol/src/model.rs
@@ -25,18 +25,13 @@ use crate::{
     ThinkingImplementation, nearest_effort, truncation::TruncationPolicyConfig,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Verbosity {
     Low,
+    #[default]
     Medium,
     High,
-}
-
-impl Default for Verbosity {
-    fn default() -> Self {
-        Self::Medium
-    }
 }
 
 /// Sampling controls and model-selection hints shared across adapters.
@@ -105,34 +100,21 @@ pub enum RequestContent {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-/// Supported input types that a model can accept.
 pub enum InputModality {
-    /// Plain text input.
+    #[default]
     Text,
-    /// Image input.
     Image,
 }
 
-impl Default for InputModality {
-    fn default() -> Self {
-        Self::Text
-    }
-}
-
 /// OpenAI-family API surfaces supported by the runtime.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OpenAiApi {
+    #[default]
     ChatCompletions,
     Responses,
-}
-
-impl Default for OpenAiApi {
-    fn default() -> Self {
-        OpenAiApi::ChatCompletions
-    }
 }
 
 /// Anthropic-family API surfaces supported by the runtime.
@@ -276,7 +258,7 @@ impl Default for Model {
 
 impl Model {
     pub fn provider_family(&self) -> ProviderFamily {
-        self.provider.clone()
+        self.provider
     }
 
     pub fn reasoning_effort_options(&self) -> Vec<ReasoningEffortPreset> {
@@ -300,7 +282,7 @@ impl Model {
     }
 
     pub fn effective_thinking_implementation(&self) -> ThinkingImplementation {
-        self.thinking_implementation.clone().unwrap_or_else(|| {
+        self.thinking_implementation.clone().unwrap_or({
             if matches!(self.thinking_capability, ThinkingCapability::Disabled) {
                 ThinkingImplementation::Disabled
             } else {

--- a/crates/provider/src/anthropic/messages.rs
+++ b/crates/provider/src/anthropic/messages.rs
@@ -300,13 +300,12 @@ impl ModelProviderSDK for AnthropicProvider {
                                 {
                                     message_id = id.to_string();
                                 }
-                                if let Some(usage) = data.get("usage") {
-                                    if let Some(input) =
+                                if let Some(usage) = data.get("usage")
+                                    && let Some(input) =
                                         usage.get("input_tokens").and_then(Value::as_u64)
                                     {
                                         input_tokens = input as usize;
                                     }
-                                }
                             }
                             "content_block_start" => {
                                 let Some(index) = data.get("index").and_then(Value::as_u64) else {
@@ -424,24 +423,21 @@ impl ModelProviderSDK for AnthropicProvider {
                             }
                             "content_block_stop" => {
                                 let index = data.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
-                                if let Some(json_str) = tool_json.remove(&index) {
-                                    if let Ok(parsed) = serde_json::from_str(&json_str) {
-                                        if let Some(ResponseContent::ToolUse { input, .. }) =
+                                if let Some(json_str) = tool_json.remove(&index)
+                                    && let Ok(parsed) = serde_json::from_str(&json_str)
+                                        && let Some(ResponseContent::ToolUse { input, .. }) =
                                             content_blocks.get_mut(&index)
                                         {
                                             *input = parsed;
                                         }
-                                    }
-                                }
                             }
                             "message_delta" => {
-                                if let Some(delta) = data.get("delta").and_then(Value::as_object) {
-                                    if let Some(reason) =
+                                if let Some(delta) = data.get("delta").and_then(Value::as_object)
+                                    && let Some(reason) =
                                         delta.get("stop_reason").and_then(Value::as_str)
                                     {
                                         stop_reason = Some(parse_stop_reason(reason));
                                     }
-                                }
                                 if let Some(usage) = data.get("usage") {
                                     if let Some(output) = usage.get("output_tokens").and_then(Value::as_u64)
                                     {

--- a/crates/provider/src/openai/chat_completions/stream.rs
+++ b/crates/provider/src/openai/chat_completions/stream.rs
@@ -51,11 +51,11 @@ use crate::text_normalization::{TaggedTextFragment, TaggedTextParser};
 ///    - logprobs: optional object
 ///      Log probability information for the choice.
 /// - created: number
-/// The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp.
+///   The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp.
 /// - model: string
-/// The model to generate the completion.
+///   The model to generate the completion.
 /// - object: "chat.completion.chunk"
-/// The object type, which is always chat.completion.chunk
+///   The object type, which is always chat.completion.chunk
 /// - service_tier: optional "auto" or "default" or "flex" or "scale" or "priority"
 /// - usage: optional CompletionUsage
 pub(super) async fn completion_stream(
@@ -135,10 +135,10 @@ impl ChatCompletionStreamState {
     fn apply_chunk(&mut self, chunk: ChatCompletionStreamChunk) -> Vec<StreamEvent> {
         let mut events = Vec::new();
 
-        if self.response_id.is_empty() {
-            if let Some(id) = chunk.id {
-                self.response_id = id;
-            }
+        if self.response_id.is_empty()
+            && let Some(id) = chunk.id
+        {
+            self.response_id = id;
         }
         if self.created.is_none() {
             self.created = chunk.created;

--- a/crates/provider/src/openai/responses.rs
+++ b/crates/provider/src/openai/responses.rs
@@ -131,27 +131,27 @@ fn build_input(request: &ModelRequest) -> Vec<Value> {
 fn build_input_message(role: OpenAIRole, content: &[RequestContent]) -> Value {
     let content = content
         .iter()
-        .filter_map(|block| match block {
-            RequestContent::Text { text } => Some(json!({
+        .map(|block| match block {
+            RequestContent::Text { text } => json!({
                 "type": "input_text",
                 "text": text,
-            })),
-            RequestContent::ToolUse { id, name, input } => Some(json!({
+            }),
+            RequestContent::ToolUse { id, name, input } => json!({
                 "type": "tool_call",
                 "id": id,
                 "name": name,
                 "input": input,
-            })),
+            }),
             RequestContent::ToolResult {
                 tool_use_id,
                 content,
                 is_error,
-            } => Some(json!({
+            } => json!({
                 "type": "function_call_output",
                 "call_id": tool_use_id,
                 "output": content,
                 "is_error": is_error,
-            })),
+            }),
         })
         .collect::<Vec<_>>();
 
@@ -442,8 +442,7 @@ impl ModelProviderSDK for OpenAIResponsesProvider {
                                 if let Some(item) = chunk.get("item") {
                                     if let Some(reasoning_content) =
                                         item.get("reasoning_content").and_then(Value::as_str)
-                                    {
-                                        if !reasoning_content.is_empty() {
+                                        && !reasoning_content.is_empty() {
                                             if !reasoning_started {
                                                 reasoning_started = true;
                                                 yield StreamEvent::ReasoningStart { index: 1 };
@@ -454,7 +453,6 @@ impl ModelProviderSDK for OpenAIResponsesProvider {
                                                 text: reasoning_content.to_string(),
                                             };
                                         }
-                                    }
                                     if let Some(ResponseContent::ToolUse { id, name, input }) = parse_output_item(item).into_iter().next() {
                                         let key = id.clone();
                                         tool_calls.insert(key.clone(), (id.clone(), name.clone(), input.to_string()));

--- a/crates/server/src/persistence.rs
+++ b/crates/server/src/persistence.rs
@@ -485,6 +485,67 @@ fn apply_turn_item(
     }
 }
 
+fn collect_rollout_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in std::fs::read_dir(root).with_context(|| format!("read dir {}", root.display()))? {
+        let entry = entry.with_context(|| format!("read entry in {}", root.display()))?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("read file type for {}", path.display()))?;
+        if file_type.is_dir() {
+            collect_rollout_files(&path, files)?;
+        } else if file_type.is_file()
+            && path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+        {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Creates one canonical persisted turn record from the transport-facing runtime state.
+pub(crate) fn build_turn_record(turn: &TurnSummary) -> TurnRecord {
+    TurnRecord {
+        id: turn.turn_id,
+        session_id: turn.session_id,
+        sequence: turn.sequence,
+        started_at: turn.started_at,
+        completed_at: turn.completed_at,
+        status: turn.status.clone(),
+        model_slug: turn.model_slug.clone(),
+        input_token_estimate: None,
+        usage: turn.usage.clone(),
+        schema_version: 1,
+    }
+}
+
+/// Creates one canonical persisted item record from a normalized turn item payload.
+pub(crate) fn build_item_record(
+    session_id: SessionId,
+    turn_id: TurnId,
+    item_id: clawcr_core::ItemId,
+    seq: u64,
+    item: TurnItem,
+    turn_status: Option<TurnStatus>,
+    worklog: Option<Worklog>,
+) -> ItemRecord {
+    ItemRecord {
+        id: item_id,
+        session_id,
+        turn_id,
+        seq,
+        timestamp: Utc::now(),
+        attempt_placement: None,
+        turn_status,
+        sibling_turn_ids: Vec::new(),
+        input_items: Vec::new(),
+        output_items: vec![item],
+        worklog,
+        error: None,
+        schema_version: 1,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};
@@ -571,66 +632,5 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(titles, vec!["assistant 1", "date"]);
-    }
-}
-
-fn collect_rollout_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in std::fs::read_dir(root).with_context(|| format!("read dir {}", root.display()))? {
-        let entry = entry.with_context(|| format!("read entry in {}", root.display()))?;
-        let path = entry.path();
-        let file_type = entry
-            .file_type()
-            .with_context(|| format!("read file type for {}", path.display()))?;
-        if file_type.is_dir() {
-            collect_rollout_files(&path, files)?;
-        } else if file_type.is_file()
-            && path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
-        {
-            files.push(path);
-        }
-    }
-    Ok(())
-}
-
-/// Creates one canonical persisted turn record from the transport-facing runtime state.
-pub(crate) fn build_turn_record(turn: &TurnSummary) -> TurnRecord {
-    TurnRecord {
-        id: turn.turn_id,
-        session_id: turn.session_id,
-        sequence: turn.sequence,
-        started_at: turn.started_at,
-        completed_at: turn.completed_at,
-        status: turn.status.clone(),
-        model_slug: turn.model_slug.clone(),
-        input_token_estimate: None,
-        usage: turn.usage.clone(),
-        schema_version: 1,
-    }
-}
-
-/// Creates one canonical persisted item record from a normalized turn item payload.
-pub(crate) fn build_item_record(
-    session_id: SessionId,
-    turn_id: TurnId,
-    item_id: clawcr_core::ItemId,
-    seq: u64,
-    item: TurnItem,
-    turn_status: Option<TurnStatus>,
-    worklog: Option<Worklog>,
-) -> ItemRecord {
-    ItemRecord {
-        id: item_id,
-        session_id,
-        turn_id,
-        seq,
-        timestamp: Utc::now(),
-        attempt_placement: None,
-        turn_status,
-        sibling_turn_ids: Vec::new(),
-        input_items: Vec::new(),
-        output_items: vec![item],
-        worklog,
-        error: None,
-        schema_version: 1,
     }
 }

--- a/crates/server/src/runtime.rs
+++ b/crates/server/src/runtime.rs
@@ -282,14 +282,14 @@ impl ServerRuntime {
             total_output_tokens: 0,
             status: SessionRuntimeStatus::Idle,
         };
-        if let Some(record) = &record {
-            if let Err(error) = self.rollout_store.append_session_meta(record) {
-                return self.error_response(
-                    request_id,
-                    ProtocolErrorCode::InternalError,
-                    format!("failed to persist session metadata: {error}"),
-                );
-            }
+        if let Some(record) = &record
+            && let Err(error) = self.rollout_store.append_session_meta(record)
+        {
+            return self.error_response(
+                request_id,
+                ProtocolErrorCode::InternalError,
+                format!("failed to persist session metadata: {error}"),
+            );
         }
         let core_session = self.deps.new_session_state(session_id, params.cwd.clone());
         let steering_queue = Arc::clone(&core_session.pending_user_prompts);
@@ -361,7 +361,7 @@ impl ServerRuntime {
         for session in sessions {
             summaries.push(session.lock().await.summary.clone());
         }
-        summaries.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+        summaries.sort_by_key(|right| std::cmp::Reverse(right.updated_at));
         serde_json::to_value(SuccessResponse {
             id: request_id,
             result: SessionListResult {
@@ -762,17 +762,16 @@ impl ServerRuntime {
         };
         self.maybe_assign_provisional_title(params.session_id, &display_input)
             .await;
-        if let Some(record) = session_arc.lock().await.record.clone() {
-            if let Err(error) = self
+        if let Some(record) = session_arc.lock().await.record.clone()
+            && let Err(error) = self
                 .rollout_store
                 .append_turn(&record, build_turn_record(&turn))
-            {
-                return self.error_response(
-                    request_id,
-                    ProtocolErrorCode::InternalError,
-                    format!("failed to persist turn start: {error}"),
-                );
-            }
+        {
+            return self.error_response(
+                request_id,
+                ProtocolErrorCode::InternalError,
+                format!("failed to persist turn start: {error}"),
+            );
         }
 
         tracing::info!(
@@ -866,17 +865,16 @@ impl ServerRuntime {
             }
             turn
         };
-        if let Some(record) = session_arc.lock().await.record.clone() {
-            if let Err(error) = self
+        if let Some(record) = session_arc.lock().await.record.clone()
+            && let Err(error) = self
                 .rollout_store
                 .append_turn(&record, build_turn_record(&interrupted_turn))
-            {
-                return self.error_response(
-                    request_id,
-                    ProtocolErrorCode::InternalError,
-                    format!("failed to persist interrupted turn: {error}"),
-                );
-            }
+        {
+            return self.error_response(
+                request_id,
+                ProtocolErrorCode::InternalError,
+                format!("failed to persist interrupted turn: {error}"),
+            );
         }
 
         tracing::info!(
@@ -1318,8 +1316,8 @@ impl ServerRuntime {
                                     session_id,
                                     turn_id: turn_for_events.turn_id,
                                     usage,
-                                    total_input_tokens: base.0 + input_tokens as usize,
-                                    total_output_tokens: base.1 + output_tokens as usize,
+                                    total_input_tokens: base.0 + input_tokens,
+                                    total_output_tokens: base.1 + output_tokens,
                                 },
                             ))
                             .await;
@@ -1431,28 +1429,27 @@ impl ServerRuntime {
             session.summary.total_output_tokens = session_total_output_tokens;
             final_turn
         };
-        if let Some(record) = session_arc.lock().await.record.clone() {
-            if let Err(error) = self
+        if let Some(record) = session_arc.lock().await.record.clone()
+            && let Err(error) = self
                 .rollout_store
                 .append_turn(&record, build_turn_record(&final_turn))
-            {
-                tracing::warn!(session_id = %session_id, error = %error, "failed to persist terminal turn line");
-            }
+        {
+            tracing::warn!(session_id = %session_id, error = %error, "failed to persist terminal turn line");
         }
-        if final_turn.status == TurnStatus::Completed {
-            if let Some(first_assistant_reply) = first_assistant_reply {
-                let runtime = Arc::clone(&self);
-                let input_for_title = display_input.clone();
-                tokio::spawn(async move {
-                    runtime
-                        .maybe_generate_final_title(
-                            session_id,
-                            &input_for_title,
-                            &first_assistant_reply,
-                        )
-                        .await;
-                });
-            }
+        if final_turn.status == TurnStatus::Completed
+            && let Some(first_assistant_reply) = first_assistant_reply
+        {
+            let runtime = Arc::clone(&self);
+            let input_for_title = display_input.clone();
+            tokio::spawn(async move {
+                runtime
+                    .maybe_generate_final_title(
+                        session_id,
+                        &input_for_title,
+                        &first_assistant_reply,
+                    )
+                    .await;
+            });
         }
 
         if let Err(error) = result {

--- a/crates/tools/src/apply_patch.rs
+++ b/crates/tools/src/apply_patch.rs
@@ -642,9 +642,8 @@ fn select_hunk_anchor(hunk: &PatchHunk) -> Option<(usize, &str)> {
                     && best_anchor
                         .map(|(_, best_text): (usize, &str)| text.len() > best_text.len())
                         .unwrap_or(true)
+                    || best_anchor.is_none()
                 {
-                    best_anchor = Some(candidate);
-                } else if best_anchor.is_none() {
                     best_anchor = Some(candidate);
                 }
                 sequence_index += 1;

--- a/crates/tools/src/file_write.rs
+++ b/crates/tools/src/file_write.rs
@@ -74,13 +74,13 @@ impl Tool for FileWriteTool {
 
         info!(path = %path.display(), bytes = content.len(), "writing file");
 
-        if let Some(parent) = path.parent() {
-            if let Err(e) = tokio::fs::create_dir_all(parent).await {
-                return Ok(ToolOutput::error(format!(
-                    "failed to create directories: {}",
-                    e
-                )));
-            }
+        if let Some(parent) = path.parent()
+            && let Err(e) = tokio::fs::create_dir_all(parent).await
+        {
+            return Ok(ToolOutput::error(format!(
+                "failed to create directories: {}",
+                e
+            )));
         }
 
         match tokio::fs::write(&path, content).await {

--- a/crates/tools/src/glob.rs
+++ b/crates/tools/src/glob.rs
@@ -77,7 +77,7 @@ impl Tool for GlobTool {
         }
 
         // Sort newest first
-        entries.sort_by(|a, b| b.1.cmp(&a.1));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         if entries.is_empty() {
             return Ok(ToolOutput::success("(no matches)"));

--- a/crates/tools/src/read.rs
+++ b/crates/tools/src/read.rs
@@ -56,12 +56,12 @@ impl Tool for ReadTool {
         let offset = input["offset"].as_u64().map(|value| value as usize);
         let limit = input["limit"].as_u64().map(|value| value as usize);
 
-        if let Some(offset) = offset {
-            if offset < 1 {
-                return Ok(ToolOutput::error(
-                    "offset must be greater than or equal to 1",
-                ));
-            }
+        if let Some(offset) = offset
+            && offset < 1
+        {
+            return Ok(ToolOutput::error(
+                "offset must be greater than or equal to 1",
+            ));
         }
 
         if !Path::new(&filepath).is_absolute() {
@@ -97,7 +97,7 @@ fn read_directory(path: &Path, limit: usize, offset: usize) -> anyhow::Result<To
             if is_dir { format!("{name}/") } else { name }
         })
         .collect::<Vec<_>>();
-    items.sort_unstable_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    items.sort_unstable_by_key(|a| a.to_lowercase());
 
     let start = offset.saturating_sub(1);
     let sliced = items
@@ -408,7 +408,7 @@ mod tests {
     fn is_binary_file_detects_null_bytes() {
         let dir = create_temp_dir("binary");
         let path = dir.join("payload.bin");
-        fs::write(&path, &[0u8, 1, 2]).unwrap();
+        fs::write(&path, [0u8, 1, 2]).unwrap();
 
         assert!(is_binary_file(&path).unwrap());
     }

--- a/crates/tui/src/input.rs
+++ b/crates/tui/src/input.rs
@@ -203,7 +203,7 @@ impl InputBuffer {
         let prompt_prefix = prompt.map(|value| format!("{value}> "));
         let prompt_width = prompt_prefix
             .as_deref()
-            .map(|value| unicode_width::UnicodeWidthStr::width(value) as usize)
+            .map(unicode_width::UnicodeWidthStr::width)
             .unwrap_or(2);
         let mut lines = Vec::new();
         let mut current = prompt_prefix.clone().unwrap_or_else(|| String::from("> "));

--- a/crates/tui/src/render/markdown.rs
+++ b/crates/tui/src/render/markdown.rs
@@ -481,8 +481,7 @@ fn highlight_code_to_lines(code: &str, lang: &str) -> Vec<Line<'static>> {
 }
 
 fn syntect_style_to_ratatui(style: syntect::highlighting::Style) -> Style {
-    let mut converted = Style::default();
-    converted.fg = Some(Color::Rgb(
+    let mut converted = Style::new().fg(Color::Rgb(
         style.foreground.r,
         style.foreground.g,
         style.foreground.b,

--- a/crates/tui/src/render/mod.rs
+++ b/crates/tui/src/render/mod.rs
@@ -144,8 +144,7 @@ pub(crate) fn composer_height(app: &TuiApp, area: Rect) -> u16 {
             3,
             area.height
                 .saturating_sub(1)
-                .max(3)
-                .min(layout::COMPOSER_MAX_HEIGHT),
+                .clamp(3, layout::COMPOSER_MAX_HEIGHT),
         );
     base_height
         .saturating_add(aux_panel_height(app))
@@ -231,10 +230,10 @@ fn format_token_count(value: usize) -> String {
 
 fn resolve_git_branch(cwd: &Path) -> Option<String> {
     let key = cwd.to_string_lossy().into_owned();
-    if let Ok(cache) = GIT_BRANCH_CACHE.lock() {
-        if let Some(branch) = cache.get(&key) {
-            return branch.clone();
-        }
+    if let Ok(cache) = GIT_BRANCH_CACHE.lock()
+        && let Some(branch) = cache.get(&key)
+    {
+        return branch.clone();
     }
 
     let branch = Command::new("git")
@@ -523,8 +522,7 @@ fn inline_command_popup_rows(
                 .max(1);
             let name_width = UnicodeWidthStr::width(suggestion.name);
             let gap = 2usize;
-            let description_width =
-                available.saturating_sub((name_width + gap) as u16).max(0) as usize;
+            let description_width = available.saturating_sub((name_width + gap) as u16) as usize;
             let description = truncate_to_width(suggestion.description, description_width);
             let mut spans = vec![
                 Span::styled(
@@ -854,7 +852,7 @@ fn centered_popup_area(base_area: Rect, desired_height: u16, item_count: usize) 
 }
 
 fn onboarding_popup_area(base_area: Rect, desired_height: u16) -> Rect {
-    let width = base_area.width.min(ONBOARDING_OVERLAY_WIDTH).max(56);
+    let width = base_area.width.clamp(56, ONBOARDING_OVERLAY_WIDTH);
     let y = base_area.y.saturating_add(BRAND_HEADER_HEIGHT);
     let available_height = base_area
         .height

--- a/crates/tui/src/runtime.rs
+++ b/crates/tui/src/runtime.rs
@@ -368,25 +368,19 @@ impl TuiApp {
                     self.scroll = self.scroll.saturating_add(1);
                 }
             }
-            KeyCode::PageUp => {
-                if !self.inline_mode {
-                    if self.follow_output {
-                        self.scroll =
-                            render::get_max_scroll(self, self.transcript_area(terminal_area));
-                        self.follow_output = false;
-                    }
-                    self.scroll = self.scroll.saturating_sub(10);
+            KeyCode::PageUp if !self.inline_mode => {
+                if self.follow_output {
+                    self.scroll = render::get_max_scroll(self, self.transcript_area(terminal_area));
+                    self.follow_output = false;
                 }
+                self.scroll = self.scroll.saturating_sub(10);
             }
-            KeyCode::PageDown => {
-                if !self.inline_mode {
-                    if self.follow_output {
-                        self.scroll =
-                            render::get_max_scroll(self, self.transcript_area(terminal_area));
-                        self.follow_output = false;
-                    }
-                    self.scroll = self.scroll.saturating_add(10);
+            KeyCode::PageDown if !self.inline_mode => {
+                if self.follow_output {
+                    self.scroll = render::get_max_scroll(self, self.transcript_area(terminal_area));
+                    self.follow_output = false;
                 }
+                self.scroll = self.scroll.saturating_add(10);
             }
             KeyCode::Esc => {
                 self.flush_pending_paste_burst(true);
@@ -489,8 +483,9 @@ impl TuiApp {
 
         if self.onboarding_base_url_pending {
             let base_url = prompt.trim();
-            if !base_url.is_empty()
-                && !(base_url.starts_with("http://") || base_url.starts_with("https://"))
+            if !(base_url.is_empty()
+                || base_url.starts_with("http://")
+                || base_url.starts_with("https://"))
             {
                 self.status_message = "Base URL must start with http:// or https://".to_string();
                 self.onboarding_prompt = Some("base url".to_string());
@@ -538,7 +533,7 @@ impl TuiApp {
                 self.onboarding_selected_api_key
                     .as_deref()
                     .map(super::worker_events::mask_secret)
-                    .unwrap_or_else(String::new)
+                    .unwrap_or_default()
             ));
             let Some(model) = self.onboarding_selected_model.clone() else {
                 anyhow::bail!("onboarding model selection was lost before validation");

--- a/crates/tui/src/transcript.rs
+++ b/crates/tui/src/transcript.rs
@@ -169,7 +169,7 @@ fn format_block(title: &str, body: &str, width: u16, prefix: Option<&str>) -> St
     }
 
     let prefix = prefix.unwrap_or("");
-    let continuation_prefix = if prefix.is_empty() { "  " } else { "  " };
+    let continuation_prefix = "  ";
     append_wrapped_body(&mut out, body, width, prefix, continuation_prefix, None);
     out
 }

--- a/crates/tui/src/worker.rs
+++ b/crates/tui/src/worker.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use anyhow::{Context, Result};
 use tokio::{
@@ -528,8 +531,8 @@ async fn run_worker_inner(
                         }
                     }
                     Some(OperationCommand::InterruptTurn) => {
-                        if let (Some(turn_id), Some(active_session_id)) = (active_turn_id, session_id) {
-                            if let Err(error) = client
+                        if let (Some(turn_id), Some(active_session_id)) = (active_turn_id, session_id)
+                            && let Err(error) = client
                                 .turn_interrupt(TurnInterruptParams {
                                     session_id: active_session_id,
                                     turn_id,
@@ -544,7 +547,6 @@ async fn run_worker_inner(
                                     total_output_tokens,
                                 });
                             }
-                        }
                     }
                     Some(OperationCommand::Shutdown) | None => {
                         break;
@@ -635,14 +637,13 @@ async fn run_worker_inner(
                                 }
                             }
                             "session/title/updated" => {
-                                if let ServerEvent::SessionTitleUpdated(payload) = event {
-                                    if let Some(title) = payload.session.title {
+                                if let ServerEvent::SessionTitleUpdated(payload) = event
+                                    && let Some(title) = payload.session.title {
                                         let _ = event_tx.send(WorkerEvent::SessionTitleUpdated {
                                             session_id: payload.session.session_id.to_string(),
                                             title,
                                         });
                                     }
-                                }
                             }
                             _ => {}
                         }
@@ -659,7 +660,7 @@ async fn run_worker_inner(
 
 async fn ensure_session_started(
     client: &mut StdioServerClient,
-    cwd: &PathBuf,
+    cwd: &Path,
     model: &str,
     session_id: &mut Option<SessionId>,
 ) -> Result<EnsureSessionOutcome> {
@@ -672,7 +673,7 @@ async fn ensure_session_started(
 
     let session = client
         .session_start(SessionStartParams {
-            cwd: cwd.clone(),
+            cwd: cwd.to_path_buf(),
             ephemeral: false,
             title: None,
             model: Some(model.to_string()),
@@ -686,13 +687,13 @@ async fn ensure_session_started(
 }
 
 async fn spawn_client(
-    cwd: &PathBuf,
+    cwd: &Path,
     env: Vec<(String, String)>,
     server_log_level: Option<String>,
 ) -> Result<StdioServerClient> {
     StdioServerClient::spawn(StdioServerClientConfig {
         program: std::env::current_exe().context("resolve current executable for server launch")?,
-        workspace_root: Some(cwd.clone()),
+        workspace_root: Some(cwd.to_path_buf()),
         env,
         args: server_log_level
             .into_iter()
@@ -850,22 +851,21 @@ fn project_history_items(items: &[SessionHistoryItem]) -> Vec<TranscriptItem> {
 
     while index < items.len() {
         let item = &items[index];
-        if item.kind == SessionHistoryItemKind::ToolCall {
-            if let Some(next) = items.get(index + 1) {
-                if matches!(
-                    next.kind,
-                    SessionHistoryItemKind::ToolResult | SessionHistoryItemKind::Error
-                ) {
-                    let merged = if next.kind == SessionHistoryItemKind::Error {
-                        TranscriptItem::tool_error(item.title.clone(), next.body.clone())
-                    } else {
-                        TranscriptItem::restored_tool_result(item.title.clone(), next.body.clone())
-                    };
-                    transcript.push(merged);
-                    index += 2;
-                    continue;
-                }
-            }
+        if item.kind == SessionHistoryItemKind::ToolCall
+            && let Some(next) = items.get(index + 1)
+            && matches!(
+                next.kind,
+                SessionHistoryItemKind::ToolResult | SessionHistoryItemKind::Error
+            )
+        {
+            let merged = if next.kind == SessionHistoryItemKind::Error {
+                TranscriptItem::tool_error(item.title.clone(), next.body.clone())
+            } else {
+                TranscriptItem::restored_tool_result(item.title.clone(), next.body.clone())
+            };
+            transcript.push(merged);
+            index += 2;
+            continue;
         }
 
         let kind = match item.kind {
@@ -1032,7 +1032,7 @@ fn resolve_validation_model(provider: ProviderFamily, model: &str) -> Result<Mod
     }
     Ok(Model {
         slug: model.to_string(),
-        provider: provider,
+        provider,
         ..Model::default()
     })
 }


### PR DESCRIPTION
## Summary
Resolves most clippy warnings across the workspace (from 30+ down to 5 remaining, which are \	oo_many_arguments\ and doc formatting that would require API restructuring).

## Changes

### protocol
- Use \#[default]\ derive instead of manual \Default\ impl for \Verbosity\, \InputModality\, \OpenAiApi\
- Remove unnecessary \clone()\ on \Copy\ type (\ProviderFamily\)
- Replace \unwrap_or_else\ with \unwrap_or\ for non-lazy evaluation

### tui
- Simplify boolean expression in base URL validation
- Use \Style::new().fg()\ instead of \Style::default()\ + field assignment
- Replace \.max().min()\ chains with \.clamp()\
- Remove identical if/else branch in transcript continuation prefix
- Use \&Path\ instead of \&PathBuf\ in function signatures
- Replace redundant closure with method reference

### provider
- Fix doc comment indentation for markdown list items
- Replace \.filter_map()\ with \.map()\ where all branches return \Some\
- Simplify collapsible if statements

### tools
- Merge identical if/else branches in apply_patch
- Use \sort_by_key\ instead of \sort_by\ in glob
- Remove unnecessary borrow in test

### core
- Fix empty line after doc comment
- Use \sort_by_key\ instead of \sort_by\ in model_catalog
- Remove redundant \ormat!()\ and \.to_string()\ in query

### server
- Use \sort_by_key\ instead of \sort_by\ in runtime
- Simplify collapsible if statements
- Remove unnecessary \s usize\ casts

### cli
- Add missing \model\ field to test \Cli\ initializers

## Testing
- All workspace tests pass (\cargo test --workspace\)
- \cargo fmt --all -- --check\ clean
- Only 5 clippy warnings remain (3x \	oo_many_arguments\, 2x doc formatting)