### PR TITLE
fix: handle null arrays in OpenAI-compatible API responses

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -40,14 +40,23 @@ async fn main() -> Result<()> {
     match cli.command {
         Some(Command::Server(args)) => run_server_process(args).await,
         Some(Command::Onboard) => {
-            run_agent(true, cli.no_alt_screen, cli.log_level.map(LogLevel::as_str), cli.model.as_deref()).await
+            run_agent(
+                true,
+                cli.no_alt_screen,
+                cli.log_level.map(LogLevel::as_str),
+                cli.model.as_deref(),
+            )
+            .await
         }
         Some(Command::Prompt { input }) => {
-            run_prompt(&input, cli.model.as_deref(), cli.log_level.map(LogLevel::as_str)).await
+            run_prompt(
+                &input,
+                cli.model.as_deref(),
+                cli.log_level.map(LogLevel::as_str),
+            )
+            .await
         }
-        Some(Command::Doctor) => {
-            run_doctor().await
-        }
+        Some(Command::Doctor) => run_doctor().await,
         None => {
             run_agent(
                 false,
@@ -142,7 +151,11 @@ impl LogLevel {
     }
 }
 
-async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Option<&str>) -> Result<()> {
+async fn run_prompt(
+    input: &str,
+    model_override: Option<&str>,
+    _log_level: Option<&str>,
+) -> Result<()> {
     use clawcr_core::{SessionConfig, SessionState, default_base_instructions};
     use clawcr_tools::{ToolOrchestrator, ToolRegistry};
 
@@ -156,10 +169,8 @@ async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Optio
     }
 
     let home_dir = find_clawcr_home()?;
-    let provider = clawcr_server::load_server_provider(
-        &home_dir.join("config.toml"),
-        Some(&resolved.model),
-    )?;
+    let provider =
+        clawcr_server::load_server_provider(&home_dir.join("config.toml"), Some(&resolved.model))?;
 
     let mut session_state = SessionState::new(SessionConfig::default(), cwd.clone());
     session_state.push_message(clawcr_core::Message::user(input.to_string()));
@@ -199,11 +210,16 @@ async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Optio
     match result {
         Ok(()) => {
             let reply = session_state.messages.iter().rev().find_map(|m| {
-                if m.role != clawcr_core::Role::Assistant { return None; }
-                m.content.iter().filter_map(|block| match block {
-                    clawcr_core::ContentBlock::Text { text } => Some(text.as_str()),
-                    _ => None,
-                }).next()
+                if m.role != clawcr_core::Role::Assistant {
+                    return None;
+                }
+                m.content
+                    .iter()
+                    .filter_map(|block| match block {
+                        clawcr_core::ContentBlock::Text { text } => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .next()
             });
             match reply {
                 Some(text) => println!("{}", text),
@@ -219,8 +235,8 @@ async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Optio
 }
 
 async fn run_doctor() -> Result<()> {
-    use std::process::Command;
     use colored::Colorize;
+    use std::process::Command;
 
     println!("{}", "=== Claw CR Doctor ===".bold());
     println!();
@@ -265,15 +281,18 @@ async fn run_doctor() -> Result<()> {
                 println!("  {} api_key or base_url missing", "!".yellow());
                 all_ok = false;
             }
-            let model_line = content.lines()
-                .find(|l| l.starts_with("model"));
+            let model_line = content.lines().find(|l| l.starts_with("model"));
             if let Some(line) = model_line {
                 println!("  default model: {}", line.trim());
             } else {
                 println!("  {} no default model set", "!".yellow());
             }
         } else {
-            println!("  {} not found at {}", "missing".yellow(), config_path.display());
+            println!(
+                "  {} not found at {}",
+                "missing".yellow(),
+                config_path.display()
+            );
             println!("  Run `clawcr onboard` to create it.");
             all_ok = false;
         }
@@ -285,7 +304,10 @@ async fn run_doctor() -> Result<()> {
         Ok(resolved) => {
             println!("  provider:   {}", resolved.provider_id);
             println!("  model:      {}", resolved.model);
-            println!("  base_url:   {}", resolved.base_url.unwrap_or("default".into()));
+            println!(
+                "  base_url:   {}",
+                resolved.base_url.unwrap_or("default".into())
+            );
             println!("  wire_api:   {:?}", resolved.wire_api);
             if resolved.api_key.is_some() {
                 println!("  api_key:    {} (set)", "✓".green());
@@ -317,7 +339,10 @@ async fn run_doctor() -> Result<()> {
     if all_ok {
         println!("{}", "All checks passed. Ready to use!".green().bold());
     } else {
-        println!("{}", "Some checks failed. See above for details.".yellow().bold());
+        println!(
+            "{}",
+            "Some checks failed. See above for details.".yellow().bold()
+        );
         std::process::exit(1);
     }
 
@@ -356,6 +381,7 @@ mod tests {
     fn cli_logging_overrides_is_empty_without_log_level() {
         let cli = Cli {
             command: None,
+            model: None,
             no_alt_screen: false,
             log_level: None,
         };
@@ -370,6 +396,7 @@ mod tests {
     fn cli_logging_overrides_sets_logging_level() {
         let cli = Cli {
             command: None,
+            model: None,
             no_alt_screen: false,
             log_level: Some(LogLevel::Debug),
         };

--- a/crates/provider/src/openai/chat_completions.rs
+++ b/crates/provider/src/openai/chat_completions.rs
@@ -70,7 +70,7 @@ impl OpenAIProvider {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(super) struct OpenAIChatCompletionResponse {
     id: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_vec")]
     choices: Vec<OpenAIChatCompletionChoice>,
     #[serde(default)]
     created: Option<u64>,
@@ -132,13 +132,13 @@ pub(super) struct OpenAIChatCompletionMessage {
     refusal: Option<String>,
     #[serde(default)]
     role: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_vec")]
     annotations: Vec<OpenAIChatCompletionAnnotation>,
     #[serde(default)]
     audio: Option<OpenAIChatCompletionAudio>,
     #[serde(default)]
     function_call: Option<OpenAIChatCompletionFunctionCall>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_vec")]
     tool_calls: Vec<OpenAIChatCompletionMessageToolCall>,
     #[serde(default)]
     reasoning_content: Option<String>,
@@ -516,6 +516,14 @@ pub(super) struct OpenAICompletionTokenDetails {
 /// - Tool results are serialized as `tool` messages with `tool_call_id`.
 /// - Streaming requests add `stream_options: { "include_usage": true }`.
 /// - Additional provider-specific fields may be merged in via `extra_body`.
+fn deserialize_null_vec<'de, D, T>(deserializer: D) -> std::result::Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    Option::<Vec<T>>::deserialize(deserializer).map(|v| v.unwrap_or_default())
+}
+
 fn build_request(request: &ModelRequest, stream: bool) -> Value {
     let profile = resolve_request_profile(&request.model, OpenAITransport::ChatCompletions);
     let mut messages = Vec::new();

--- a/crates/provider/src/openai/chat_completions/stream.rs
+++ b/crates/provider/src/openai/chat_completions/stream.rs
@@ -570,7 +570,7 @@ struct ChatCompletionStreamChunk {
     service_tier: Option<String>,
     #[serde(default)]
     system_fingerprint: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_vec")]
     choices: Vec<ChatCompletionStreamChoice>,
     #[serde(default)]
     usage: Option<OpenAICompletionUsage>,

--- a/crates/provider/src/openai/chat_completions/stream.rs
+++ b/crates/provider/src/openai/chat_completions/stream.rs
@@ -598,8 +598,16 @@ struct ChatCompletionStreamDelta {
     reasoning_content: Option<String>,
     #[serde(default)]
     refusal: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_vec")]
     tool_calls: Vec<ChatCompletionStreamToolCallDelta>,
+}
+
+fn deserialize_null_vec<'de, D, T>(deserializer: D) -> std::result::Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    Option::<Vec<T>>::deserialize(deserializer).map(|v| v.unwrap_or_default())
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/tui/src/worker_events.rs
+++ b/crates/tui/src/worker_events.rs
@@ -324,13 +324,11 @@ impl TuiApp {
                     content: AuxPanelContent::SessionList(entries),
                     ..
                 }) = self.aux_panel.as_mut()
-                {
-                    if let Some(entry) = entries
+                    && let Some(entry) = entries
                         .iter_mut()
                         .find(|entry| entry.session_id.to_string() == session_id)
-                    {
-                        entry.title = title.clone();
-                    }
+                {
+                    entry.title = title.clone();
                 }
                 self.status_message = format!("Session titled: {title}");
             }
@@ -397,11 +395,11 @@ impl TuiApp {
     }
 
     pub(crate) fn set_turn_status_line(&mut self, title: impl Into<String>) {
-        if let Some(index) = self.pending_status_index {
-            if let Some(item) = self.transcript.get_mut(index) {
-                item.title = title.into();
-                item.body.clear();
-            }
+        if let Some(index) = self.pending_status_index
+            && let Some(item) = self.transcript.get_mut(index)
+        {
+            item.title = title.into();
+            item.body.clear();
         }
     }
 


### PR DESCRIPTION
## Problem

Some OpenAI-compatible providers (e.g., NVIDIA NIM) return \
ull\ instead of \[]\ for array fields like \choices\, \	ool_calls\, and \nnotations\. This causes serde deserialization to fail with:

\\\
invalid type: null, expected a sequence
\\\

## Solution

Add a custom \deserialize_null_vec\ deserializer that treats \
ull\ as an empty vector (\Vec::default()\). Applied to all \Vec\ fields in chat completion and streaming response types:

- \OpenAIChatCompletionResponse::choices\
- \OpenAIChatCompletionMessage::annotations\
- \OpenAIChatCompletionMessage::tool_calls\
- \ChatCompletionStreamDelta::tool_calls\

## Testing

All three CI checks pass locally:
-  \cargo fmt --all -- --check\
-  \cargo clippy --workspace --all-targets\
-  \cargo test --workspace\ (262 tests passed)