### PR TITLE
fix: make --log-level work in prompt mode

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -40,14 +40,23 @@ async fn main() -> Result<()> {
     match cli.command {
         Some(Command::Server(args)) => run_server_process(args).await,
         Some(Command::Onboard) => {
-            run_agent(true, cli.no_alt_screen, cli.log_level.map(LogLevel::as_str), cli.model.as_deref()).await
+            run_agent(
+                true,
+                cli.no_alt_screen,
+                cli.log_level.map(LogLevel::as_str),
+                cli.model.as_deref(),
+            )
+            .await
         }
         Some(Command::Prompt { input }) => {
-            run_prompt(&input, cli.model.as_deref(), cli.log_level.map(LogLevel::as_str)).await
+            run_prompt(
+                &input,
+                cli.model.as_deref(),
+                cli.log_level.map(LogLevel::as_str),
+            )
+            .await
         }
-        Some(Command::Doctor) => {
-            run_doctor().await
-        }
+        Some(Command::Doctor) => run_doctor().await,
         None => {
             run_agent(
                 false,
@@ -142,7 +151,16 @@ impl LogLevel {
     }
 }
 
-async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Option<&str>) -> Result<()> {
+async fn run_prompt(
+    input: &str,
+    model_override: Option<&str>,
+    log_level: Option<&str>,
+) -> Result<()> {
+    if let Some(level) = log_level {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::new(level))
+            .try_init();
+    }
     use clawcr_core::{SessionConfig, SessionState, default_base_instructions};
     use clawcr_tools::{ToolOrchestrator, ToolRegistry};
 
@@ -156,10 +174,8 @@ async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Optio
     }
 
     let home_dir = find_clawcr_home()?;
-    let provider = clawcr_server::load_server_provider(
-        &home_dir.join("config.toml"),
-        Some(&resolved.model),
-    )?;
+    let provider =
+        clawcr_server::load_server_provider(&home_dir.join("config.toml"), Some(&resolved.model))?;
 
     let mut session_state = SessionState::new(SessionConfig::default(), cwd.clone());
     session_state.push_message(clawcr_core::Message::user(input.to_string()));
@@ -199,11 +215,16 @@ async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Optio
     match result {
         Ok(()) => {
             let reply = session_state.messages.iter().rev().find_map(|m| {
-                if m.role != clawcr_core::Role::Assistant { return None; }
-                m.content.iter().filter_map(|block| match block {
-                    clawcr_core::ContentBlock::Text { text } => Some(text.as_str()),
-                    _ => None,
-                }).next()
+                if m.role != clawcr_core::Role::Assistant {
+                    return None;
+                }
+                m.content
+                    .iter()
+                    .filter_map(|block| match block {
+                        clawcr_core::ContentBlock::Text { text } => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .next()
             });
             match reply {
                 Some(text) => println!("{}", text),
@@ -219,8 +240,8 @@ async fn run_prompt(input: &str, model_override: Option<&str>, _log_level: Optio
 }
 
 async fn run_doctor() -> Result<()> {
-    use std::process::Command;
     use colored::Colorize;
+    use std::process::Command;
 
     println!("{}", "=== Claw CR Doctor ===".bold());
     println!();
@@ -265,15 +286,18 @@ async fn run_doctor() -> Result<()> {
                 println!("  {} api_key or base_url missing", "!".yellow());
                 all_ok = false;
             }
-            let model_line = content.lines()
-                .find(|l| l.starts_with("model"));
+            let model_line = content.lines().find(|l| l.starts_with("model"));
             if let Some(line) = model_line {
                 println!("  default model: {}", line.trim());
             } else {
                 println!("  {} no default model set", "!".yellow());
             }
         } else {
-            println!("  {} not found at {}", "missing".yellow(), config_path.display());
+            println!(
+                "  {} not found at {}",
+                "missing".yellow(),
+                config_path.display()
+            );
             println!("  Run `clawcr onboard` to create it.");
             all_ok = false;
         }
@@ -285,7 +309,10 @@ async fn run_doctor() -> Result<()> {
         Ok(resolved) => {
             println!("  provider:   {}", resolved.provider_id);
             println!("  model:      {}", resolved.model);
-            println!("  base_url:   {}", resolved.base_url.unwrap_or("default".into()));
+            println!(
+                "  base_url:   {}",
+                resolved.base_url.unwrap_or("default".into())
+            );
             println!("  wire_api:   {:?}", resolved.wire_api);
             if resolved.api_key.is_some() {
                 println!("  api_key:    {} (set)", "✓".green());
@@ -317,7 +344,10 @@ async fn run_doctor() -> Result<()> {
     if all_ok {
         println!("{}", "All checks passed. Ready to use!".green().bold());
     } else {
-        println!("{}", "Some checks failed. See above for details.".yellow().bold());
+        println!(
+            "{}",
+            "Some checks failed. See above for details.".yellow().bold()
+        );
         std::process::exit(1);
     }
 
@@ -356,6 +386,7 @@ mod tests {
     fn cli_logging_overrides_is_empty_without_log_level() {
         let cli = Cli {
             command: None,
+            model: None,
             no_alt_screen: false,
             log_level: None,
         };
@@ -370,6 +401,7 @@ mod tests {
     fn cli_logging_overrides_sets_logging_level() {
         let cli = Cli {
             command: None,
+            model: None,
             no_alt_screen: false,
             log_level: Some(LogLevel::Debug),
         };


### PR DESCRIPTION
## Problem

Running `clawcr prompt --log-level debug` has no effect — the flag is accepted but silently ignored.

The `run_prompt` function receives a `_log_level` parameter (underscore prefix = unused) and never initializes any tracing subscriber with it. In contrast, `run_agent` (TUI mode) properly passes log level to the server logging bootstrap.

## Solution

Initialize a console `tracing_subscriber::fmt()` subscriber when `--log-level` is passed in prompt mode, using the same pattern as other CLI tools.

## Testing

All CI checks pass locally:
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --workspace --all-targets`
- ✅ `cargo test --workspace`

Verified: `clawcr --log-level debug` now outputs debug-level traces.