### PR TITLE
fix: onboarding redesign, session restore, interrupt handling, and exit coordinates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,6 +769,7 @@ dependencies = [
  "devo-utils",
  "futures",
  "pretty_assertions",
+ "rusqlite",
  "serde",
  "serde_json",
  "smol_str",
@@ -1037,6 +1038,18 @@ dependencies = [
  "nom 7.1.3",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1333,6 +1346,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -1742,6 +1764,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2545,6 +2578,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3611,6 +3658,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "stream",
 ] }
 reqwest-eventsource = "0.6"
+rusqlite = { version = "0.33", features = ["bundled"] }
 schemars = "0.8.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/core/src/conversation/records.rs
+++ b/crates/core/src/conversation/records.rs
@@ -200,6 +200,9 @@ pub enum TurnItem {
     ImageGeneration(TextItem),
     /// A context-compaction summary item.
     ContextCompaction(TextItem),
+    /// A turn boundary summary with model name and duration.
+    /// title = model name, body = duration_secs:u64 as string
+    TurnSummary(TextItem),
 }
 
 /// Stores optional high-level progress notes for an item append.

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -57,17 +57,17 @@ pub struct SessionState {
     /// Input tokens reported by the model for the most recent turn.
     /// Used by `TokenBudget::should_compact()` to decide when to compact.
     pub last_input_tokens: usize,
-    /// Thread-safe inbox for pending inputs pushed from server handlers
-    /// while the query loop is running.
-    pub pending_user_prompts: Arc<Mutex<VecDeque<PendingInputItem>>>,
-    /// Thread-safe inbox for /btw steer inputs pushed while the query loop
-    /// is running. These are drained into the CURRENT turn's pending_input
-    /// at each loop iteration and are NOT carried over to the next turn.
-    pub steer_input_queue: Arc<Mutex<VecDeque<PendingInputItem>>>,
+    /// Thread-safe queue for pending turn inputs.
+    /// - Source: user sends `turn/start` while a turn is active.
+    /// - Lifecycle: preserved across turns; unconsumed items are pushed back
+    ///   when the current turn ends and consumed when the next turn starts.
+    pub pending_turn_queue: Arc<Mutex<VecDeque<PendingInputItem>>>,
+    /// Thread-safe queue for /btw steer inputs.
+    /// - Source: user sends `turn/steer` while a turn is active.
+    /// - Lifecycle: scoped to current turn only; cleared when the turn ends.
+    pub btw_input_queue: Arc<Mutex<VecDeque<PendingInputItem>>>,
     /// Turn-scoped state (Some while a turn is active).
     pub(crate) turn_state: Option<TurnState>,
-    /// Items queued for next turn when current turn ends with unconsumed input.
-    pub idle_pending_input: VecDeque<PendingInputItem>,
 }
 
 impl SessionState {
@@ -87,10 +87,9 @@ impl SessionState {
             total_cache_read_tokens: 0,
             prompt_token_estimate: 0,
             last_input_tokens: 0,
-            pending_user_prompts: Arc::new(Mutex::new(VecDeque::new())),
-            steer_input_queue: Arc::new(Mutex::new(VecDeque::new())),
+            pending_turn_queue: Arc::new(Mutex::new(VecDeque::new())),
+            btw_input_queue: Arc::new(Mutex::new(VecDeque::new())),
             turn_state: None,
-            idle_pending_input: VecDeque::new(),
         }
     }
 
@@ -129,71 +128,68 @@ impl SessionState {
         }
     }
 
+    /// Pushes a pending input to the turn queue (for execution in a future turn).
     pub fn enqueue_pending_input(&self, item: PendingInputItem) {
-        self.pending_user_prompts
+        self.pending_turn_queue
             .lock()
-            .expect("pending user prompts mutex should not be poisoned")
+            .expect("pending turn queue mutex should not be poisoned")
             .push_back(item);
     }
 
-    pub fn drain_pending_user_prompts(&self) -> Vec<PendingInputItem> {
+    /// Drains all pending inputs from the turn queue.
+    pub fn drain_pending_turn_queue(&self) -> Vec<PendingInputItem> {
         let mut pending = self
-            .pending_user_prompts
+            .pending_turn_queue
             .lock()
-            .expect("pending user prompts mutex should not be poisoned");
+            .expect("pending turn queue mutex should not be poisoned");
         pending.drain(..).collect()
     }
 
+    /// Drains all pending inputs from the /btw queue.
+    pub fn drain_btw_input_queue(&self) -> Vec<PendingInputItem> {
+        let mut guard = self
+            .btw_input_queue
+            .lock()
+            .expect("btw input queue mutex should not be poisoned");
+        guard.drain(..).collect()
+    }
+
     pub fn start_turn(&mut self, kind: TurnKind) {
-        // Move idle-pending items into the new turn's pending_input.
-        let idle = std::mem::take(&mut self.idle_pending_input);
         let mut turn = TurnState::new(kind);
-        turn.pending_input = idle.into();
+        // Drain pending turn queue into the new turn's pending input.
+        let pending = self.drain_pending_turn_queue();
+        turn.pending_input = pending;
         self.turn_state = Some(turn);
     }
 
     pub fn end_turn(&mut self) {
         if let Some(turn) = self.turn_state.take() {
-            // Unconsumed pending input goes back to idle queue.
-            self.idle_pending_input.extend(turn.pending_input);
+            // Unconsumed pending input goes back to the turn queue (prepend to preserve order).
+            let mut queue = self
+                .pending_turn_queue
+                .lock()
+                .expect("pending turn queue mutex should not be poisoned");
+            for item in turn.pending_input.into_iter().rev() {
+                queue.push_front(item);
+            }
         }
         // /btw steer inputs are scoped to the current turn only; discard any
         // that arrived too late to be consumed.
-        self.steer_input_queue
+        self.btw_input_queue
             .lock()
-            .expect("steer input queue mutex should not be poisoned")
+            .expect("btw input queue mutex should not be poisoned")
             .clear();
     }
 
-    pub fn drain_steer_input_queue(&self) -> Vec<PendingInputItem> {
-        let mut guard = self
-            .steer_input_queue
-            .lock()
-            .expect("steer input queue mutex should not be poisoned");
-        guard.drain(..).collect()
-    }
-
     /// Merge turn-scoped pending input with both cross-thread inboxes.
-    /// Order: steer inbox → turn-state pending → next-turn queue
+    /// Order: btw inbox → turn-state pending → turn queue
     pub fn take_turn_pending_input(&mut self) -> Vec<PendingInputItem> {
-        let mut result = self.drain_steer_input_queue();
+        let mut result = self.drain_btw_input_queue();
         if let Some(turn) = self.turn_state.as_mut() {
             result.extend(turn.take_pending_input());
         }
-        result.extend(self.drain_pending_user_prompts());
+        result.extend(self.drain_pending_turn_queue());
         result
-    }
-
-    pub fn queue_for_next_turn(&mut self, items: Vec<PendingInputItem>) {
-        self.idle_pending_input.extend(items);
-    }
-
-    pub fn take_queued_for_next_turn(&mut self) -> Vec<PendingInputItem> {
-        self.idle_pending_input.drain(..).collect()
-    }
-
-    pub fn has_queued_for_next_turn(&self) -> bool {
-        !self.idle_pending_input.is_empty()
     }
 }
 
@@ -251,7 +247,7 @@ mod tests {
     }
 
     #[test]
-    fn session_state_drains_pending_user_prompts() {
+    fn session_state_drains_pending_turn_queue() {
         use chrono::Utc;
         let state = SessionState::new(SessionConfig::default(), PathBuf::from("/tmp"));
         state.enqueue_pending_input(PendingInputItem {
@@ -269,9 +265,9 @@ mod tests {
             created_at: Utc::now(),
         });
 
-        let drained = state.drain_pending_user_prompts();
+        let drained = state.drain_pending_turn_queue();
         assert_eq!(drained.len(), 2);
-        assert!(state.drain_pending_user_prompts().is_empty());
+        assert!(state.drain_pending_turn_queue().is_empty());
     }
 
     #[test]
@@ -284,12 +280,12 @@ mod tests {
     }
 
     #[test]
-    fn session_state_start_turn_drains_idle_queue() {
+    fn session_state_start_turn_drains_pending_queue() {
         use chrono::Utc;
         let mut state = SessionState::new(SessionConfig::default(), PathBuf::from("/tmp"));
-        state.idle_pending_input.push_back(PendingInputItem {
+        state.enqueue_pending_input(PendingInputItem {
             kind: devo_protocol::PendingInputKind::UserText {
-                text: "idle".to_string(),
+                text: "queued".to_string(),
             },
             metadata: None,
             created_at: Utc::now(),
@@ -297,11 +293,11 @@ mod tests {
         state.start_turn(TurnKind::Regular);
         let pending = state.take_turn_pending_input();
         assert_eq!(pending.len(), 1);
-        assert!(state.idle_pending_input.is_empty());
+        assert!(state.pending_turn_queue.lock().unwrap().is_empty());
     }
 
     #[test]
-    fn session_state_end_turn_moves_unconsumed_to_idle() {
+    fn session_state_end_turn_moves_unconsumed_back_to_queue() {
         use chrono::Utc;
         let mut state = SessionState::new(SessionConfig::default(), PathBuf::from("/tmp"));
         state.start_turn(TurnKind::Regular);
@@ -317,7 +313,7 @@ mod tests {
         }
         state.end_turn();
         assert!(state.turn_state.is_none());
-        assert_eq!(state.idle_pending_input.len(), 1);
+        assert_eq!(state.pending_turn_queue.lock().unwrap().len(), 1);
     }
 
     #[test]
@@ -345,24 +341,6 @@ mod tests {
         });
         let merged = state.take_turn_pending_input();
         assert_eq!(merged.len(), 2);
-    }
-
-    #[test]
-    fn session_state_queue_and_take_for_next_turn() {
-        use chrono::Utc;
-        let mut state = SessionState::new(SessionConfig::default(), PathBuf::from("/tmp"));
-        assert!(!state.has_queued_for_next_turn());
-        state.queue_for_next_turn(vec![PendingInputItem {
-            kind: devo_protocol::PendingInputKind::UserText {
-                text: "queued".to_string(),
-            },
-            metadata: None,
-            created_at: Utc::now(),
-        }]);
-        assert!(state.has_queued_for_next_turn());
-        let taken = state.take_queued_for_next_turn();
-        assert_eq!(taken.len(), 1);
-        assert!(!state.has_queued_for_next_turn());
     }
 
     #[test]

--- a/crates/protocol/src/session.rs
+++ b/crates/protocol/src/session.rs
@@ -62,6 +62,8 @@ pub struct SessionResumeResult {
     pub latest_turn: Option<TurnMetadata>,
     pub loaded_item_count: u64,
     pub history_items: Vec<SessionHistoryItem>,
+    /// Pending turn input texts queued for the next turn.
+    pub pending_texts: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,6 +75,7 @@ pub enum SessionHistoryItemKind {
     ToolCall,
     ToolResult,
     Error,
+    TurnSummary,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -20,6 +20,7 @@ devo-safety = { workspace = true }
 devo-tools = { workspace = true }
 devo-utils = { workspace = true }
 futures = { workspace = true }
+rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 smol_str = { workspace = true }

--- a/crates/server/src/bootstrap.rs
+++ b/crates/server/src/bootstrap.rs
@@ -13,8 +13,8 @@ use devo_tools::handlers;
 use devo_utils::FileSystemConfigPathResolver;
 
 use crate::{
-    ListenTarget, ServerRuntime, execution::ServerRuntimeDependencies, load_server_provider,
-    resolve_listen_targets, run_listeners,
+    ListenTarget, ServerRuntime, db::Database, execution::ServerRuntimeDependencies,
+    load_server_provider, resolve_listen_targets, run_listeners,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -107,6 +107,12 @@ pub async fn run_server_process(args: ServerProcessArgs) -> Result<()> {
         workspace_roots: workspace_skill_roots,
         watch_for_changes: config.skills.watch_for_changes,
     }));
+
+    // Initialize SQLite database
+    let db_path = resolver.user_config_dir().join("devo.db");
+    tracing::info!(db_path = %db_path.display(), "opening database");
+    let db = Arc::new(Database::open(db_path)?);
+
     let runtime = ServerRuntime::new(
         resolver.user_config_dir(),
         ServerRuntimeDependencies::new(
@@ -117,6 +123,7 @@ pub async fn run_server_process(args: ServerProcessArgs) -> Result<()> {
             skill_workspace_root,
             skill_catalog,
             config.agents_md_config(),
+            db,
         ),
     );
     tracing::info!("starting persisted session restore");

--- a/crates/server/src/bootstrap.rs
+++ b/crates/server/src/bootstrap.rs
@@ -131,7 +131,7 @@ pub async fn run_server_process(args: ServerProcessArgs) -> Result<()> {
     tracing::info!("persisted session restore completed");
     tracing::info!("server bootstrap completed; starting listeners");
     tokio::select! {
-        result = run_listeners(runtime, &effective_listen) => {
+        result = run_listeners(runtime.clone(), &effective_listen) => {
             result?;
         }
         result = tokio::signal::ctrl_c() => {
@@ -139,6 +139,8 @@ pub async fn run_server_process(args: ServerProcessArgs) -> Result<()> {
             tracing::info!("server shutdown requested");
         }
     }
+    tracing::info!("completing deferred items for active turns");
+    runtime.shutdown().await;
     Ok(())
 }
 

--- a/crates/server/src/db.rs
+++ b/crates/server/src/db.rs
@@ -1,0 +1,676 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use std::str::FromStr;
+
+use anyhow::{Context, Result};
+use chrono::{TimeZone, Utc};
+use rusqlite::{Connection, params};
+use serde_json;
+
+use devo_protocol::{
+    PendingInputItem, PendingInputKind, SessionId, SessionMetadata, SessionRuntimeStatus,
+    SessionTitleState,
+};
+
+/// Queue type for pending messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueueType {
+    /// Pending turn inputs (from turn/start while a turn is active).
+    Turn,
+    /// /btw steer inputs (from turn/steer, scoped to current turn only).
+    Btw,
+}
+
+impl QueueType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            QueueType::Turn => "turn",
+            QueueType::Btw => "btw",
+        }
+    }
+}
+
+/// Session-level token statistics.
+#[derive(Debug, Clone)]
+pub struct SessionStats {
+    pub total_input_tokens: usize,
+    pub total_output_tokens: usize,
+    pub total_cache_creation_tokens: usize,
+    pub total_cache_read_tokens: usize,
+    pub last_input_tokens: usize,
+    pub turn_count: usize,
+    pub prompt_token_estimate: usize,
+}
+
+/// SQLite database for session metadata, token stats, and pending queues.
+pub struct Database {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl Database {
+    /// Opens or creates the SQLite database at the given path.
+    pub fn open(db_path: PathBuf) -> Result<Self> {
+        let conn = Connection::open(&db_path)
+            .with_context(|| format!("failed to open database at {}", db_path.display()))?;
+        let db = Self {
+            conn: Arc::new(Mutex::new(conn)),
+        };
+        db.migrate()?;
+        Ok(db)
+    }
+
+    /// Runs schema migrations.
+    fn migrate(&self) -> Result<()> {
+        let conn = self.conn.lock().expect("database mutex poisoned");
+        conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                title_state TEXT NOT NULL DEFAULT 'unset',
+                model TEXT,
+                thinking TEXT,
+                cwd TEXT NOT NULL,
+                ephemeral INTEGER NOT NULL DEFAULT 0,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                schema_version INTEGER NOT NULL DEFAULT 2
+            );
+
+            CREATE TABLE IF NOT EXISTS session_stats (
+                session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+                total_input_tokens INTEGER NOT NULL DEFAULT 0,
+                total_output_tokens INTEGER NOT NULL DEFAULT 0,
+                total_cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+                total_cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                last_input_tokens INTEGER NOT NULL DEFAULT 0,
+                turn_count INTEGER NOT NULL DEFAULT 0,
+                prompt_token_estimate INTEGER NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE IF NOT EXISTS pending_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                queue_type TEXT NOT NULL CHECK(queue_type IN ('turn', 'btw')),
+                kind TEXT NOT NULL,
+                content TEXT NOT NULL,
+                metadata TEXT,
+                created_at INTEGER NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_pending_session
+                ON pending_messages(session_id, queue_type);
+            ",
+        )
+        .context("failed to run database migrations")?;
+        Ok(())
+    }
+
+    // === Session CRUD ===
+
+    /// Inserts or updates a session's metadata.
+    pub fn upsert_session(&self, meta: &SessionMetadata) -> Result<()> {
+        let conn = self.conn.lock().expect("database mutex poisoned");
+        let title_state_str = match &meta.title_state {
+            SessionTitleState::Unset => "unset",
+            SessionTitleState::Provisional => "provisional",
+            SessionTitleState::Final(_) => "final",
+        };
+        conn.execute(
+            "INSERT INTO sessions (id, title, title_state, model, thinking, cwd, ephemeral, created_at, updated_at, schema_version)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 2)
+             ON CONFLICT(id) DO UPDATE SET
+                title = excluded.title,
+                title_state = excluded.title_state,
+                model = excluded.model,
+                thinking = excluded.thinking,
+                cwd = excluded.cwd,
+                updated_at = excluded.updated_at",
+            params![
+                meta.session_id.to_string(),
+                meta.title,
+                title_state_str,
+                meta.model,
+                meta.thinking,
+                meta.cwd.to_string_lossy().to_string(),
+                meta.ephemeral as i32,
+                meta.created_at.timestamp(),
+                meta.updated_at.timestamp(),
+            ],
+        )
+        .context("failed to upsert session")?;
+        Ok(())
+    }
+
+    /// Retrieves a session's metadata by ID.
+    pub fn get_session(&self, id: &SessionId) -> Result<Option<SessionMetadata>> {
+        let conn = self.conn.lock().expect("database mutex poisoned");
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, title, title_state, model, thinking, cwd, ephemeral, created_at, updated_at
+                 FROM sessions WHERE id = ?1",
+            )
+            .context("failed to prepare get_session statement")?;
+        let result = stmt.query_row(params![id.to_string()], |row| {
+            let id_str: String = row.get(0)?;
+            let title: Option<String> = row.get(1)?;
+            let title_state_str: String = row.get(2)?;
+            let model: Option<String> = row.get(3)?;
+            let thinking: Option<String> = row.get(4)?;
+            let cwd_str: String = row.get(5)?;
+            let ephemeral: i32 = row.get(6)?;
+            let created_at: i64 = row.get(7)?;
+            let updated_at: i64 = row.get(8)?;
+
+            let title_state = match title_state_str.as_str() {
+                "provisional" => SessionTitleState::Provisional,
+                "final" => {
+                    SessionTitleState::Final(devo_protocol::SessionTitleFinalSource::ModelGenerated)
+                }
+                _ => SessionTitleState::Unset,
+            };
+
+            Ok(SessionMetadata {
+                session_id: SessionId::from_str(&id_str).unwrap_or_default(),
+                cwd: PathBuf::from(&cwd_str),
+                created_at: Utc
+                    .timestamp_opt(created_at, 0)
+                    .single()
+                    .unwrap_or_else(Utc::now),
+                updated_at: Utc
+                    .timestamp_opt(updated_at, 0)
+                    .single()
+                    .unwrap_or_else(Utc::now),
+                title,
+                title_state,
+                ephemeral: ephemeral != 0,
+                model,
+                thinking,
+                reasoning_effort: None,
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                prompt_token_estimate: 0,
+                status: SessionRuntimeStatus::Idle,
+            })
+        });
+
+        match result {
+            Ok(meta) => Ok(Some(meta)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Lists all sessions ordered by most recently updated.
+    pub fn list_sessions(&self) -> Result<Vec<SessionMetadata>> {
+        let conn = self.conn.lock().expect("database mutex poisoned");
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, title, title_state, model, thinking, cwd, ephemeral, created_at, updated_at
+                 FROM sessions ORDER BY updated_at DESC",
+            )
+            .context("failed to prepare list_sessions statement")?;
+        let rows = stmt
+            .query_map([], |row| {
+                let id_str: String = row.get(0)?;
+                let title: Option<String> = row.get(1)?;
+                let title_state_str: String = row.get(2)?;
+                let model: Option<String> = row.get(3)?;
+                let thinking: Option<String> = row.get(4)?;
+                let cwd_str: String = row.get(5)?;
+                let ephemeral: i32 = row.get(6)?;
+                let created_at: i64 = row.get(7)?;
+                let updated_at: i64 = row.get(8)?;
+
+                let title_state = match title_state_str.as_str() {
+                    "provisional" => SessionTitleState::Provisional,
+                    "final" => SessionTitleState::Final(
+                        devo_protocol::SessionTitleFinalSource::ModelGenerated,
+                    ),
+                    _ => SessionTitleState::Unset,
+                };
+
+                Ok(SessionMetadata {
+                    session_id: SessionId::from_str(&id_str).unwrap_or_default(),
+                    cwd: PathBuf::from(&cwd_str),
+                    created_at: Utc
+                        .timestamp_opt(created_at, 0)
+                        .single()
+                        .unwrap_or_else(Utc::now),
+                    updated_at: Utc
+                        .timestamp_opt(updated_at, 0)
+                        .single()
+                        .unwrap_or_else(Utc::now),
+                    title,
+                    title_state,
+                    ephemeral: ephemeral != 0,
+                    model,
+                    thinking,
+                    reasoning_effort: None,
+                    total_input_tokens: 0,
+                    total_output_tokens: 0,
+                    prompt_token_estimate: 0,
+                    status: SessionRuntimeStatus::Idle,
+                })
+            })
+            .context("failed to query sessions")?;
+
+        let mut sessions = Vec::new();
+        for row in rows {
+            sessions.push(row?);
+        }
+        Ok(sessions)
+    }
+
+    /// Deletes a session and its related data.
+    pub fn delete_session(&self, id: &SessionId) -> Result<()> {
+        let conn = self.conn.lock().expect("database mutex poisoned");
+        conn.execute(
+            "DELETE FROM sessions WHERE id = ?1",
+            params![id.to_string()],
+        )
+        .context("failed to delete session")?;
+        Ok(())
+    }
+
+    // === Session Stats ===
+
+    /// Inserts or updates session token statistics.
+    pub fn update_stats(&self, id: &SessionId, stats: &SessionStats) -> Result<()> {
+        let conn = self.conn.lock().expect("database mutex poisoned");
+        conn.execute(
+            "INSERT INTO session_stats (session_id, total_input_tokens, total_output_tokens,
+                total_cache_creation_tokens, total_cache_read_tokens, last_input_tokens,
+                turn_count, prompt_token_estimate)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(session_id) DO UPDATE SET
+                total_input_tokens = excluded.total_input_tokens,
+                total_output_tokens = excluded.total_output_tokens,
+                total_cache_creation_tokens = excluded.total_cache_creation_tokens,
+                total_cache_read_tokens = excluded.total_cache_read_tokens,
+                last_input_tokens = excluded.last_input_tokens,
+                turn_count = excluded.turn_count,
+                prompt_token_estimate = excluded.prompt_token_estimate",
+            params![
+                id.to_string(),
+                stats.total_input_tokens as i64,
+                stats.total_output_tokens as i64,
+                stats.total_cache_creation_tokens as i64,
+                stats.total_cache_read_tokens as i64,
+                stats.last_input_tokens as i64,
+                stats.turn_count as i64,
+                stats.prompt_token_estimate as i64,
+            ],
+        )
+        .context("failed to update session stats")?;
+        Ok(())
+    }
+
+    /// Retrieves session token statistics.
+    pub fn get_stats(&self, id: &SessionId) -> Result<Option<SessionStats>> {
+        let conn = self.conn.lock().expect("database mutex poisoned");
+        let result = conn.query_row(
+            "SELECT total_input_tokens, total_output_tokens, total_cache_creation_tokens,
+                    total_cache_read_tokens, last_input_tokens, turn_count, prompt_token_estimate
+             FROM session_stats WHERE session_id = ?1",
+            params![id.to_string()],
+            |row| {
+                Ok(SessionStats {
+                    total_input_tokens: row.get::<_, i64>(0)? as usize,
+                    total_output_tokens: row.get::<_, i64>(1)? as usize,
+                    total_cache_creation_tokens: row.get::<_, i64>(2)? as usize,
+                    total_cache_read_tokens: row.get::<_, i64>(3)? as usize,
+                    last_input_tokens: row.get::<_, i64>(4)? as usize,
+                    turn_count: row.get::<_, i64>(5)? as usize,
+                    prompt_token_estimate: row.get::<_, i64>(6)? as usize,
+                })
+            },
+        );
+
+        match result {
+            Ok(stats) => Ok(Some(stats)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    // === Pending Messages ===
+
+    /// Pushes a pending message to the specified queue.
+    pub fn push_pending(
+        &self,
+        session_id: &SessionId,
+        queue: QueueType,
+        item: &PendingInputItem,
+    ) -> Result<()> {
+        let conn = self.conn.lock().expect("database mutex poisoned");
+        let (kind_str, content) = match &item.kind {
+            PendingInputKind::UserText { text } => ("user_text", text.clone()),
+            PendingInputKind::ToolCallBlockedByHook {
+                tool_use_id,
+                reason,
+            } => {
+                let content = serde_json::json!({
+                    "tool_use_id": tool_use_id,
+                    "reason": reason,
+                });
+                ("tool_call_blocked", content.to_string())
+            }
+            PendingInputKind::BudgetLimitSteering => ("budget_limit", String::new()),
+        };
+        let metadata_str = item.metadata.as_ref().map(|v| v.to_string());
+        conn.execute(
+            "INSERT INTO pending_messages (session_id, queue_type, kind, content, metadata, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                session_id.to_string(),
+                queue.as_str(),
+                kind_str,
+                content,
+                metadata_str,
+                item.created_at.timestamp(),
+            ],
+        )
+        .context("failed to push pending message")?;
+        Ok(())
+    }
+
+    /// Drains all pending messages from the specified queue, deleting them in the process.
+    pub fn drain_pending(
+        &self,
+        session_id: &SessionId,
+        queue: QueueType,
+    ) -> Result<Vec<PendingInputItem>> {
+        let mut conn = self.conn.lock().expect("database mutex poisoned");
+
+        let tx = conn
+            .transaction()
+            .context("failed to begin drain transaction")?;
+
+        let items = {
+            let mut stmt = tx
+                .prepare(
+                    "SELECT kind, content, metadata, created_at
+                     FROM pending_messages
+                     WHERE session_id = ?1 AND queue_type = ?2
+                     ORDER BY id ASC",
+                )
+                .context("failed to prepare drain_pending statement")?;
+            let rows = stmt
+                .query_map(params![session_id.to_string(), queue.as_str()], |row| {
+                    let kind_str: String = row.get(0)?;
+                    let content: String = row.get(1)?;
+                    let metadata_str: Option<String> = row.get(2)?;
+                    let created_at: i64 = row.get(3)?;
+
+                    let kind = match kind_str.as_str() {
+                        "user_text" => PendingInputKind::UserText { text: content },
+                        "tool_call_blocked" => {
+                            let parsed: serde_json::Value =
+                                serde_json::from_str(&content).unwrap_or_default();
+                            PendingInputKind::ToolCallBlockedByHook {
+                                tool_use_id: parsed["tool_use_id"]
+                                    .as_str()
+                                    .unwrap_or_default()
+                                    .to_string(),
+                                reason: parsed["reason"].as_str().unwrap_or_default().to_string(),
+                            }
+                        }
+                        "budget_limit" => PendingInputKind::BudgetLimitSteering,
+                        _ => PendingInputKind::UserText { text: content },
+                    };
+
+                    let metadata = metadata_str.and_then(|s| serde_json::from_str(&s).ok());
+
+                    Ok(PendingInputItem {
+                        kind,
+                        metadata,
+                        created_at: Utc
+                            .timestamp_opt(created_at, 0)
+                            .single()
+                            .unwrap_or_else(Utc::now),
+                    })
+                })
+                .context("failed to query pending messages")?;
+
+            let mut items = Vec::new();
+            for row in rows {
+                items.push(row?);
+            }
+            items
+        };
+
+        tx.execute(
+            "DELETE FROM pending_messages WHERE session_id = ?1 AND queue_type = ?2",
+            params![session_id.to_string(), queue.as_str()],
+        )
+        .context("failed to delete drained messages")?;
+
+        tx.commit().context("failed to commit drain transaction")?;
+
+        Ok(items)
+    }
+
+    /// Clears all pending messages from the specified queue.
+    pub fn clear_pending(&self, session_id: &SessionId, queue: QueueType) -> Result<()> {
+        let conn = self.conn.lock().expect("database mutex poisoned");
+        conn.execute(
+            "DELETE FROM pending_messages WHERE session_id = ?1 AND queue_type = ?2",
+            params![session_id.to_string(), queue.as_str()],
+        )
+        .context("failed to clear pending messages")?;
+        Ok(())
+    }
+
+    /// Counts pending messages in the specified queue.
+    #[allow(dead_code)]
+    pub fn count_pending(&self, session_id: &SessionId, queue: QueueType) -> Result<usize> {
+        let conn = self.conn.lock().expect("database mutex poisoned");
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pending_messages WHERE session_id = ?1 AND queue_type = ?2",
+            params![session_id.to_string(), queue.as_str()],
+            |row| row.get(0),
+        )?;
+        Ok(count as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_db() -> (Database, TempDir) {
+        let dir = TempDir::new().expect("create temp dir");
+        let db_path = dir.path().join("test.db");
+        let db = Database::open(db_path).expect("open database");
+        (db, dir)
+    }
+
+    fn sample_session(id: &str) -> SessionMetadata {
+        SessionMetadata {
+            session_id: SessionId::from_str(id).unwrap_or_default(),
+            cwd: PathBuf::from("/tmp"),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            title: Some("Test Session".into()),
+            title_state: SessionTitleState::Provisional,
+            ephemeral: false,
+            model: Some("claude-sonnet-4-20250514".into()),
+            thinking: None,
+            reasoning_effort: None,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            prompt_token_estimate: 0,
+            status: SessionRuntimeStatus::Idle,
+        }
+    }
+
+    #[test]
+    fn upsert_and_get_session() {
+        let (db, _dir) = test_db();
+        let meta = sample_session("session-1");
+        db.upsert_session(&meta).expect("upsert");
+
+        let retrieved = db.get_session(&meta.session_id).expect("get");
+        assert!(retrieved.is_some());
+        let retrieved = retrieved.unwrap();
+        assert_eq!(retrieved.session_id, meta.session_id);
+        assert_eq!(retrieved.title, Some("Test Session".into()));
+    }
+
+    #[test]
+    fn list_sessions_ordered() {
+        let (db, _dir) = test_db();
+        let meta1 = sample_session("session-1");
+        let mut meta2 = sample_session("session-2");
+        meta2.updated_at = Utc::now() + chrono::Duration::seconds(10);
+        db.upsert_session(&meta1).expect("upsert");
+        db.upsert_session(&meta2).expect("upsert");
+
+        let sessions = db.list_sessions().expect("list");
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].session_id, meta2.session_id);
+    }
+
+    #[test]
+    fn delete_session_cascades() {
+        let (db, _dir) = test_db();
+        let meta = sample_session("session-1");
+        db.upsert_session(&meta).expect("upsert");
+
+        db.delete_session(&meta.session_id).expect("delete");
+        let retrieved = db.get_session(&meta.session_id).expect("get");
+        assert!(retrieved.is_none());
+    }
+
+    #[test]
+    fn update_and_get_stats() {
+        let (db, _dir) = test_db();
+        let meta = sample_session("session-1");
+        db.upsert_session(&meta).expect("upsert");
+
+        let stats = SessionStats {
+            total_input_tokens: 1000,
+            total_output_tokens: 500,
+            total_cache_creation_tokens: 100,
+            total_cache_read_tokens: 50,
+            last_input_tokens: 200,
+            turn_count: 5,
+            prompt_token_estimate: 800,
+        };
+        db.update_stats(&meta.session_id, &stats).expect("update");
+
+        let retrieved = db.get_stats(&meta.session_id).expect("get");
+        assert!(retrieved.is_some());
+        let retrieved = retrieved.unwrap();
+        assert_eq!(retrieved.total_input_tokens, 1000);
+        assert_eq!(retrieved.total_output_tokens, 500);
+        assert_eq!(retrieved.turn_count, 5);
+    }
+
+    #[test]
+    fn push_and_drain_pending() {
+        let (db, _dir) = test_db();
+        let meta = sample_session("session-1");
+        db.upsert_session(&meta).expect("upsert");
+
+        let item1 = PendingInputItem {
+            kind: PendingInputKind::UserText {
+                text: "hello".into(),
+            },
+            metadata: None,
+            created_at: Utc::now(),
+        };
+        let item2 = PendingInputItem {
+            kind: PendingInputKind::UserText {
+                text: "world".into(),
+            },
+            metadata: None,
+            created_at: Utc::now(),
+        };
+
+        db.push_pending(&meta.session_id, QueueType::Turn, &item1)
+            .expect("push");
+        db.push_pending(&meta.session_id, QueueType::Turn, &item2)
+            .expect("push");
+
+        let count = db
+            .count_pending(&meta.session_id, QueueType::Turn)
+            .expect("count");
+        assert_eq!(count, 2);
+
+        let drained = db
+            .drain_pending(&meta.session_id, QueueType::Turn)
+            .expect("drain");
+        assert_eq!(drained.len(), 2);
+        assert!(matches!(&drained[0].kind, PendingInputKind::UserText { text } if text == "hello"));
+        assert!(matches!(&drained[1].kind, PendingInputKind::UserText { text } if text == "world"));
+
+        let count = db
+            .count_pending(&meta.session_id, QueueType::Turn)
+            .expect("count");
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn queue_types_are_isolated() {
+        let (db, _dir) = test_db();
+        let meta = sample_session("session-1");
+        db.upsert_session(&meta).expect("upsert");
+
+        let turn_item = PendingInputItem {
+            kind: PendingInputKind::UserText {
+                text: "turn msg".into(),
+            },
+            metadata: None,
+            created_at: Utc::now(),
+        };
+        let btw_item = PendingInputItem {
+            kind: PendingInputKind::UserText {
+                text: "btw msg".into(),
+            },
+            metadata: None,
+            created_at: Utc::now(),
+        };
+
+        db.push_pending(&meta.session_id, QueueType::Turn, &turn_item)
+            .expect("push");
+        db.push_pending(&meta.session_id, QueueType::Btw, &btw_item)
+            .expect("push");
+
+        let turn_count = db
+            .count_pending(&meta.session_id, QueueType::Turn)
+            .expect("count");
+        let btw_count = db
+            .count_pending(&meta.session_id, QueueType::Btw)
+            .expect("count");
+        assert_eq!(turn_count, 1);
+        assert_eq!(btw_count, 1);
+
+        db.clear_pending(&meta.session_id, QueueType::Btw)
+            .expect("clear");
+        let btw_count = db
+            .count_pending(&meta.session_id, QueueType::Btw)
+            .expect("count");
+        assert_eq!(btw_count, 0);
+
+        let turn_count = db
+            .count_pending(&meta.session_id, QueueType::Turn)
+            .expect("count");
+        assert_eq!(turn_count, 1);
+    }
+
+    #[test]
+    fn drain_pending_empty_returns_empty() {
+        let (db, _dir) = test_db();
+        let meta = sample_session("session-1");
+        db.upsert_session(&meta).expect("upsert");
+
+        let drained = db
+            .drain_pending(&meta.session_id, QueueType::Turn)
+            .expect("drain");
+        assert!(drained.is_empty());
+    }
+}

--- a/crates/server/src/execution.rs
+++ b/crates/server/src/execution.rs
@@ -27,6 +27,7 @@ use devo_tools::ToolRegistry;
 
 use crate::InputItem;
 use crate::SkillRecord;
+use crate::db::Database;
 use crate::session::SessionHistoryItem;
 use crate::session::SessionMetadata;
 use crate::turn::TurnMetadata;
@@ -53,10 +54,13 @@ pub struct ServerRuntimeDependencies {
     pub(crate) skill_catalog: StdMutex<Box<dyn SkillCatalog + Send>>,
     /// AGENTS.md discovery configuration applied to new sessions.
     pub(crate) agents_md: AgentsMdConfig,
+    /// SQLite database for session metadata, token stats, and pending queues.
+    pub(crate) db: Arc<Database>,
 }
 
 impl ServerRuntimeDependencies {
     /// Creates a new bundle of runtime dependencies for the transport server.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         provider: Arc<dyn ModelProviderSDK>,
         registry: Arc<ToolRegistry>,
@@ -65,6 +69,7 @@ impl ServerRuntimeDependencies {
         skill_workspace_root: Option<PathBuf>,
         skill_catalog: Box<dyn SkillCatalog + Send>,
         agents_md: AgentsMdConfig,
+        db: Arc<Database>,
     ) -> Self {
         Self {
             provider,
@@ -74,6 +79,7 @@ impl ServerRuntimeDependencies {
             skill_workspace_root,
             skill_catalog: StdMutex::new(skill_catalog),
             agents_md,
+            db,
         }
     }
 
@@ -226,11 +232,12 @@ pub(crate) struct RuntimeSession {
     pub(crate) persisted_turn_items: Vec<PersistedTurnItem>,
     /// Latest compaction snapshot used to rebuild the model-facing prompt view.
     pub(crate) latest_compaction_snapshot: Option<devo_core::CompactionSnapshotLine>,
-    /// Pending same-turn steering inputs (from busy turn/start).
-    pub(crate) steering_queue: Arc<StdMutex<VecDeque<PendingInputItem>>>,
-    /// /btw steer inputs scoped to the current turn. These are drained by the
-    /// query loop at each iteration and never carried to the next turn.
-    pub(crate) steer_input_queue: Arc<StdMutex<VecDeque<PendingInputItem>>>,
+    /// Pending turn inputs (from turn/start while a turn is active).
+    /// Preserved across turns; unconsumed items are pushed back when the turn ends.
+    pub(crate) pending_turn_queue: Arc<StdMutex<VecDeque<PendingInputItem>>>,
+    /// /btw steer inputs scoped to the current turn.
+    /// Drained by the query loop at each iteration and never carried to the next turn.
+    pub(crate) btw_input_queue: Arc<StdMutex<VecDeque<PendingInputItem>>>,
     /// Live query task for the active turn.
     pub(crate) active_task: Option<JoinHandle<()>>,
     /// Monotonic session-scoped item sequence counter.

--- a/crates/server/src/execution.rs
+++ b/crates/server/src/execution.rs
@@ -240,6 +240,11 @@ pub(crate) struct RuntimeSession {
     pub(crate) btw_input_queue: Arc<StdMutex<VecDeque<PendingInputItem>>>,
     /// Live query task for the active turn.
     pub(crate) active_task: Option<JoinHandle<()>>,
+    /// Deferred completion info for in-progress assistant text item.
+    /// Cleared when the item is completed; used for crash/interrupt recovery.
+    pub(crate) deferred_assistant: Option<(devo_core::ItemId, u64, String)>,
+    /// Deferred completion info for in-progress reasoning text item.
+    pub(crate) deferred_reasoning: Option<(devo_core::ItemId, u64, String)>,
     /// Monotonic session-scoped item sequence counter.
     pub(crate) next_item_seq: u64,
     /// First user input captured from the session's first turn, used for title generation.

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -2,6 +2,7 @@ mod approval;
 mod bootstrap;
 mod client;
 mod connection;
+pub mod db;
 mod event;
 mod execution;
 mod persistence;

--- a/crates/server/src/persistence.rs
+++ b/crates/server/src/persistence.rs
@@ -500,10 +500,10 @@ impl ReplayState {
             history_items: replayed_history_items,
             persisted_turn_items: replayed_persisted_turn_items,
             latest_compaction_snapshot: self.latest_compaction_snapshot,
-            steering_queue: std::sync::Arc::new(std::sync::Mutex::new(
+            pending_turn_queue: std::sync::Arc::new(std::sync::Mutex::new(
                 std::collections::VecDeque::new(),
             )),
-            steer_input_queue: std::sync::Arc::new(std::sync::Mutex::new(
+            btw_input_queue: std::sync::Arc::new(std::sync::Mutex::new(
                 std::collections::VecDeque::new(),
             )),
             active_task: None,

--- a/crates/server/src/persistence.rs
+++ b/crates/server/src/persistence.rs
@@ -343,6 +343,35 @@ impl ReplayState {
                 self.session = Some(line.session);
             }
             RolloutLine::Turn(line) => {
+                // Insert turn summary for the previous turn before processing the new turn
+                if let Some(ref prev_turn) = self.latest_turn_metadata
+                    && prev_turn.status == devo_core::TurnStatus::Completed
+                {
+                    let ts = prev_turn.completed_at.unwrap_or(prev_turn.started_at);
+                    let duration_secs = prev_turn.completed_at.and_then(|completed| {
+                        let dur = completed - prev_turn.started_at;
+                        let secs = dur.num_seconds();
+                        if secs > 0 { Some(secs as u64) } else { None }
+                    });
+                    let body = duration_secs.map(|s| s.to_string()).unwrap_or_default();
+                    self.pending_items.push(ReplayHistoryItem {
+                        item_id: devo_core::ItemId::new(),
+                        seq: self.loaded_item_count,
+                        timestamp: ts,
+                        record_timestamp: ts,
+                        line_timestamp: ts,
+                        bucket_priority: 0,
+                        intra_record_order: u32::MAX as usize,
+                        turn_item: devo_core::TurnItem::TurnSummary(devo_core::TextItem {
+                            text: if duration_secs.is_some() {
+                                format!("{}:{}", prev_turn.model, body)
+                            } else {
+                                prev_turn.model.clone()
+                            },
+                        }),
+                    });
+                }
+
                 self.turns_seen = self.turns_seen.max(line.turn.sequence);
                 if let Some(usage) = &line.turn.usage {
                     self.total_input_tokens += usage.input_tokens as usize;
@@ -407,7 +436,36 @@ impl ReplayState {
         Ok(())
     }
 
-    fn into_runtime_session(self, deps: &ServerRuntimeDependencies) -> Result<RuntimeSession> {
+    fn into_runtime_session(mut self, deps: &ServerRuntimeDependencies) -> Result<RuntimeSession> {
+        // Insert turn summary for the last turn before converting
+        if let Some(ref last_turn) = self.latest_turn_metadata
+            && last_turn.status == devo_core::TurnStatus::Completed
+        {
+            let ts = last_turn.completed_at.unwrap_or(last_turn.started_at);
+            let duration_secs = last_turn.completed_at.and_then(|completed| {
+                let dur = completed - last_turn.started_at;
+                let secs = dur.num_seconds();
+                if secs > 0 { Some(secs as u64) } else { None }
+            });
+            let body = duration_secs.map(|s| s.to_string()).unwrap_or_default();
+            self.pending_items.push(ReplayHistoryItem {
+                item_id: devo_core::ItemId::new(),
+                seq: self.loaded_item_count,
+                timestamp: ts,
+                record_timestamp: ts,
+                line_timestamp: ts,
+                bucket_priority: 0,
+                intra_record_order: u32::MAX as usize,
+                turn_item: devo_core::TurnItem::TurnSummary(devo_core::TextItem {
+                    text: if duration_secs.is_some() {
+                        format!("{}:{}", last_turn.model, body)
+                    } else {
+                        last_turn.model.clone()
+                    },
+                }),
+            });
+        }
+
         let record = self.session.context("missing SessionMetaLine in rollout")?;
         let mut core_session = deps.new_session_state(record.id, record.cwd.clone());
         let mut ordered_items = self.pending_items;
@@ -507,6 +565,8 @@ impl ReplayState {
                 std::collections::VecDeque::new(),
             )),
             active_task: None,
+            deferred_assistant: None,
+            deferred_reasoning: None,
             next_item_seq: self.next_item_seq.max(1),
             first_user_input: None,
         })
@@ -751,7 +811,8 @@ fn apply_turn_item(
         },
         TurnItem::ToolProgress(_)
         | TurnItem::ApprovalRequest(_)
-        | TurnItem::ApprovalDecision(_) => {}
+        | TurnItem::ApprovalDecision(_)
+        | TurnItem::TurnSummary(_) => {}
     }
 }
 
@@ -871,7 +932,8 @@ fn apply_prompt_turn_item(
         },
         TurnItem::ToolProgress(_)
         | TurnItem::ApprovalRequest(_)
-        | TurnItem::ApprovalDecision(_) => {}
+        | TurnItem::ApprovalDecision(_)
+        | TurnItem::TurnSummary(_) => {}
     }
 }
 

--- a/crates/server/src/projection.rs
+++ b/crates/server/src/projection.rs
@@ -155,6 +155,20 @@ pub(crate) fn history_item_from_turn_item(item: &TurnItem) -> Option<SessionHist
         TurnItem::ToolProgress(_)
         | TurnItem::ApprovalRequest(_)
         | TurnItem::ApprovalDecision(_) => None,
+        TurnItem::TurnSummary(TextItem { text }) => {
+            // Format: "model_name:duration_secs" or just "model_name"
+            let (model_name, duration_secs) = match text.split_once(':') {
+                Some((model, dur)) => (model.to_string(), dur.parse::<u64>().ok()),
+                None => (text.clone(), None),
+            };
+            Some(SessionHistoryItem {
+                tool_call_id: None,
+                kind: SessionHistoryItemKind::TurnSummary,
+                title: model_name,
+                body: String::new(),
+                duration_ms: duration_secs,
+            })
+        }
     }
 }
 

--- a/crates/server/src/runtime.rs
+++ b/crates/server/src/runtime.rs
@@ -295,9 +295,7 @@ impl ServerRuntime {
                     item_id,
                     item_seq,
                     ItemKind::AgentMessage,
-                    TurnItem::AgentMessage(TextItem {
-                        text: text.clone(),
-                    }),
+                    TurnItem::AgentMessage(TextItem { text: text.clone() }),
                     serde_json::json!({ "title": "Assistant", "text": text }),
                 )
                 .await;
@@ -309,9 +307,7 @@ impl ServerRuntime {
                     item_id,
                     item_seq,
                     ItemKind::Reasoning,
-                    TurnItem::Reasoning(TextItem {
-                        text: text.clone(),
-                    }),
+                    TurnItem::Reasoning(TextItem { text: text.clone() }),
                     serde_json::json!({ "title": "Reasoning", "text": text }),
                 )
                 .await;
@@ -332,9 +328,11 @@ impl ServerRuntime {
                 session.latest_turn = Some(turn.clone());
                 session.summary.status = SessionRuntimeStatus::Idle;
                 session.summary.updated_at = Utc::now();
-                let token_totals = session.core_session.try_lock().ok().map(
-                    |core| (core.total_input_tokens, core.total_output_tokens),
-                );
+                let token_totals = session
+                    .core_session
+                    .try_lock()
+                    .ok()
+                    .map(|core| (core.total_input_tokens, core.total_output_tokens));
                 if let Some((input, output)) = token_totals {
                     session.summary.total_input_tokens = input;
                     session.summary.total_output_tokens = output;
@@ -347,7 +345,10 @@ impl ServerRuntime {
                 let (session_context, turn_context) = {
                     let session = session_arc.lock().await;
                     let core = session.core_session.lock().await;
-                    (core.session_context.clone(), core.latest_turn_context.clone())
+                    (
+                        core.session_context.clone(),
+                        core.latest_turn_context.clone(),
+                    )
                 };
                 if let Err(error) = self.rollout_store.append_turn(
                     &record,
@@ -1732,9 +1733,7 @@ impl ServerRuntime {
                 item_id,
                 item_seq,
                 ItemKind::AgentMessage,
-                TurnItem::AgentMessage(TextItem {
-                    text: text.clone(),
-                }),
+                TurnItem::AgentMessage(TextItem { text: text.clone() }),
                 serde_json::json!({ "title": "Assistant", "text": text }),
             )
             .await;
@@ -1746,9 +1745,7 @@ impl ServerRuntime {
                 item_id,
                 item_seq,
                 ItemKind::Reasoning,
-                TurnItem::Reasoning(TextItem {
-                    text: text.clone(),
-                }),
+                TurnItem::Reasoning(TextItem { text: text.clone() }),
                 serde_json::json!({ "title": "Reasoning", "text": text }),
             )
             .await;

--- a/crates/server/src/runtime.rs
+++ b/crates/server/src/runtime.rs
@@ -1713,37 +1713,45 @@ impl ServerRuntime {
             );
         };
 
-        // Complete any deferred (in-progress) items before aborting the turn task
-        {
+        // Complete any deferred (in-progress) items before aborting the turn task.
+        // Take the items out while holding the session lock, then drop the lock
+        // before calling complete_item to avoid re-locking session_arc inside
+        // persist_item, which would deadlock on the non-reentrant tokio Mutex.
+        let deferred_assistant = {
             let mut session = session_arc.lock().await;
-            if let Some((item_id, item_seq, text)) = session.deferred_assistant.take() {
-                self.complete_item(
-                    params.session_id,
-                    params.turn_id,
-                    item_id,
-                    item_seq,
-                    ItemKind::AgentMessage,
-                    TurnItem::AgentMessage(TextItem {
-                        text: text.clone(),
-                    }),
-                    serde_json::json!({ "title": "Assistant", "text": text }),
-                )
-                .await;
-            }
-            if let Some((item_id, item_seq, text)) = session.deferred_reasoning.take() {
-                self.complete_item(
-                    params.session_id,
-                    params.turn_id,
-                    item_id,
-                    item_seq,
-                    ItemKind::Reasoning,
-                    TurnItem::Reasoning(TextItem {
-                        text: text.clone(),
-                    }),
-                    serde_json::json!({ "title": "Reasoning", "text": text }),
-                )
-                .await;
-            }
+            session.deferred_assistant.take()
+        };
+        let deferred_reasoning = {
+            let mut session = session_arc.lock().await;
+            session.deferred_reasoning.take()
+        };
+        if let Some((item_id, item_seq, text)) = deferred_assistant {
+            self.complete_item(
+                params.session_id,
+                params.turn_id,
+                item_id,
+                item_seq,
+                ItemKind::AgentMessage,
+                TurnItem::AgentMessage(TextItem {
+                    text: text.clone(),
+                }),
+                serde_json::json!({ "title": "Assistant", "text": text }),
+            )
+            .await;
+        }
+        if let Some((item_id, item_seq, text)) = deferred_reasoning {
+            self.complete_item(
+                params.session_id,
+                params.turn_id,
+                item_id,
+                item_seq,
+                ItemKind::Reasoning,
+                TurnItem::Reasoning(TextItem {
+                    text: text.clone(),
+                }),
+                serde_json::json!({ "title": "Reasoning", "text": text }),
+            )
+            .await;
         }
 
         if let Some(task) = self.active_tasks.lock().await.remove(&params.session_id) {

--- a/crates/server/src/runtime.rs
+++ b/crates/server/src/runtime.rs
@@ -85,6 +85,8 @@ use crate::TurnStartResult;
 use crate::TurnSteerParams;
 use crate::TurnSteerResult;
 use crate::TurnUsageUpdatedPayload;
+use crate::db::QueueType;
+use crate::db::SessionStats;
 use crate::execution::RuntimeSession;
 use crate::execution::ServerRuntimeDependencies;
 use crate::persistence::RolloutStore;
@@ -148,9 +150,110 @@ impl ServerRuntime {
     }
 
     /// Loads durable sessions from rollout files and installs them into the runtime map.
+    /// Also restores token stats and pending queues from SQLite.
     pub async fn load_persisted_sessions(self: &Arc<Self>) -> anyhow::Result<()> {
         let sessions = self.rollout_store.load_sessions(&self.deps)?;
         tracing::info!(session_count = sessions.len(), "loaded persisted sessions");
+
+        // Restore token stats and pending queues from SQLite
+        for (session_id, session_arc) in &sessions {
+            let mut session = session_arc.lock().await;
+
+            // Skip ephemeral sessions
+            if session.summary.ephemeral {
+                continue;
+            }
+
+            // Restore token stats from SQLite
+            match self.deps.db.get_stats(session_id) {
+                Ok(Some(stats)) => {
+                    session.summary.total_input_tokens = stats.total_input_tokens;
+                    session.summary.total_output_tokens = stats.total_output_tokens;
+                    session.summary.prompt_token_estimate = stats.prompt_token_estimate;
+                    if let Ok(mut core) = session.core_session.try_lock() {
+                        core.total_input_tokens = stats.total_input_tokens;
+                        core.total_output_tokens = stats.total_output_tokens;
+                        core.total_cache_creation_tokens = stats.total_cache_creation_tokens;
+                        core.total_cache_read_tokens = stats.total_cache_read_tokens;
+                        core.last_input_tokens = stats.last_input_tokens;
+                        core.prompt_token_estimate = stats.prompt_token_estimate;
+                    }
+                    tracing::debug!(
+                        session_id = %session_id,
+                        "restored token stats from database"
+                    );
+                }
+                Ok(None) => {
+                    // No stats in database, persist current stats
+                    let stats = crate::db::SessionStats {
+                        total_input_tokens: session.summary.total_input_tokens,
+                        total_output_tokens: session.summary.total_output_tokens,
+                        total_cache_creation_tokens: 0,
+                        total_cache_read_tokens: 0,
+                        last_input_tokens: 0,
+                        turn_count: 0,
+                        prompt_token_estimate: session.summary.prompt_token_estimate,
+                    };
+                    if let Err(err) = self.deps.db.update_stats(session_id, &stats) {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            error = %err,
+                            "failed to persist initial token stats to database"
+                        );
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        error = %err,
+                        "failed to load token stats from database"
+                    );
+                }
+            }
+
+            // Restore pending turn queue from SQLite
+            match self
+                .deps
+                .db
+                .drain_pending(session_id, crate::db::QueueType::Turn)
+            {
+                Ok(items) => {
+                    if !items.is_empty() {
+                        let mut queue = session
+                            .pending_turn_queue
+                            .lock()
+                            .expect("pending turn queue mutex should not be poisoned");
+                        queue.extend(items);
+                        tracing::debug!(
+                            session_id = %session_id,
+                            pending_count = queue.len(),
+                            "restored pending turn queue from database"
+                        );
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        error = %err,
+                        "failed to load pending turn queue from database"
+                    );
+                }
+            }
+
+            // Clear any stale btw inputs from previous session
+            if let Err(err) = self
+                .deps
+                .db
+                .clear_pending(session_id, crate::db::QueueType::Btw)
+            {
+                tracing::warn!(
+                    session_id = %session_id,
+                    error = %err,
+                    "failed to clear stale btw inputs from database"
+                );
+            }
+        }
+
         let mut runtime_sessions = self.sessions.lock().await;
         runtime_sessions.extend(sessions);
         Ok(())
@@ -379,8 +482,8 @@ impl ServerRuntime {
             );
         }
         let core_session = self.deps.new_session_state(session_id, params.cwd.clone());
-        let steering_queue = Arc::clone(&core_session.pending_user_prompts);
-        let steer_input_queue = Arc::clone(&core_session.steer_input_queue);
+        let pending_turn_queue = Arc::clone(&core_session.pending_turn_queue);
+        let btw_input_queue = Arc::clone(&core_session.btw_input_queue);
         self.sessions.lock().await.insert(
             session_id,
             RuntimeSession {
@@ -393,8 +496,8 @@ impl ServerRuntime {
                 history_items: Vec::new(),
                 persisted_turn_items: Vec::new(),
                 latest_compaction_snapshot: None,
-                steering_queue,
-                steer_input_queue,
+                pending_turn_queue,
+                btw_input_queue,
                 active_task: None,
                 next_item_seq: 1,
                 first_user_input: None,
@@ -403,6 +506,18 @@ impl ServerRuntime {
         );
         self.subscribe_connection_to_session(connection_id, session_id, None)
             .await;
+
+        // Persist session metadata to SQLite (skip for ephemeral sessions)
+        if !summary.ephemeral
+            && let Err(err) = self.deps.db.upsert_session(&summary)
+        {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %err,
+                "failed to persist session metadata to database"
+            );
+        }
+
         tracing::info!(
             connection_id,
             session_id = %session_id,
@@ -499,6 +614,18 @@ impl ServerRuntime {
             }
             session.summary.clone()
         };
+
+        // Persist updated session metadata to SQLite
+        if !updated_session.ephemeral
+            && let Err(err) = self.deps.db.upsert_session(&updated_session)
+        {
+            tracing::warn!(
+                session_id = %params.session_id,
+                error = %err,
+                "failed to update session metadata in database"
+            );
+        }
+
         serde_json::to_value(SuccessResponse {
             id: request_id,
             result: SessionMetadataUpdateResult {
@@ -566,6 +693,18 @@ impl ServerRuntime {
             }
             session.summary.clone()
         };
+
+        // Persist updated session metadata to SQLite
+        if !summary.ephemeral
+            && let Err(err) = self.deps.db.upsert_session(&summary)
+        {
+            tracing::warn!(
+                session_id = %params.session_id,
+                error = %err,
+                "failed to update session title in database"
+            );
+        }
+
         self.broadcast_event(ServerEvent::SessionTitleUpdated(SessionEventPayload {
             session: summary.clone(),
         }))
@@ -695,8 +834,8 @@ impl ServerRuntime {
         let persisted_turn_items = source.persisted_turn_items.clone();
         drop(source_core_session);
         drop(source);
-        let steering_queue = Arc::clone(&core_session.pending_user_prompts);
-        let steer_input_queue = Arc::clone(&core_session.steer_input_queue);
+        let pending_turn_queue = Arc::clone(&core_session.pending_turn_queue);
+        let btw_input_queue = Arc::clone(&core_session.btw_input_queue);
         self.sessions.lock().await.insert(
             forked_id,
             RuntimeSession {
@@ -709,8 +848,8 @@ impl ServerRuntime {
                 history_items,
                 persisted_turn_items,
                 latest_compaction_snapshot,
-                steering_queue,
-                steer_input_queue,
+                pending_turn_queue,
+                btw_input_queue,
                 active_task: None,
                 next_item_seq: loaded_item_count + 1,
                 first_user_input: None,
@@ -1210,24 +1349,40 @@ impl ServerRuntime {
         let turn = {
             let mut session = session_arc.lock().await;
             if let Some(active_turn) = session.active_turn.as_ref() {
-                // Queue instead of rejecting — push directly to the steering_queue
+                // Queue instead of rejecting — push directly to the pending_turn_queue
                 // (independent lock) so we don't block on core_session which is
                 // held by the running query() loop.
-                let steering_queue = Arc::clone(&session.steering_queue);
+                let pending_turn_queue = Arc::clone(&session.pending_turn_queue);
                 let active_turn_id = active_turn.turn_id;
+                let is_ephemeral = session.summary.ephemeral;
                 drop(session);
 
                 {
-                    let mut guard = steering_queue
+                    let mut guard = pending_turn_queue
                         .lock()
-                        .expect("steering queue mutex should not be poisoned");
-                    guard.push_back(devo_core::PendingInputItem {
+                        .expect("pending turn queue mutex should not be poisoned");
+                    let item = devo_core::PendingInputItem {
                         kind: devo_core::PendingInputKind::UserText {
                             text: input_text.clone(),
                         },
                         metadata: None,
                         created_at: chrono::Utc::now(),
-                    });
+                    };
+                    guard.push_back(item.clone());
+
+                    // Persist to SQLite (skip for ephemeral sessions)
+                    if !is_ephemeral
+                        && let Err(err) =
+                            self.deps
+                                .db
+                                .push_pending(&params.session_id, QueueType::Turn, &item)
+                    {
+                        tracing::warn!(
+                            session_id = %params.session_id,
+                            error = %err,
+                            "failed to persist pending turn message to database"
+                        );
+                    }
                 }
                 // Send response via the high-priority channel so it bypasses
                 // any backlog of event notifications on the shared channel.
@@ -1291,11 +1446,25 @@ impl ServerRuntime {
             session.summary.status = SessionRuntimeStatus::ActiveTurn;
             session.summary.updated_at = now;
             session.active_turn = Some(turn.clone());
+
+            // Clear pending queue (both in-memory and SQLite)
             session
-                .steering_queue
+                .pending_turn_queue
                 .lock()
-                .expect("steering queue mutex should not be poisoned")
+                .expect("pending turn queue mutex should not be poisoned")
                 .clear();
+            if !session.summary.ephemeral
+                && let Err(err) = self
+                    .deps
+                    .db
+                    .clear_pending(&params.session_id, QueueType::Turn)
+            {
+                tracing::warn!(
+                    session_id = %params.session_id,
+                    error = %err,
+                    "failed to clear pending turn messages from database"
+                );
+            }
             let clear_session_id = params.session_id;
             let runtime_for_broadcast = Arc::clone(self);
             tokio::spawn(async move {
@@ -1575,7 +1744,7 @@ impl ServerRuntime {
                 "session does not exist",
             );
         };
-        let (turn_id, workspace_root, steering_queue) = {
+        let (turn_id, workspace_root, btw_input_queue) = {
             let session = session_arc.lock().await;
             let Some(turn_id) = session.active_turn.as_ref().map(|turn| turn.turn_id) else {
                 return self.error_response(
@@ -1602,7 +1771,7 @@ impl ServerRuntime {
             (
                 turn_id,
                 session.summary.cwd.clone(),
-                Arc::clone(&session.steer_input_queue),
+                Arc::clone(&session.btw_input_queue),
             )
         };
         let prompt_text = match self
@@ -1647,14 +1816,32 @@ impl ServerRuntime {
             serde_json::json!({ "title": "You", "text": display_input }),
         )
         .await;
-        steering_queue
+        let item = devo_core::PendingInputItem {
+            kind: devo_core::PendingInputKind::UserText { text: prompt_text },
+            metadata: None,
+            created_at: chrono::Utc::now(),
+        };
+        btw_input_queue
             .lock()
-            .expect("steering queue mutex should not be poisoned")
-            .push_back(devo_core::PendingInputItem {
-                kind: devo_core::PendingInputKind::UserText { text: prompt_text },
-                metadata: None,
-                created_at: chrono::Utc::now(),
-            });
+            .expect("btw input queue mutex should not be poisoned")
+            .push_back(item.clone());
+
+        // Persist to SQLite (skip for ephemeral sessions)
+        {
+            let session = session_arc.lock().await;
+            if !session.summary.ephemeral
+                && let Err(err) =
+                    self.deps
+                        .db
+                        .push_pending(&params.session_id, QueueType::Btw, &item)
+            {
+                tracing::warn!(
+                    session_id = %params.session_id,
+                    error = %err,
+                    "failed to persist btw input to database"
+                );
+            }
+        }
 
         self.emit_to_connection(
             connection_id,
@@ -2112,8 +2299,53 @@ impl ServerRuntime {
             session.summary.total_input_tokens = session_total_input_tokens;
             session.summary.total_output_tokens = session_total_output_tokens;
             session.summary.prompt_token_estimate = session_prompt_token_estimate;
+
+            // Persist token stats to SQLite (skip for ephemeral sessions)
+            if !session.summary.ephemeral {
+                let stats = SessionStats {
+                    total_input_tokens: session_total_input_tokens,
+                    total_output_tokens: session_total_output_tokens,
+                    total_cache_creation_tokens: 0,
+                    total_cache_read_tokens: 0,
+                    last_input_tokens: final_turn
+                        .usage
+                        .as_ref()
+                        .map(|u| u.input_tokens as usize)
+                        .unwrap_or(0),
+                    turn_count: session.summary.updated_at.timestamp() as usize,
+                    prompt_token_estimate: session_prompt_token_estimate,
+                };
+                if let Err(err) = self.deps.db.update_stats(&session_id, &stats) {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        error = %err,
+                        "failed to persist token stats to database"
+                    );
+                }
+            }
+
             final_turn
         };
+
+        // Clear btw input queue (both in-memory and SQLite)
+        {
+            let session = session_arc.lock().await;
+            session
+                .btw_input_queue
+                .lock()
+                .expect("btw input queue mutex should not be poisoned")
+                .clear();
+            if !session.summary.ephemeral
+                && let Err(err) = self.deps.db.clear_pending(&session_id, QueueType::Btw)
+            {
+                tracing::warn!(
+                    session_id = %session_id,
+                    error = %err,
+                    "failed to clear btw input messages from database"
+                );
+            }
+        }
+
         let (record, session_context, turn_context) = {
             let session = session_arc.lock().await;
             let core_session = session.core_session.lock().await;
@@ -2184,16 +2416,16 @@ impl ServerRuntime {
                 Some(s) => s,
                 None => return,
             };
-            let steering_queue = {
+            let pending_turn_queue = {
                 let session = session_arc.lock().await;
                 if session.active_turn.is_some() {
                     return;
                 }
-                Arc::clone(&session.steering_queue)
+                Arc::clone(&session.pending_turn_queue)
             };
-            let mut queue = steering_queue
+            let mut queue = pending_turn_queue
                 .lock()
-                .expect("steering queue mutex should not be poisoned");
+                .expect("pending turn queue mutex should not be poisoned");
             match queue.pop_front() {
                 Some(devo_core::PendingInputItem {
                     kind: devo_core::PendingInputKind::UserText { text },
@@ -2285,13 +2517,13 @@ impl ServerRuntime {
                 Some(s) => s,
                 None => return,
             };
-            let steering_queue = {
+            let pending_turn_queue = {
                 let session = session_arc.lock().await;
-                Arc::clone(&session.steering_queue)
+                Arc::clone(&session.pending_turn_queue)
             };
-            let mut guard = steering_queue
+            let mut guard = pending_turn_queue
                 .lock()
-                .expect("steering queue mutex should not be poisoned");
+                .expect("pending turn queue mutex should not be poisoned");
             match guard.pop_front() {
                 Some(devo_core::PendingInputItem {
                     kind: devo_core::PendingInputKind::UserText { text },
@@ -2381,9 +2613,9 @@ impl ServerRuntime {
         let (pending_count, pending_texts) = {
             let session = session_arc.lock().await;
             let queue = session
-                .steering_queue
+                .pending_turn_queue
                 .lock()
-                .expect("steering queue mutex should not be poisoned");
+                .expect("pending turn queue mutex should not be poisoned");
             let texts: Vec<String> = queue
                 .iter()
                 .filter_map(|item| match &item.kind {

--- a/crates/server/src/runtime.rs
+++ b/crates/server/src/runtime.rs
@@ -1785,12 +1785,18 @@ impl ServerRuntime {
         };
         let (record, session_context, turn_context) = {
             let session = session_arc.lock().await;
-            let core_session = session.core_session.lock().await;
-            (
-                session.record.clone(),
-                core_session.session_context.clone(),
-                core_session.latest_turn_context.clone(),
-            )
+            let core_session_lock = session.core_session.try_lock();
+            if let Ok(core_session) = core_session_lock {
+                (
+                    session.record.clone(),
+                    core_session.session_context.clone(),
+                    core_session.latest_turn_context.clone(),
+                )
+            } else {
+                // core_session is held by the running turn task — skip
+                // session context in the rollout record for this interrupt.
+                (session.record.clone(), None, None)
+            }
         };
         if let Some(record) = record
             && let Err(error) = self.rollout_store.append_turn(

--- a/crates/server/src/runtime.rs
+++ b/crates/server/src/runtime.rs
@@ -259,6 +259,116 @@ impl ServerRuntime {
         Ok(())
     }
 
+    /// Completes deferred (in-progress) items for all active turns and
+    /// persists interrupted turn records. Called on graceful shutdown.
+    pub async fn shutdown(self: &Arc<Self>) {
+        let session_ids: Vec<SessionId> = {
+            let sessions = self.sessions.lock().await;
+            sessions.keys().cloned().collect()
+        };
+
+        for session_id in session_ids {
+            let Some(session_arc) = self.sessions.lock().await.get(&session_id).cloned() else {
+                continue;
+            };
+
+            let (deferred_assistant, deferred_reasoning, turn_id, record) = {
+                let mut session = session_arc.lock().await;
+                let turn_id = session.active_turn.as_ref().map(|t| t.turn_id);
+                (
+                    session.deferred_assistant.take(),
+                    session.deferred_reasoning.take(),
+                    turn_id,
+                    session.record.clone(),
+                )
+            };
+
+            let Some(turn_id) = turn_id else {
+                continue;
+            };
+
+            // Complete deferred items before shutting down
+            if let Some((item_id, item_seq, text)) = deferred_assistant {
+                self.complete_item(
+                    session_id,
+                    turn_id,
+                    item_id,
+                    item_seq,
+                    ItemKind::AgentMessage,
+                    TurnItem::AgentMessage(TextItem {
+                        text: text.clone(),
+                    }),
+                    serde_json::json!({ "title": "Assistant", "text": text }),
+                )
+                .await;
+            }
+            if let Some((item_id, item_seq, text)) = deferred_reasoning {
+                self.complete_item(
+                    session_id,
+                    turn_id,
+                    item_id,
+                    item_seq,
+                    ItemKind::Reasoning,
+                    TurnItem::Reasoning(TextItem {
+                        text: text.clone(),
+                    }),
+                    serde_json::json!({ "title": "Reasoning", "text": text }),
+                )
+                .await;
+            }
+
+            // Mark turn as interrupted
+            let interrupted_turn = {
+                let mut session = session_arc.lock().await;
+                let Some(mut turn) = session.active_turn.take() else {
+                    continue;
+                };
+                if turn.turn_id != turn_id {
+                    session.active_turn = Some(turn);
+                    continue;
+                }
+                turn.status = TurnStatus::Interrupted;
+                turn.completed_at = Some(Utc::now());
+                session.latest_turn = Some(turn.clone());
+                session.summary.status = SessionRuntimeStatus::Idle;
+                session.summary.updated_at = Utc::now();
+                let token_totals = session.core_session.try_lock().ok().map(
+                    |core| (core.total_input_tokens, core.total_output_tokens),
+                );
+                if let Some((input, output)) = token_totals {
+                    session.summary.total_input_tokens = input;
+                    session.summary.total_output_tokens = output;
+                }
+                turn
+            };
+
+            // Persist interrupted turn record
+            if let Some(record) = record {
+                let (session_context, turn_context) = {
+                    let session = session_arc.lock().await;
+                    let core = session.core_session.lock().await;
+                    (core.session_context.clone(), core.latest_turn_context.clone())
+                };
+                if let Err(error) = self.rollout_store.append_turn(
+                    &record,
+                    build_turn_record(&interrupted_turn, session_context, turn_context),
+                ) {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        error = %error,
+                        "failed to persist interrupted turn on shutdown"
+                    );
+                }
+            }
+
+            tracing::info!(
+                session_id = %session_id,
+                turn_id = %interrupted_turn.turn_id,
+                "completed deferred items and interrupted turn on shutdown"
+            );
+        }
+    }
+
     pub async fn register_connection(
         self: &Arc<Self>,
         transport: ClientTransportKind,
@@ -499,6 +609,8 @@ impl ServerRuntime {
                 pending_turn_queue,
                 btw_input_queue,
                 active_task: None,
+                deferred_assistant: None,
+                deferred_reasoning: None,
                 next_item_seq: 1,
                 first_user_input: None,
             }
@@ -745,6 +857,16 @@ impl ServerRuntime {
         let latest_turn = session.latest_turn.clone();
         let loaded_item_count = session.loaded_item_count;
         let history_items = session.history_items.clone();
+        let pending_texts: Vec<String> = session
+            .pending_turn_queue
+            .lock()
+            .expect("pending turn queue mutex poisoned")
+            .iter()
+            .filter_map(|item| match &item.kind {
+                devo_core::PendingInputKind::UserText { text } => Some(text.clone()),
+                _ => None,
+            })
+            .collect();
         drop(session);
         self.subscribe_connection_to_session(connection_id, params.session_id, None)
             .await;
@@ -753,6 +875,7 @@ impl ServerRuntime {
             session_id = %params.session_id,
             loaded_item_count,
             has_latest_turn = latest_turn.is_some(),
+            pending_count = pending_texts.len(),
             "resumed session"
         );
         serde_json::to_value(SuccessResponse {
@@ -762,6 +885,7 @@ impl ServerRuntime {
                 latest_turn,
                 loaded_item_count,
                 history_items,
+                pending_texts,
             },
         })
         .expect("serialize session/resume response")
@@ -851,6 +975,8 @@ impl ServerRuntime {
                 pending_turn_queue,
                 btw_input_queue,
                 active_task: None,
+                deferred_assistant: None,
+                deferred_reasoning: None,
                 next_item_seq: loaded_item_count + 1,
                 first_user_input: None,
             }
@@ -1230,7 +1356,8 @@ impl ServerRuntime {
                     },
                     TurnItem::ToolProgress(_)
                     | TurnItem::ApprovalRequest(_)
-                    | TurnItem::ApprovalDecision(_) => return None,
+                    | TurnItem::ApprovalDecision(_)
+                    | TurnItem::TurnSummary(_) => return None,
                 };
                 (!response_item.is_reason()).then_some((item.item_id, response_item))
             })
@@ -1604,6 +1731,40 @@ impl ServerRuntime {
                 "session does not exist",
             );
         };
+
+        // Complete any deferred (in-progress) items before aborting the turn task
+        {
+            let mut session = session_arc.lock().await;
+            if let Some((item_id, item_seq, text)) = session.deferred_assistant.take() {
+                self.complete_item(
+                    params.session_id,
+                    params.turn_id,
+                    item_id,
+                    item_seq,
+                    ItemKind::AgentMessage,
+                    TurnItem::AgentMessage(TextItem {
+                        text: text.clone(),
+                    }),
+                    serde_json::json!({ "title": "Assistant", "text": text }),
+                )
+                .await;
+            }
+            if let Some((item_id, item_seq, text)) = session.deferred_reasoning.take() {
+                self.complete_item(
+                    params.session_id,
+                    params.turn_id,
+                    item_id,
+                    item_seq,
+                    ItemKind::Reasoning,
+                    TurnItem::Reasoning(TextItem {
+                        text: text.clone(),
+                    }),
+                    serde_json::json!({ "title": "Reasoning", "text": text }),
+                )
+                .await;
+            }
+        }
+
         if let Some(task) = self.active_tasks.lock().await.remove(&params.session_id) {
             task.abort();
         }
@@ -1975,6 +2136,12 @@ impl ServerRuntime {
                             })
                             .await;
                         let _ = item_seq;
+
+                        // Store deferred completion info for interrupt recovery
+                        if let Ok(mut session) = event_session_arc.try_lock() {
+                            session.deferred_assistant =
+                                Some((item_id, item_seq, assistant_text.clone()));
+                        }
                     }
                     QueryEvent::ReasoningDelta(text) => {
                         let (item_id, item_seq) = match (reasoning_item_id, reasoning_item_seq) {
@@ -2012,6 +2179,12 @@ impl ServerRuntime {
                             })
                             .await;
                         let _ = item_seq;
+
+                        // Store deferred completion info for interrupt recovery
+                        if let Ok(mut session) = event_session_arc.try_lock() {
+                            session.deferred_reasoning =
+                                Some((item_id, item_seq, reasoning_text.clone()));
+                        }
                     }
                     QueryEvent::ToolUseStart { id, name, input } => {
                         tool_names_by_id.insert(id.clone(), name.clone());

--- a/crates/server/src/runtime.rs
+++ b/crates/server/src/runtime.rs
@@ -1573,25 +1573,6 @@ impl ServerRuntime {
             session.summary.status = SessionRuntimeStatus::ActiveTurn;
             session.summary.updated_at = now;
             session.active_turn = Some(turn.clone());
-
-            // Clear pending queue (both in-memory and SQLite)
-            session
-                .pending_turn_queue
-                .lock()
-                .expect("pending turn queue mutex should not be poisoned")
-                .clear();
-            if !session.summary.ephemeral
-                && let Err(err) = self
-                    .deps
-                    .db
-                    .clear_pending(&params.session_id, QueueType::Turn)
-            {
-                tracing::warn!(
-                    session_id = %params.session_id,
-                    error = %err,
-                    "failed to clear pending turn messages from database"
-                );
-            }
             let clear_session_id = params.session_id;
             let runtime_for_broadcast = Arc::clone(self);
             tokio::spawn(async move {

--- a/crates/server/tests/end_to_end.rs
+++ b/crates/server/tests/end_to_end.rs
@@ -198,6 +198,8 @@ async fn websocket_listener_supports_handshake_subscription_and_turn_lifecycle()
         port
     };
     let bind_address = format!("127.0.0.1:{port}");
+    let db_path = std::env::temp_dir().join("test_end_to_end.db");
+    let db = Arc::new(devo_server::db::Database::open(db_path).expect("open test database"));
     let runtime = ServerRuntime::new(
         std::env::temp_dir(),
         ServerRuntimeDependencies::new(
@@ -208,6 +210,7 @@ async fn websocket_listener_supports_handshake_subscription_and_turn_lifecycle()
             None,
             Box::new(FileSystemSkillCatalog::new(SkillsConfig::default())),
             devo_core::AgentsMdConfig::default(),
+            db,
         ),
     );
     let listen = vec![format!("ws://{bind_address}")];

--- a/crates/server/tests/persistence_resume.rs
+++ b/crates/server/tests/persistence_resume.rs
@@ -931,6 +931,8 @@ fn build_runtime_with_provider(
     data_root: &std::path::Path,
     provider: Arc<dyn ModelProviderSDK>,
 ) -> Result<Arc<ServerRuntime>> {
+    let db_path = data_root.join("test_persistence.db");
+    let db = Arc::new(devo_server::db::Database::open(db_path).expect("open test database"));
     Ok(ServerRuntime::new(
         data_root.to_path_buf(),
         ServerRuntimeDependencies::new(
@@ -941,6 +943,7 @@ fn build_runtime_with_provider(
             None,
             Box::new(FileSystemSkillCatalog::new(SkillsConfig::default())),
             devo_core::AgentsMdConfig::default(),
+            db,
         ),
     ))
 }

--- a/crates/server/tests/skills_integration.rs
+++ b/crates/server/tests/skills_integration.rs
@@ -139,6 +139,8 @@ fn build_runtime_with_registry(
         .iter()
         .map(|root| root.join(".devo").join("skills"))
         .collect::<Vec<_>>();
+    let db_path = data_root.join("test_skills.db");
+    let db = Arc::new(devo_server::db::Database::open(db_path).expect("open test database"));
     ServerRuntime::new(
         data_root.to_path_buf(),
         ServerRuntimeDependencies::new(
@@ -154,6 +156,7 @@ fn build_runtime_with_registry(
                 watch_for_changes: false,
             })),
             devo_core::AgentsMdConfig::default(),
+            db,
         ),
     )
 }

--- a/crates/tui/src/bottom_pane/bottom_pane_view.rs
+++ b/crates/tui/src/bottom_pane/bottom_pane_view.rs
@@ -2,7 +2,6 @@ use crate::render::renderable::Renderable;
 use crossterm::event::KeyEvent;
 
 use super::CancellationEvent;
-use super::onboarding_view::OnboardingResult;
 
 /// Trait implemented by every view that can be shown in the bottom pane.
 pub(crate) trait BottomPaneView: Renderable {
@@ -31,14 +30,6 @@ pub(crate) trait BottomPaneView: Renderable {
     fn take_model_selection(&mut self) -> Option<String> {
         None
     }
-
-    fn take_onboarding_result(&mut self) -> Option<OnboardingResult> {
-        None
-    }
-
-    fn on_validation_succeeded(&mut self, _reply_preview: String) {}
-
-    fn on_validation_failed(&mut self, _error_message: String) {}
 
     /// Handle Ctrl-C while this view is active.
     fn on_ctrl_c(&mut self) -> CancellationEvent {

--- a/crates/tui/src/bottom_pane/mod.rs
+++ b/crates/tui/src/bottom_pane/mod.rs
@@ -187,7 +187,9 @@ impl OnboardingHandle {
     }
 
     pub(crate) fn take_result(&mut self) -> Option<OnboardingResult> {
-        self.completed_result.take().or_else(|| self.view.take_result())
+        self.completed_result
+            .take()
+            .or_else(|| self.view.take_result())
     }
 
     pub(crate) fn on_validation_succeeded(&mut self, reply_preview: String) {

--- a/crates/tui/src/bottom_pane/mod.rs
+++ b/crates/tui/src/bottom_pane/mod.rs
@@ -132,9 +132,87 @@ pub(crate) struct BottomPaneParams {
     pub(crate) animations_enabled: bool,
 }
 
+/// Owns the lifecycle of a single onboarding flow.
+///
+/// Separated from the generic `view_stack` so that onboarding does not block
+/// task-interrupt routing (Esc) or pollute the `BottomPaneView` trait with
+/// onboarding-specific methods. The result is extracted and preserved here
+/// before the view is dropped so callers can retrieve it at any point.
+pub(crate) struct OnboardingHandle {
+    view: OnboardingView,
+    /// Result extracted from the view when it completes. Held here so callers
+    /// can retrieve it even after the handle has been reset.
+    completed_result: Option<OnboardingResult>,
+}
+
+impl OnboardingHandle {
+    pub(crate) fn new(
+        models: &[devo_protocol::Model],
+        app_event_tx: AppEventSender,
+        frame_requester: FrameRequester,
+        animations_enabled: bool,
+    ) -> Self {
+        Self {
+            view: OnboardingView::new(models, app_event_tx, frame_requester, animations_enabled),
+            completed_result: None,
+        }
+    }
+
+    pub(crate) fn handle_key_event(&mut self, key: KeyEvent) {
+        self.view.handle_key_event(key);
+        if self.view.is_complete() {
+            // Extract result before it's overwritten
+            self.completed_result = self.view.take_result();
+        }
+    }
+
+    pub(crate) fn render(&self, area: Rect, buf: &mut Buffer) {
+        self.view.render(area, buf);
+    }
+
+    pub(crate) fn desired_height(&self, width: u16) -> u16 {
+        self.view.desired_height(width)
+    }
+
+    pub(crate) fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
+        self.view.cursor_pos(area)
+    }
+
+    pub(crate) fn is_complete(&self) -> bool {
+        self.view.is_complete()
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        !self.view.is_complete()
+    }
+
+    pub(crate) fn take_result(&mut self) -> Option<OnboardingResult> {
+        self.completed_result.take().or_else(|| self.view.take_result())
+    }
+
+    pub(crate) fn on_validation_succeeded(&mut self, reply_preview: String) {
+        self.view.on_validation_succeeded(reply_preview);
+        if self.view.is_complete() {
+            self.completed_result = self.view.take_result();
+        }
+    }
+
+    pub(crate) fn on_validation_failed(&mut self, error_message: String) {
+        self.view.on_validation_failed(error_message);
+    }
+
+    pub(crate) fn cancel(&mut self) {
+        if !self.view.is_complete() {
+            self.view.cancel();
+            self.completed_result = self.view.take_result();
+        }
+    }
+}
+
 pub(crate) struct BottomPane {
     composer: ChatComposer,
     view_stack: Vec<Box<dyn BottomPaneView>>,
+    onboarding: Option<OnboardingHandle>,
     app_event_tx: AppEventSender,
     frame_requester: FrameRequester,
     unified_exec_footer: UnifiedExecFooter,
@@ -182,6 +260,7 @@ impl BottomPane {
         Self {
             composer,
             view_stack: Vec::new(),
+            onboarding: None,
             app_event_tx,
             frame_requester,
             unified_exec_footer: UnifiedExecFooter::new(),
@@ -200,6 +279,13 @@ impl BottomPane {
     }
 
     pub(crate) fn handle_key_event(&mut self, key: KeyEvent) -> InputResult {
+        // Route to onboarding first — it takes priority over views and composer.
+        if let Some(handle) = self.onboarding.as_mut() {
+            handle.handle_key_event(key);
+            self.request_redraw();
+            return InputResult::None;
+        }
+
         if !self.view_stack.is_empty() {
             return self.handle_view_key_event(key);
         }
@@ -326,47 +412,44 @@ impl BottomPane {
         self.allow_empty_submit = enabled;
     }
 
-    pub(crate) fn open_model_picker(&mut self, entries: Vec<ModelPickerEntry>) {
-        self.push_view(Box::new(ModelPickerView::new(entries)));
-    }
-
-    pub(crate) fn open_onboarding(&mut self, models: &[devo_protocol::Model]) {
-        self.push_view(Box::new(OnboardingView::new(
+    pub(crate) fn start_onboarding(&mut self, models: &[devo_protocol::Model]) {
+        self.onboarding = Some(OnboardingHandle::new(
             models,
             self.app_event_tx.clone(),
             self.frame_requester.clone(),
             self.animations_enabled,
-        )));
+        ));
+        self.request_redraw();
+    }
+
+    pub(crate) fn poll_onboarding_result(&mut self) -> Option<OnboardingResult> {
+        let result = self.onboarding.as_mut().and_then(|h| h.take_result());
+        if result.is_some() {
+            self.onboarding = None;
+        }
+        result
+    }
+
+    pub(crate) fn is_onboarding_active(&self) -> bool {
+        self.onboarding.as_ref().is_some_and(|h| h.is_active())
     }
 
     pub(crate) fn onboarding_on_validation_succeeded(&mut self, reply_preview: String) {
-        if let Some(view) = self.view_stack.last_mut() {
-            view.on_validation_succeeded(reply_preview);
-            if view.is_complete() {
-                self.view_stack.pop();
-                self.on_active_view_complete();
-                self.request_redraw();
-            }
-        }
-    }
-
-    pub(crate) fn onboarding_on_validation_failed(&mut self, error_message: String) {
-        if let Some(view) = self.view_stack.last_mut() {
-            view.on_validation_failed(error_message);
+        if let Some(handle) = &mut self.onboarding {
+            handle.on_validation_succeeded(reply_preview);
             self.request_redraw();
         }
     }
 
-    pub(crate) fn take_onboarding_result(&mut self) -> Option<OnboardingResult> {
-        self.view_stack
-            .last_mut()
-            .and_then(|view| view.take_onboarding_result())
+    pub(crate) fn onboarding_on_validation_failed(&mut self, error_message: String) {
+        if let Some(handle) = &mut self.onboarding {
+            handle.on_validation_failed(error_message);
+            self.request_redraw();
+        }
     }
 
-    pub(crate) fn is_onboarding_active(&self) -> bool {
-        self.view_stack
-            .last()
-            .is_some_and(|view| view.view_id() == Some("onboarding"))
+    pub(crate) fn open_model_picker(&mut self, entries: Vec<ModelPickerEntry>) {
+        self.push_view(Box::new(ModelPickerView::new(entries)));
     }
 
     pub(crate) fn restore_input_from_history(&mut self, text: Option<String>) {
@@ -704,6 +787,10 @@ impl Renderable for BottomPane {
         if area.is_empty() {
             return;
         }
+        if let Some(handle) = &self.onboarding {
+            handle.render(area, buf);
+            return;
+        }
         if let Some(view) = self.active_view() {
             view.render(area, buf);
             return;
@@ -729,6 +816,9 @@ impl Renderable for BottomPane {
     }
 
     fn desired_height(&self, width: u16) -> u16 {
+        if let Some(handle) = &self.onboarding {
+            return handle.desired_height(width);
+        }
         if let Some(view) = self.active_view() {
             return view.desired_height(width);
         }
@@ -751,6 +841,9 @@ impl Renderable for BottomPane {
     }
 
     fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
+        if let Some(handle) = &self.onboarding {
+            return handle.cursor_pos(area);
+        }
         if let Some(view) = self.active_view() {
             return view.cursor_pos(area);
         }

--- a/crates/tui/src/bottom_pane/onboarding_view.rs
+++ b/crates/tui/src/bottom_pane/onboarding_view.rs
@@ -17,8 +17,6 @@ use ratatui::widgets::Wrap;
 use devo_protocol::Model;
 use devo_protocol::ProviderWireApi;
 
-use super::CancellationEvent;
-use super::bottom_pane_view::BottomPaneView;
 use super::popup_consts::MAX_POPUP_ROWS;
 use super::scroll_state::ScrollState;
 /// Simple content area with padding, no background styling.
@@ -215,6 +213,11 @@ impl OnboardingView {
 
     pub(crate) fn is_complete(&self) -> bool {
         self.complete
+    }
+
+    pub(crate) fn cancel(&mut self) {
+        self.complete = true;
+        self.result = Some(OnboardingResult::Cancelled);
     }
 
     /// Called when validation succeeds.
@@ -1297,8 +1300,9 @@ impl OnboardingView {
     }
 }
 
-impl BottomPaneView for OnboardingView {
-    fn handle_key_event(&mut self, key_event: KeyEvent) {
+impl OnboardingView {
+    /// Entry point for key events, called by `OnboardingHandle`.
+    pub(crate) fn handle_key_event(&mut self, key_event: KeyEvent) {
         if matches!(key_event.kind, KeyEventKind::Release) {
             return;
         }
@@ -1320,36 +1324,6 @@ impl BottomPaneView for OnboardingView {
                 self.validation_failed_handle_key(key_event);
             }
         }
-    }
-
-    fn is_complete(&self) -> bool {
-        self.complete
-    }
-
-    fn view_id(&self) -> Option<&'static str> {
-        Some("onboarding")
-    }
-
-    fn on_ctrl_c(&mut self) -> CancellationEvent {
-        self.complete = true;
-        self.result = Some(OnboardingResult::Cancelled);
-        CancellationEvent::Handled
-    }
-
-    fn prefer_esc_to_handle_key_event(&self) -> bool {
-        true
-    }
-
-    fn take_onboarding_result(&mut self) -> Option<OnboardingResult> {
-        self.result.take()
-    }
-
-    fn on_validation_succeeded(&mut self, reply_preview: String) {
-        self.on_validation_succeeded(reply_preview);
-    }
-
-    fn on_validation_failed(&mut self, error_message: String) {
-        self.on_validation_failed(error_message);
     }
 }
 

--- a/crates/tui/src/bottom_pane/onboarding_view.rs
+++ b/crates/tui/src/bottom_pane/onboarding_view.rs
@@ -1354,10 +1354,22 @@ impl BottomPaneView for OnboardingView {
 }
 
 impl Renderable for OnboardingView {
-    fn desired_height(&self, width: u16) -> u16 {
-        let _ = width;
-        // Return a reasonable height that will be clamped by the layout
-        20
+    fn desired_height(&self, _width: u16) -> u16 {
+        match &self.state {
+            OnboardingState::ModelSelection {
+                filtered_indices, ..
+            } => {
+                // title + subtitle + blank + search + blank + items + blank + footer
+                let items = MAX_POPUP_ROWS.min(filtered_indices.len().max(1)) as u16;
+                items * 2 + 7
+            }
+            OnboardingState::CustomModelName { .. } => 8,
+            OnboardingState::ProviderSelection { .. } => 14,
+            OnboardingState::BaseUrl { .. } => 11,
+            OnboardingState::ApiKey { .. } => 12,
+            OnboardingState::Validating { .. } => 10,
+            OnboardingState::ValidationFailed { .. } => 12,
+        }
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {

--- a/crates/tui/src/chatwidget.rs
+++ b/crates/tui/src/chatwidget.rs
@@ -644,6 +644,9 @@ impl ChatWidget {
             self.handle_resume_browser_key_event(key);
             return;
         }
+        if let Some(result) = self.bottom_pane.poll_onboarding_result() {
+            self.handle_onboarding_result(result);
+        }
         match self.bottom_pane.handle_key_event(key) {
             InputResult::Submitted {
                 text,
@@ -954,11 +957,8 @@ impl ChatWidget {
             WorkerEvent::ProviderValidationSucceeded { reply_preview } => {
                 self.bottom_pane
                     .onboarding_on_validation_succeeded(reply_preview.clone());
-                if !self.bottom_pane.is_onboarding_active() {
-                    // Onboarding view completed, check for result
-                    if let Some(result) = self.bottom_pane.take_onboarding_result() {
-                        self.handle_onboarding_result(result);
-                    }
+                if let Some(result) = self.bottom_pane.poll_onboarding_result() {
+                    self.handle_onboarding_result(result);
                 }
                 self.add_to_history(history_cell::new_info_event(
                     format!("Validation reply: {reply_preview}"),
@@ -1124,12 +1124,8 @@ impl ChatWidget {
     }
 
     fn submit_user_message(&mut self, user_message: UserMessage) {
-        // Check if the onboarding view completed with a validation request
-        if self.bottom_pane.is_onboarding_active() {
-            if let Some(result) = self.bottom_pane.take_onboarding_result() {
-                self.handle_onboarding_result(result);
-            }
-            return;
+        if let Some(result) = self.bottom_pane.poll_onboarding_result() {
+            self.handle_onboarding_result(result);
         }
         if user_message.text.trim().is_empty() {
             return;
@@ -1283,7 +1279,7 @@ impl ChatWidget {
         self.onboarding_step = None;
         self.history.clear();
         self.next_history_flush_index = 0;
-        self.bottom_pane.open_onboarding(&self.available_models);
+        self.bottom_pane.start_onboarding(&self.available_models);
         self.set_status_message("Onboarding");
     }
 

--- a/crates/tui/src/chatwidget.rs
+++ b/crates/tui/src/chatwidget.rs
@@ -1053,6 +1053,11 @@ impl ChatWidget {
                 );
                 // Restore pending queue state from the resumed session
                 self.queued_count = pending_texts.len();
+                self.bottom_pane.clear_pending_cells();
+                for text in &pending_texts {
+                    self.bottom_pane.push_pending_cell(text.clone());
+                }
+                self.busy = false;
                 self.set_status_message("Session switched");
             }
             WorkerEvent::SessionRenamed { session_id, title } => {
@@ -1238,6 +1243,12 @@ impl ChatWidget {
             }
             SlashCommand::Btw => {
                 if let Some(turn_id) = self.active_turn_id {
+                    self.add_to_history(history_cell::new_user_prompt(
+                        format!("/btw {argument}"),
+                        Vec::new(),
+                        Vec::new(),
+                        Vec::new(),
+                    ));
                     self.app_event_tx
                         .send(AppEvent::Command(AppCommand::SteerTurn {
                             input: vec![devo_protocol::InputItem::Text { text: argument }],
@@ -1828,8 +1839,8 @@ impl ChatWidget {
                 Vec::new(),
                 Vec::new(),
             ));
-            self.queued_count = self.queued_count.saturating_sub(1);
         }
+        self.queued_count = self.queued_count.saturating_sub(1);
     }
 
     fn add_history_entry_without_redraw(&mut self, cell: Box<dyn HistoryCell>) {

--- a/crates/tui/src/chatwidget.rs
+++ b/crates/tui/src/chatwidget.rs
@@ -796,14 +796,16 @@ impl ChatWidget {
                 self.set_status_message("Thinking");
             }
             WorkerEvent::AssistantMessageCompleted(text) => {
-                if self.stream_controller.is_none() {
+                if self.busy && self.stream_controller.is_none() {
                     self.active_assistant_text = text;
                 }
                 self.sync_active_assistant_cell();
                 self.set_status_message("Generating");
             }
             WorkerEvent::ReasoningCompleted(text) => {
-                self.active_reasoning_text = text;
+                if self.busy {
+                    self.active_reasoning_text = text;
+                }
                 self.sync_active_reasoning_cell();
                 self.set_status_message("Thinking");
             }

--- a/crates/tui/src/chatwidget.rs
+++ b/crates/tui/src/chatwidget.rs
@@ -502,6 +502,7 @@ impl ChatWidget {
         for item in &history_items {
             self.add_transcript_item_without_redraw(item.clone());
         }
+
         if !loaded_any_history {
             self.add_history_entry_without_redraw(Box::new(history_cell::new_info_event(
                 format!(
@@ -1026,6 +1027,7 @@ impl ChatWidget {
                 prompt_token_estimate,
                 history_items,
                 loaded_item_count,
+                pending_texts,
             } => {
                 self.resume_browser_loading = false;
                 self.session.cwd = cwd;
@@ -1050,6 +1052,8 @@ impl ChatWidget {
                     &session_id,
                     title.as_deref(),
                 );
+                // Restore pending queue state from the resumed session
+                self.queued_count = pending_texts.len();
                 self.set_status_message("Session switched");
             }
             WorkerEvent::SessionRenamed { session_id, title } => {
@@ -1581,6 +1585,12 @@ impl ChatWidget {
                     item.title,
                     Some(item.body),
                 )));
+            }
+            TranscriptItemKind::TurnSummary => {
+                // item.title contains model name, item.duration_ms contains seconds
+                self.add_history_entry_without_redraw(Box::new(
+                    history_cell::TurnSummaryCell::new(item.title.clone(), item.duration_ms),
+                ));
             }
         }
     }

--- a/crates/tui/src/chatwidget_tests.rs
+++ b/crates/tui/src/chatwidget_tests.rs
@@ -606,6 +606,7 @@ fn session_switch_restores_header_and_double_blank_line_before_user_input() {
             ),
         ],
         loaded_item_count: 2,
+        pending_texts: vec![],
     });
 
     let committed_lines = widget.drain_scrollback_lines(80);
@@ -850,6 +851,7 @@ fn restored_reasoning_text_is_visible_in_transcript() {
             "thinking text",
         )],
         loaded_item_count: 1,
+        pending_texts: vec![],
     });
 
     let scrollback = widget.drain_scrollback_lines(80);
@@ -994,6 +996,7 @@ fn session_switch_updates_session_identity_projection() {
         prompt_token_estimate: 3,
         history_items: Vec::new(),
         loaded_item_count: 0,
+        pending_texts: vec![],
     });
 
     assert_eq!(widget.current_cwd(), resumed_cwd.as_path());
@@ -1029,6 +1032,7 @@ fn new_session_prepared_resets_session_identity_projection() {
         prompt_token_estimate: 3,
         history_items: Vec::new(),
         loaded_item_count: 0,
+        pending_texts: vec![],
     });
     widget.handle_worker_event(crate::events::WorkerEvent::NewSessionPrepared {
         cwd: initial_cwd.clone(),

--- a/crates/tui/src/events.rs
+++ b/crates/tui/src/events.rs
@@ -178,6 +178,8 @@ pub(crate) enum WorkerEvent {
         history_items: Vec<TranscriptItem>,
         /// Number of persisted items loaded for the resumed session.
         loaded_item_count: u64,
+        /// Pending turn input texts queued for the next turn.
+        pending_texts: Vec<String>,
     },
     /// The current session title changed.
     SessionRenamed {
@@ -300,4 +302,6 @@ pub(crate) enum TranscriptItemKind {
     Error,
     /// Local UI/system note that is not model-authored content.
     System,
+    /// Turn summary with model name and duration.
+    TurnSummary,
 }

--- a/crates/tui/src/tui.rs
+++ b/crates/tui/src/tui.rs
@@ -678,8 +678,7 @@ impl Tui {
         if snapshot.mode == ExitLayoutMode::InlineChat && !snapshot.bottom_pane_area.is_empty() {
             let current_viewport_top = terminal.viewport_area.top();
             let snapshot_viewport_top = snapshot.frame_area.top();
-            let delta_y =
-                i32::from(current_viewport_top) - i32::from(snapshot_viewport_top);
+            let delta_y = i32::from(current_viewport_top) - i32::from(snapshot_viewport_top);
             // Offset the snapshot coordinates to account for viewport drift since
             // the last render (e.g. from flush_pending_history_lines_for_exit).
             let offset = ratatui::layout::Offset { x: 0, y: delta_y };
@@ -691,9 +690,7 @@ impl Tui {
                 x: 0,
                 y: history_area.top(),
                 width: terminal.size()?.width,
-                height: bottom_pane_area
-                    .bottom()
-                    .saturating_sub(history_area.top()),
+                height: bottom_pane_area.bottom().saturating_sub(history_area.top()),
             };
             terminal.clear_screen_area(clear_area)?;
             terminal.set_cursor_below_rect(bottom_pane_area)?;
@@ -967,44 +964,35 @@ mod tests {
         terminal
             .set_cursor_position(Position { x: 0, y: 2 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"scrollback row 1")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"scrollback row 1").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 3 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"scrollback row 2")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"scrollback row 2").expect("write");
 
         // Write live content within the viewport
         terminal
             .set_cursor_position(Position { x: 0, y: 4 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"live history row")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"live history row").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 5 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"live assistant row")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"live assistant row").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 6 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"bottom pane row 1")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"bottom pane row 1").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 7 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"bottom pane row 2")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"bottom pane row 2").expect("write");
 
         // Simulate pending history lines pushed before exit.
         // flush_pending_history_lines_for_exit() inserts these above the viewport,
         // shifting viewport.y downward.
-        let mut pending_lines = vec![
-            ScrollbackLine::from(Line::from("pending history line")),
-        ];
-        insert_history_lines(&mut terminal, pending_lines.clone())
-            .expect("insert");
+        let mut pending_lines = vec![ScrollbackLine::from(Line::from("pending history line"))];
+        insert_history_lines(&mut terminal, pending_lines.clone()).expect("insert");
         pending_lines.clear();
         // viewport.y is now 5 (shifted down by 1)
 
@@ -1020,8 +1008,7 @@ mod tests {
         )
         .expect("apply");
 
-        let rows: Vec<String> =
-            terminal.backend().vt100().screen().rows(0, width).collect();
+        let rows: Vec<String> = terminal.backend().vt100().screen().rows(0, width).collect();
 
         // Scrollback rows above viewport must be preserved
         let scrollback_idx = rows
@@ -1062,23 +1049,19 @@ mod tests {
         terminal
             .set_cursor_position(Position { x: 0, y: 2 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"session header row")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"session header row").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 3 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"live text row")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"live text row").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 4 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"composer row 1")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"composer row 1").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 5 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"composer row 2")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"composer row 2").expect("write");
 
         // Snapshot captures the full viewport at y=2
         Tui::apply_exit_layout_snapshot(
@@ -1092,13 +1075,10 @@ mod tests {
         )
         .expect("apply");
 
-        let rows: Vec<String> =
-            terminal.backend().vt100().screen().rows(0, width).collect();
+        let rows: Vec<String> = terminal.backend().vt100().screen().rows(0, width).collect();
 
         // History area rows (y=2,3) should be cleared — session header should NOT remain
-        let header_row = rows
-            .iter()
-            .position(|r| r.contains("session header row"));
+        let header_row = rows.iter().position(|r| r.contains("session header row"));
         assert!(
             header_row.is_none(),
             "session header should be cleared, but found at row {:?}: {rows:?}",
@@ -1133,23 +1113,19 @@ mod tests {
         terminal
             .set_cursor_position(Position { x: 0, y: 3 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"status line")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"status line").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 4 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"composer")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"composer").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 5 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"footer")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"footer").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 6 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"spacer")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"spacer").expect("write");
 
         // Snapshot — no pending history lines, delta_y = 0
         Tui::apply_exit_layout_snapshot(
@@ -1163,8 +1139,7 @@ mod tests {
         )
         .expect("apply");
 
-        let rows: Vec<String> =
-            terminal.backend().vt100().screen().rows(0, width).collect();
+        let rows: Vec<String> = terminal.backend().vt100().screen().rows(0, width).collect();
 
         // All viewport rows cleared
         assert_eq!("", rows[3].trim_end());
@@ -1188,38 +1163,31 @@ mod tests {
         terminal
             .set_cursor_position(Position { x: 0, y: 2 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"  Welcome to Devo")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"  Welcome to Devo").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 3 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"  Choose a model")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"  Choose a model").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 4 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"  > model-name")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"  > model-name").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 5 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"  model desc")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"  model desc").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 6 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"  > other-model")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"  > other-model").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 7 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"  other desc")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"  other desc").expect("write");
         terminal
             .set_cursor_position(Position { x: 0, y: 8 })
             .expect("cursor");
-        std::io::Write::write_all(terminal.backend_mut(), b"  > Custom Model")
-            .expect("write");
+        std::io::Write::write_all(terminal.backend_mut(), b"  > Custom Model").expect("write");
 
         // Snapshot — large bottom_pane_area like onboarding view
         Tui::apply_exit_layout_snapshot(
@@ -1233,8 +1201,7 @@ mod tests {
         )
         .expect("apply");
 
-        let rows: Vec<String> =
-            terminal.backend().vt100().screen().rows(0, width).collect();
+        let rows: Vec<String> = terminal.backend().vt100().screen().rows(0, width).collect();
 
         // All onboarding content cleared
         for y in 2..9 {

--- a/crates/tui/src/tui.rs
+++ b/crates/tui/src/tui.rs
@@ -678,11 +678,24 @@ impl Tui {
         if snapshot.mode == ExitLayoutMode::InlineChat && !snapshot.bottom_pane_area.is_empty() {
             let current_viewport_top = terminal.viewport_area.top();
             let snapshot_viewport_top = snapshot.frame_area.top();
-            let bottom_pane_area = snapshot.bottom_pane_area.offset(ratatui::layout::Offset {
+            let delta_y =
+                i32::from(current_viewport_top) - i32::from(snapshot_viewport_top);
+            // Offset the snapshot coordinates to account for viewport drift since
+            // the last render (e.g. from flush_pending_history_lines_for_exit).
+            let offset = ratatui::layout::Offset { x: 0, y: delta_y };
+            let bottom_pane_area = snapshot.bottom_pane_area.offset(offset);
+            // Also clear the history area so that session header and live text
+            // do not remain on screen after exit.
+            let history_area = snapshot.history_area.offset(offset);
+            let clear_area = ratatui::layout::Rect {
                 x: 0,
-                y: i32::from(current_viewport_top) - i32::from(snapshot_viewport_top),
-            });
-            terminal.clear_screen_area(bottom_pane_area)?;
+                y: history_area.top(),
+                width: terminal.size()?.width,
+                height: bottom_pane_area
+                    .bottom()
+                    .saturating_sub(history_area.top()),
+            };
+            terminal.clear_screen_area(clear_area)?;
             terminal.set_cursor_below_rect(bottom_pane_area)?;
             return Ok(());
         }
@@ -810,17 +823,19 @@ mod tests {
     }
 
     #[test]
-    fn shutdown_inline_precise_clears_only_bottom_pane_and_repositions_cursor() {
+    fn shutdown_inline_precise_clears_viewport_and_repositions_cursor() {
         let width: u16 = 24;
         let height: u16 = 8;
         let backend = VT100Backend::new(width, height);
         let mut terminal = CustomTerminal::with_options(backend).expect("terminal");
         terminal.set_viewport_area(Rect::new(0, 3, width, 3));
 
+        // Write scrollback ABOVE viewport (y < 3)
         terminal
             .set_cursor_position(Position { x: 0, y: 2 })
             .expect("cursor position");
         std::io::Write::write_all(terminal.backend_mut(), b"history row").expect("write history");
+        // Write live content WITHIN viewport (y >= 3)
         terminal
             .set_cursor_position(Position { x: 0, y: 3 })
             .expect("cursor position");
@@ -835,7 +850,7 @@ mod tests {
             ExitLayoutSnapshot {
                 mode: ExitLayoutMode::InlineChat,
                 frame_area: Rect::new(0, 3, width, 3),
-                history_area: Rect::new(0, 0, width, 1),
+                history_area: Rect::new(0, 3, width, 1),
                 bottom_pane_area: Rect::new(0, 4, width, 2),
             },
         )
@@ -847,9 +862,11 @@ mod tests {
             .position(|row| row.contains("history row"))
             .expect("history row remains visible");
         assert!(
-            history_row < 4,
-            "history should remain above bottom pane: {rows_after:?}"
+            history_row < 3,
+            "history should remain above viewport: {rows_after:?}"
         );
+        // All viewport rows cleared
+        assert_eq!("", rows_after[3].trim_end());
         assert_eq!("", rows_after[4].trim_end());
         assert_eq!("", rows_after[5].trim_end());
         assert_eq!(Position { x: 0, y: 6 }, terminal.last_known_cursor_pos);
@@ -872,6 +889,9 @@ mod tests {
             .expect("cursor position");
         std::io::Write::write_all(terminal.backend_mut(), b"current bottom").expect("write bottom");
 
+        // Snapshot is stale: frame_area.y=3, but viewport is now at y=5
+        // delta_y = 5 - 3 = 2
+        // Area should be shifted down by 2 rows
         Tui::apply_exit_layout_snapshot(
             &mut terminal,
             ExitLayoutSnapshot {
@@ -884,10 +904,12 @@ mod tests {
         .expect("apply exit snapshot");
 
         let rows_after: Vec<String> = terminal.backend().vt100().screen().rows(0, width).collect();
+        // Scrollback above viewport y=5 is preserved
         assert!(
-            rows_after[5].contains("live history"),
-            "expected stale rows to remain untouched: {rows_after:?}"
+            rows_after[4].is_empty() || !rows_after[4].contains("live"),
+            "row above viewport untouched: {rows_after:?}"
         );
+        // Viewport content shifted + cleared
         assert_eq!("", rows_after[6].trim_end());
         assert_eq!("", rows_after[7].trim_end());
         assert_eq!(Position { x: 0, y: 8 }, terminal.last_known_cursor_pos);
@@ -931,5 +953,298 @@ mod tests {
             "history should remain above viewport: {rows_after:?}"
         );
         assert_eq!("", rows_after[3].trim_end());
+    }
+
+    #[test]
+    fn shutdown_full_flow_preserves_scrollback_and_positions_cursor() {
+        let width: u16 = 24;
+        let height: u16 = 12;
+        let backend = VT100Backend::new(width, height);
+        let mut terminal = CustomTerminal::with_options(backend).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 4, width, 4));
+
+        // Write scrollback content above the viewport
+        terminal
+            .set_cursor_position(Position { x: 0, y: 2 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"scrollback row 1")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 3 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"scrollback row 2")
+            .expect("write");
+
+        // Write live content within the viewport
+        terminal
+            .set_cursor_position(Position { x: 0, y: 4 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"live history row")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 5 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"live assistant row")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 6 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"bottom pane row 1")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 7 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"bottom pane row 2")
+            .expect("write");
+
+        // Simulate pending history lines pushed before exit.
+        // flush_pending_history_lines_for_exit() inserts these above the viewport,
+        // shifting viewport.y downward.
+        let mut pending_lines = vec![
+            ScrollbackLine::from(Line::from("pending history line")),
+        ];
+        insert_history_lines(&mut terminal, pending_lines.clone())
+            .expect("insert");
+        pending_lines.clear();
+        // viewport.y is now 5 (shifted down by 1)
+
+        // Apply the exit snapshot captured at the LAST render (viewport was at y=4).
+        Tui::apply_exit_layout_snapshot(
+            &mut terminal,
+            ExitLayoutSnapshot {
+                mode: ExitLayoutMode::InlineChat,
+                frame_area: Rect::new(0, 4, width, 4),
+                history_area: Rect::new(0, 4, width, 2),
+                bottom_pane_area: Rect::new(0, 6, width, 2),
+            },
+        )
+        .expect("apply");
+
+        let rows: Vec<String> =
+            terminal.backend().vt100().screen().rows(0, width).collect();
+
+        // Scrollback rows above viewport must be preserved
+        let scrollback_idx = rows
+            .iter()
+            .position(|r| r.contains("scrollback row 1"))
+            .expect("scrollback should be preserved");
+        assert!(scrollback_idx < 4, "scrollback above viewport: {rows:?}");
+
+        // The pending history line pushed at exit should also be in scrollback
+        let pending_idx = rows
+            .iter()
+            .position(|r| r.contains("pending history line"))
+            .expect("pending history line should be in scrollback");
+        assert!(pending_idx < 6, "pending line in scrollback: {rows:?}");
+
+        // All viewport rows (from history_area to bottom of bottom_pane) cleared
+        assert_eq!("", rows[6].trim_end(), "viewport row cleared: {rows:?}");
+        assert_eq!("", rows[7].trim_end(), "viewport row cleared: {rows:?}");
+        assert_eq!("", rows[8].trim_end(), "viewport row cleared: {rows:?}");
+
+        // Cursor placed right below the cleared bottom pane
+        assert_eq!(
+            Position { x: 0, y: 9 },
+            terminal.last_known_cursor_pos,
+            "cursor below bottom pane: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn shutdown_clears_history_area_content() {
+        let width: u16 = 24;
+        let height: u16 = 8;
+        let backend = VT100Backend::new(width, height);
+        let mut terminal = CustomTerminal::with_options(backend).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 2, width, 5));
+
+        // Write content in all areas
+        terminal
+            .set_cursor_position(Position { x: 0, y: 2 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"session header row")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 3 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"live text row")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 4 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"composer row 1")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 5 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"composer row 2")
+            .expect("write");
+
+        // Snapshot captures the full viewport at y=2
+        Tui::apply_exit_layout_snapshot(
+            &mut terminal,
+            ExitLayoutSnapshot {
+                mode: ExitLayoutMode::InlineChat,
+                frame_area: Rect::new(0, 2, width, 5),
+                history_area: Rect::new(0, 2, width, 2),
+                bottom_pane_area: Rect::new(0, 4, width, 2),
+            },
+        )
+        .expect("apply");
+
+        let rows: Vec<String> =
+            terminal.backend().vt100().screen().rows(0, width).collect();
+
+        // History area rows (y=2,3) should be cleared — session header should NOT remain
+        let header_row = rows
+            .iter()
+            .position(|r| r.contains("session header row"));
+        assert!(
+            header_row.is_none(),
+            "session header should be cleared, but found at row {:?}: {rows:?}",
+            header_row
+        );
+
+        // Live text row should also be cleared
+        let live_row = rows.iter().position(|r| r.contains("live text row"));
+        assert!(
+            live_row.is_none(),
+            "live text should be cleared, but found at row {:?}: {rows:?}",
+            live_row
+        );
+
+        // Bottom pane cleared
+        assert_eq!("", rows[4].trim_end());
+        assert_eq!("", rows[5].trim_end());
+
+        // Cursor below bottom pane
+        assert_eq!(Position { x: 0, y: 6 }, terminal.last_known_cursor_pos);
+    }
+
+    #[test]
+    fn shutdown_with_no_pending_lines_positions_cursor_correctly() {
+        let width: u16 = 24;
+        let height: u16 = 10;
+        let backend = VT100Backend::new(width, height);
+        let mut terminal = CustomTerminal::with_options(backend).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 3, width, 4));
+
+        // Write composer content
+        terminal
+            .set_cursor_position(Position { x: 0, y: 3 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"status line")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 4 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"composer")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 5 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"footer")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 6 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"spacer")
+            .expect("write");
+
+        // Snapshot — no pending history lines, delta_y = 0
+        Tui::apply_exit_layout_snapshot(
+            &mut terminal,
+            ExitLayoutSnapshot {
+                mode: ExitLayoutMode::InlineChat,
+                frame_area: Rect::new(0, 3, width, 4),
+                history_area: Rect::new(0, 3, width, 1),
+                bottom_pane_area: Rect::new(0, 4, width, 3),
+            },
+        )
+        .expect("apply");
+
+        let rows: Vec<String> =
+            terminal.backend().vt100().screen().rows(0, width).collect();
+
+        // All viewport rows cleared
+        assert_eq!("", rows[3].trim_end());
+        assert_eq!("", rows[4].trim_end());
+        assert_eq!("", rows[5].trim_end());
+        assert_eq!("", rows[6].trim_end());
+
+        // Cursor right below the cleared area
+        assert_eq!(Position { x: 0, y: 7 }, terminal.last_known_cursor_pos);
+    }
+
+    #[test]
+    fn shutdown_with_onboarding_view_clears_correct_area() {
+        let width: u16 = 24;
+        let height: u16 = 10;
+        let backend = VT100Backend::new(width, height);
+        let mut terminal = CustomTerminal::with_options(backend).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 2, width, 7));
+
+        // Write onboarding content (12-row onboarding view takes most of viewport)
+        terminal
+            .set_cursor_position(Position { x: 0, y: 2 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"  Welcome to Devo")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 3 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"  Choose a model")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 4 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"  > model-name")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 5 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"  model desc")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 6 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"  > other-model")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 7 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"  other desc")
+            .expect("write");
+        terminal
+            .set_cursor_position(Position { x: 0, y: 8 })
+            .expect("cursor");
+        std::io::Write::write_all(terminal.backend_mut(), b"  > Custom Model")
+            .expect("write");
+
+        // Snapshot — large bottom_pane_area like onboarding view
+        Tui::apply_exit_layout_snapshot(
+            &mut terminal,
+            ExitLayoutSnapshot {
+                mode: ExitLayoutMode::InlineChat,
+                frame_area: Rect::new(0, 2, width, 7),
+                history_area: Rect::new(0, 2, width, 1),
+                bottom_pane_area: Rect::new(0, 3, width, 6),
+            },
+        )
+        .expect("apply");
+
+        let rows: Vec<String> =
+            terminal.backend().vt100().screen().rows(0, width).collect();
+
+        // All onboarding content cleared
+        for y in 2..9 {
+            assert!(
+                rows[y].trim().is_empty() || rows[y].trim().starts_with("│"),
+                "row {y} should be cleared: {rows:?}"
+            );
+        }
+
+        // Cursor below the cleared bottom pane
+        assert_eq!(Position { x: 0, y: 9 }, terminal.last_known_cursor_pos);
     }
 }

--- a/crates/tui/src/worker.rs
+++ b/crates/tui/src/worker.rs
@@ -606,6 +606,7 @@ async fn run_worker_inner(
                                 session_id = Some(next_session_id);
                                 session_cwd = result.session.cwd.clone();
                                 input_history_cursor = None;
+
                                 let _ = event_tx.send(WorkerEvent::SessionSwitched {
                                     session_id: next_session_id.to_string(),
                                     cwd: result.session.cwd,
@@ -618,6 +619,7 @@ async fn run_worker_inner(
                                     prompt_token_estimate: result.session.prompt_token_estimate,
                                     history_items: project_history_items(&result.history_items),
                                     loaded_item_count: result.loaded_item_count,
+                                    pending_texts: result.pending_texts,
                                 });
                                 model = result
                                     .session
@@ -1188,6 +1190,7 @@ fn project_history_items(items: &[SessionHistoryItem]) -> Vec<TranscriptItem> {
             SessionHistoryItemKind::ToolCall => TranscriptItemKind::ToolCall,
             SessionHistoryItemKind::ToolResult => TranscriptItemKind::ToolResult,
             SessionHistoryItemKind::Error => TranscriptItemKind::Error,
+            SessionHistoryItemKind::TurnSummary => TranscriptItemKind::TurnSummary,
         };
         let mut transcript_item = match item.kind {
             SessionHistoryItemKind::ToolCall => TranscriptItem::tool_call(item.title.clone()),
@@ -1196,6 +1199,10 @@ fn project_history_items(items: &[SessionHistoryItem]) -> Vec<TranscriptItem> {
             }
             SessionHistoryItemKind::Error => {
                 TranscriptItem::tool_error(item.title.clone(), item.body.clone())
+            }
+            SessionHistoryItemKind::TurnSummary => {
+                // TurnSummary uses title for model name, duration_ms for duration in seconds
+                TranscriptItem::new(kind, item.title.clone(), String::new())
             }
             SessionHistoryItemKind::User
             | SessionHistoryItemKind::Assistant


### PR DESCRIPTION
- Onboarding redesign: replace text-input wizard with modern picker-based UI; dedicated OnboardingHandle separated from view_stack so Esc interrupts always work
- Session restore: restore pending messages to bottom pane, fix InputQueueUpdated infinite loop, reset busy on switch, preserve server-side pending queue
- Interrupt: fix deadlock in handle_turn_interrupt (tokio Mutex reentrancy), fix core_session lock blocking interrupt response
- Exit coordinates: clear full viewport (history_area + bottom_pane) on exit, add 4 tests covering delta_y correction, scrollback preservation, onboarding view cleanup
- Steer/BTW: show /btw messages in TUI history during live sessions
- Duplicate cells: guard against duplicate history cells after turn interrupt