### PR TITLE
fix: duplicate transcript items after interrupt, header box dedup,

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ model_thinking_selection = "high"
 
 [model_providers."api.deepseek.com"]
 name = "api.deepseek.com"
-api_key = "sk-0b7b2422983141e5973d1fc3eccf0822"
+api_key = "sk-..."
 base_url = "https://api.deepseek.com"
 wire_api = "openai_chat_completions"
 
@@ -113,8 +113,8 @@ model = "deepseek-v4-flash"
 
 ```toml
 # ── Model Provider (required) ───────────────────────────────────
-model_provider = "openai"          # active provider id
-model = "gpt-4o"                   # active model slug
+model_provider = "api.deepseek.com"          # active provider id
+model = "deepseek-v4-flash"                   # active model slug
 model_thinking_selection = "high"   # optional: thinking/reasoning effort
 model_auto_compact_token_limit = 970000   # optional
 model_context_window = 128000      # optional
@@ -122,58 +122,58 @@ disable_response_storage = false   # optional
 preferred_auth_method = "apikey"   # optional: "apikey"
 
 # ── Provider Profiles ───────────────────────────────────────────
-[model_providers.openai]
-name = "OpenAI"
-base_url = "https://api.openai.com/v1"
+[model_providers."api.deepseek.com"]
+name = "api.deepseek.com"
+base_url = "https://api.deepseek.com"
 wire_api = "openai_chat_completions"   # openai_chat_completions | openai_responses | anthropic_messages
 api_key = "sk-..."
-default_model = "gpt-4o"
+default_model = "deepseek-v4-flash"  # optional
 
 [[model_providers.openai.models]]
-model = "gpt-4o"
+model = "deepseek-v4-pro"
 
 [[model_providers.openai.models]]
-model = "gpt-4o-mini"
+model = "deepseek-v4-flash"
 
 # ── App Settings (optional) ─────────────────────────────────────
-enable_auxiliary_model = false     # use a second model for safety/summaries
-summary_model = "UseTurnModel"     # "UseTurnModel" or "UseAxiliaryModel"
-safety_policy_model = "UseAxiliaryModel"
-project_root_markers = [".git"]
+enable_auxiliary_model = false     # optional, use a second model for safety/summaries
+summary_model = "UseTurnModel"     # optional, "UseTurnModel" or "UseAxiliaryModel"
+safety_policy_model = "UseAxiliaryModel" # optional
+project_root_markers = [".git"] # optional
 
 [context]
-preserve_recent_turns = 3          # keep last N turns un-compacted
-auto_compact_percent = 90          # trigger compaction at N% of context window
-manual_compaction_enabled = true
+preserve_recent_turns = 3          # optional, keep last N turns un-compacted
+auto_compact_percent = 97          # optional, trigger compaction at N% of context window
+manual_compaction_enabled = true   # optional
 
 [server]
-listen = []                        # e.g. ["stdio://", "ws://127.0.0.1:3000"]
-max_connections = 32
-event_buffer_size = 1024
-idle_session_timeout_secs = 1800
-persist_ephemeral_sessions = false
+listen = []                        # optional, e.g. ["stdio://", "ws://127.0.0.1:3000"]
+max_connections = 32               # optional
+event_buffer_size = 1024           # optional
+idle_session_timeout_secs = 1800   # optional
+persist_ephemeral_sessions = false # optional
 
 [logging]
-level = "info"                     # trace, debug, info, warn, error
-json = false                       # emit JSON-formatted logs
-redact_secrets_in_logs = true
+level = "info"                     # optional, trace, debug, info, warn, error
+json = false                       # optional, emit JSON-formatted logs
+redact_secrets_in_logs = true      # optional
 
 [logging.file]
-directory = "logs"                 # relative to DEVO_HOME
-filename_prefix = "devo"
-rotation = "Daily"                 # Never | Minutely | Hourly | Daily
-max_files = 14
+directory = "logs"                 # optional, relative to DEVO_HOME
+filename_prefix = "devo"           # optional
+rotation = "Daily"                 # optional, Never | Minutely | Hourly | Daily
+max_files = 14                     # optional
 
 [skills]
-enabled = true
-user_roots = ["skills"]            # dirs to scan for user skills
-workspace_roots = ["skills"]       # dirs to scan for workspace skills
-watch_for_changes = true
+enabled = true                     # optional
+user_roots = ["skills"]            # optional, dirs to scan for user skills
+workspace_roots = ["skills"]       # optional, dirs to scan for workspace skills
+watch_for_changes = true           # optional
 
 [updates]
-enabled = true
-check_on_startup = true
-check_interval_hours = 24
+enabled = true                     # optional
+check_on_startup = true            # optional
+check_interval_hours = 24          # optional
 ```
 
 ### Model Catalog (`~/.devo/models.json`)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,146 @@ cargo build --release
 > [!TIP]
 > Make sure you have Rust installed, 1.75+ recommended (via https://rustup.rs/).
 
+## ⚙️ Configuration
+
+Devo reads configuration from a TOML file, merged with higher-priority sources
+overriding lower-priority ones:
+
+1. Built-in defaults (compiled into the binary)
+2. `DEVO_HOME/config.toml` — user-level config (defaults to `~/.devo/config.toml`)
+3. `<workspace>/.devo/config.toml` — project-level config
+4. CLI flags — command-line overrides
+
+Both config files are optional. A minimal config file only needs a provider
+section so devo knows which model to use. Run `devo onboard` for an interactive
+setup that writes this for you.
+
+### Minimal Config Example
+
+```toml
+# ~/.devo/config.toml
+model = "deepseek-v4-flash"
+model_provider = "api.deepseek.com"
+model_thinking_selection = "high"
+
+[model_providers."api.deepseek.com"]
+name = "api.deepseek.com"
+api_key = "sk-0b7b2422983141e5973d1fc3eccf0822"
+base_url = "https://api.deepseek.com"
+wire_api = "openai_chat_completions"
+
+[[model_providers."api.deepseek.com".models]]
+model = "deepseek-v4-pro"
+
+[[model_providers."api.deepseek.com".models]]
+model = "deepseek-v4-flash"
+```
+
+### Full Config Reference
+
+```toml
+# ── Model Provider (required) ───────────────────────────────────
+model_provider = "openai"          # active provider id
+model = "gpt-4o"                   # active model slug
+model_thinking_selection = "high"   # optional: thinking/reasoning effort
+model_auto_compact_token_limit = 970000   # optional
+model_context_window = 128000      # optional
+disable_response_storage = false   # optional
+preferred_auth_method = "apikey"   # optional: "apikey"
+
+# ── Provider Profiles ───────────────────────────────────────────
+[model_providers.openai]
+name = "OpenAI"
+base_url = "https://api.openai.com/v1"
+wire_api = "openai_chat_completions"   # openai_chat_completions | openai_responses | anthropic_messages
+api_key = "sk-..."
+default_model = "gpt-4o"
+
+[[model_providers.openai.models]]
+model = "gpt-4o"
+
+[[model_providers.openai.models]]
+model = "gpt-4o-mini"
+
+# ── App Settings (optional) ─────────────────────────────────────
+enable_auxiliary_model = false     # use a second model for safety/summaries
+summary_model = "UseTurnModel"     # "UseTurnModel" or "UseAxiliaryModel"
+safety_policy_model = "UseAxiliaryModel"
+project_root_markers = [".git"]
+
+[context]
+preserve_recent_turns = 3          # keep last N turns un-compacted
+auto_compact_percent = 90          # trigger compaction at N% of context window
+manual_compaction_enabled = true
+
+[server]
+listen = []                        # e.g. ["stdio://", "ws://127.0.0.1:3000"]
+max_connections = 32
+event_buffer_size = 1024
+idle_session_timeout_secs = 1800
+persist_ephemeral_sessions = false
+
+[logging]
+level = "info"                     # trace, debug, info, warn, error
+json = false                       # emit JSON-formatted logs
+redact_secrets_in_logs = true
+
+[logging.file]
+directory = "logs"                 # relative to DEVO_HOME
+filename_prefix = "devo"
+rotation = "Daily"                 # Never | Minutely | Hourly | Daily
+max_files = 14
+
+[skills]
+enabled = true
+user_roots = ["skills"]            # dirs to scan for user skills
+workspace_roots = ["skills"]       # dirs to scan for workspace skills
+watch_for_changes = true
+
+[updates]
+enabled = true
+check_on_startup = true
+check_interval_hours = 24
+```
+
+### Model Catalog (`~/.devo/models.json`)
+
+A separate JSON file defines available models and their capabilities. On first
+run, the built-in catalog is automatically copied to `~/.devo/models.json` so
+you can customize it. Models are organized by `channel` (brand/vendor).
+
+```json
+[
+  {
+    "slug": "deepseek-v4-pro",
+    "display_name": "deepseek-v4-pro",
+    "channel": "DeepSeek",
+    "provider_family": "openai",
+    "description": "DeepSeek v4 pro model",
+    "context_window": 1000000,
+    "max_tokens": 384000,
+    "thinking_capability": "toggle",
+    "supported_reasoning_levels": ["high", "max"],
+    "base_instructions": "You are Devo, a coding agent based on DeepSeek...",
+    "input_modalities": ["text"],
+    "priority": 10
+  }
+]
+```
+
+Merge order: builtin defaults < `~/.devo/models.json` < `<workspace>/.devo/models.json`,
+merged by model `slug`. You can override existing entries (e.g. change prompts or
+context window) or add custom models.
+
+The `/model` slash command in the TUI shows only models you have configured
+with credentials in `config.toml`, not the full catalog.
+
+### Environment Variables
+
+| Variable      | Purpose                                       |
+|---------------|-----------------------------------------------|
+| `DEVO_HOME`   | Override the config directory (default: `~/.devo`) |
+
 ## FAQ
 
 ### How is this different from Claude Code?

--- a/crates/cli/src/agent_command.rs
+++ b/crates/cli/src/agent_command.rs
@@ -11,6 +11,7 @@ use devo_tui::InitialTuiSession;
 use devo_tui::InteractiveTuiConfig;
 use devo_tui::SavedModelEntry;
 use devo_tui::run_interactive_tui;
+use devo_utils::find_devo_home;
 
 /// Runs the interactive coding-agent entrypoint.
 ///
@@ -20,7 +21,8 @@ use devo_tui::run_interactive_tui;
 /// for this session without mutating the stored provider config.
 pub(crate) async fn run_agent(force_onboarding: bool, log_level: Option<&str>) -> Result<()> {
     let cwd = std::env::current_dir()?;
-    let model_catalog = PresetModelCatalog::load()?;
+    let config_home = find_devo_home().context("could not determine devo home directory")?;
+    let model_catalog = PresetModelCatalog::load_from_config(&config_home, Some(&cwd))?;
     let stored_config = load_config().unwrap_or_default();
     let (onboarding_mode, resolved) =
         resolve_initial_provider_settings(force_onboarding, &stored_config, &model_catalog)?;

--- a/crates/cli/src/prompt_command.rs
+++ b/crates/cli/src/prompt_command.rs
@@ -53,7 +53,7 @@ pub(crate) async fn run_prompt(
         std::sync::Arc::new(reg)
     };
     let runtime = ToolRuntime::new_without_permissions(std::sync::Arc::clone(&registry));
-    let model_catalog = PresetModelCatalog::load()?;
+    let model_catalog = PresetModelCatalog::load_from_config(&home_dir, Some(&cwd))?;
 
     let turn_config = devo_core::TurnConfig {
         model: model_catalog

--- a/crates/client/src/stdio.rs
+++ b/crates/client/src/stdio.rs
@@ -13,6 +13,10 @@ use devo_protocol::ClientTransportKind;
 use devo_protocol::ErrorResponse;
 use devo_protocol::InitializeParams;
 use devo_protocol::InitializeResult;
+use devo_protocol::ModelCatalogParams;
+use devo_protocol::ModelCatalogResult;
+use devo_protocol::ModelSavedParams;
+use devo_protocol::ModelSavedResult;
 use devo_protocol::NotificationEnvelope;
 use devo_protocol::ProtocolErrorCode;
 use devo_protocol::ServerEvent;
@@ -198,6 +202,17 @@ impl StdioServerClient {
         params: SkillChangedParams,
     ) -> Result<SkillChangedResult> {
         self.request("skills/changed", params).await
+    }
+
+    pub async fn model_catalog(
+        &mut self,
+        params: ModelCatalogParams,
+    ) -> Result<ModelCatalogResult> {
+        self.request("model/catalog", params).await
+    }
+
+    pub async fn model_saved(&mut self, params: ModelSavedParams) -> Result<ModelSavedResult> {
+        self.request("model/saved", params).await
     }
 
     pub async fn turn_start(&mut self, params: TurnStartParams) -> Result<TurnStartResult> {

--- a/crates/core/models.json
+++ b/crates/core/models.json
@@ -2,6 +2,7 @@
     {
         "slug": "qwen3-coder-next",
         "display_name": "qwen3-coder-next",
+        "channel": "Qwen",
         "provider_family": "openai",
         "description": "3B activated parameters (80B total parameters) released at 02/2026 by Qwen",
         "thinking_capability": "unsupported",
@@ -25,6 +26,7 @@
     {
         "slug": "kimi-k2.5",
         "display_name": "kimi-k2.5",
+        "channel": "Kimi",
         "provider_family": "openai",
         "description": "An open-weight, native multimodal agentic model, 3B activated parameters (80B total parameters) released at 2026 by moonshot",
         "thinking_capability": "toggle",
@@ -73,6 +75,7 @@
     {
         "slug": "minimax-m2.7",
         "display_name": "minimax-m2.7",
+        "channel": "MiniMax",
         "provider_family": "openai",
         "description": "229B open-weight model released at 04/2026 by minimax",
         "thinking_capability": "unsupported",
@@ -96,6 +99,7 @@
     {
         "slug": "glm-5.1",
         "display_name": "glm-5.1",
+        "channel": "GLM",
         "provider_family": "openai",
         "description": "754B flagship open-weight model released at 04/2026 by z.ai",
         "thinking_capability": "toggle",
@@ -143,6 +147,7 @@
     {
         "slug": "deepseek-v4-flash",
         "display_name": "deepseek-v4-flash",
+        "channel": "DeepSeek",
         "provider_family": "openai",
         "description": "deepseek v4 flash model released by deepseek at 2026.",
         "thinking_capability": "toggle",
@@ -163,6 +168,7 @@
     {
         "slug": "deepseek-v4-pro",
         "display_name": "deepseek-v4-pro",
+        "channel": "DeepSeek",
         "provider_family": "openai",
         "description": "deepseek v4 pro model released by deepseek at 2026.",
         "thinking_capability": "toggle",

--- a/crates/core/src/model_catalog.rs
+++ b/crates/core/src/model_catalog.rs
@@ -10,7 +10,7 @@
 //! - catalog loading stays in `devo-core` because the embedded assets live here
 //! - this module is the bridge between raw preset/config data and runtime model consumers
 //! - models are sorted and materialized here so downstream code can work only with resolved `Model`
-//! - the layered merge order is: builtin < ~/.devo/models.json < <workspace>/.devo/models.json
+//! - the layered merge order is: builtin < ~/.devo/models.json < `<workspace>/.devo/models.json`
 //!
 //! Boundary:
 //! - this module should not define the runtime model shape itself; that lives in `devo-protocol`

--- a/crates/core/src/model_catalog.rs
+++ b/crates/core/src/model_catalog.rs
@@ -2,6 +2,7 @@
 //!
 //! Main focus:
 //! - load the bundled preset list from disk-independent embedded assets
+//! - load per-user and per-project model overrides from the filesystem
 //! - convert raw `ModelPreset` values into runtime `Model` values
 //! - provide the concrete builtin implementation of the shared `ModelCatalog` trait
 //!
@@ -9,27 +10,66 @@
 //! - catalog loading stays in `devo-core` because the embedded assets live here
 //! - this module is the bridge between raw preset/config data and runtime model consumers
 //! - models are sorted and materialized here so downstream code can work only with resolved `Model`
+//! - the layered merge order is: builtin < ~/.devo/models.json < <workspace>/.devo/models.json
 //!
 //! Boundary:
 //! - this module should not define the runtime model shape itself; that lives in `devo-protocol`
 //! - serde compatibility for the raw preset file belongs in `model_preset.rs`
 //! - execution logic should depend on `ModelCatalog` and `Model`, not on how this module reads JSON
 //!
+use std::path::Path;
+
 use crate::{Model, ModelCatalog, ModelError, ModelPreset};
 
 const DEFAULT_BASE_INSTRUCTIONS: &str = include_str!("../default_base_instructions.txt");
+const BUILTIN_MODELS_JSON: &str = include_str!("../models.json");
 
 /// Filesystem-independent loader for the built-in model catalog bundled with the binary.
+///
+/// Use [`PresetModelCatalog::load_from_config`] to include user and project overrides.
+/// Use [`PresetModelCatalog::load`] for the builtin-only variant (tests, doctor, etc.).
 #[derive(Debug, Clone, Default)]
 pub struct PresetModelCatalog {
     models: Vec<Model>,
 }
 
 impl PresetModelCatalog {
-    /// Loads the built-in catalog from `crates/core/models.json`.
+    /// Loads the built-in catalog only (no filesystem overrides).
     pub fn load() -> Result<Self, PresetModelCatalogError> {
         Ok(Self {
             models: load_builtin_models()?,
+        })
+    }
+
+    /// Loads the effective catalog from three layers, merged highest-wins:
+    /// 1. built-in models (embedded)
+    /// 2. `config_home/models.json` (user overrides)
+    /// 3. `<workspace_root>/.devo/models.json` (project overrides)
+    ///
+    /// If the user file does not exist it is seeded from the builtin list so
+    /// users can discover and customize the catalog.
+    pub fn load_from_config(
+        config_home: &Path,
+        workspace_root: Option<&Path>,
+    ) -> Result<Self, PresetModelCatalogError> {
+        seed_user_models_file(config_home);
+
+        let mut presets = load_builtin_model_presets()?;
+
+        if let Some(user_overrides) = load_models_from_file(&config_home.join("models.json")) {
+            presets = merge_model_presets(presets, user_overrides);
+        }
+
+        if let Some(workspace_root) = workspace_root {
+            let project_path = workspace_root.join(".devo").join("models.json");
+            if let Some(project_overrides) = load_models_from_file(&project_path) {
+                presets = merge_model_presets(presets, project_overrides);
+            }
+        }
+
+        presets.sort_by(|left, right| right.priority.cmp(&left.priority));
+        Ok(Self {
+            models: presets.into_iter().map(Model::from).collect(),
         })
     }
 
@@ -70,7 +110,7 @@ impl ModelCatalog for PresetModelCatalog {
 
 /// Loads the built-in raw model preset list bundled with the crate.
 pub fn load_builtin_model_presets() -> Result<Vec<ModelPreset>, PresetModelCatalogError> {
-    serde_json::from_str(include_str!("../models.json")).map_err(Into::into)
+    serde_json::from_str(BUILTIN_MODELS_JSON).map_err(Into::into)
 }
 
 /// Loads the built-in model list bundled with the crate.
@@ -78,6 +118,41 @@ pub fn load_builtin_models() -> Result<Vec<Model>, PresetModelCatalogError> {
     let mut presets = load_builtin_model_presets()?;
     presets.sort_by(|left, right| right.priority.cmp(&left.priority));
     Ok(presets.into_iter().map(Model::from).collect())
+}
+
+/// Reads model presets from a filesystem JSON path. Returns `None` if the file
+/// does not exist, and a parse error if the file exists but is invalid.
+fn load_models_from_file(path: &Path) -> Option<Vec<ModelPreset>> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    if contents.trim().is_empty() {
+        return Some(Vec::new());
+    }
+    Some(serde_json::from_str(&contents).unwrap_or_default())
+}
+
+/// Merges two model lists by slug. Entries from `overlay` replace matching
+/// entries in `base`; entries with new slugs are appended.
+fn merge_model_presets(mut base: Vec<ModelPreset>, overlay: Vec<ModelPreset>) -> Vec<ModelPreset> {
+    for entry in overlay {
+        match base.iter_mut().find(|m| m.slug == entry.slug) {
+            Some(existing) => *existing = entry,
+            None => base.push(entry),
+        }
+    }
+    base
+}
+
+/// Copies the built-in `models.json` to the user config directory if no user
+/// file exists yet.
+fn seed_user_models_file(config_home: &Path) {
+    let user_path = config_home.join("models.json");
+    if user_path.exists() {
+        return;
+    }
+    if let Some(parent) = user_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&user_path, BUILTIN_MODELS_JSON);
 }
 
 /// Returns the shared fallback base instructions used when a model has no catalog entry.
@@ -95,13 +170,35 @@ pub enum PresetModelCatalogError {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use pretty_assertions::assert_eq;
 
     use super::{
         PresetModelCatalog, default_base_instructions, load_builtin_model_presets,
-        load_builtin_models,
+        load_builtin_models, merge_model_presets,
     };
-    use crate::ModelCatalog;
+    use crate::{ModelCatalog, ModelPreset};
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("devo-{name}-{nanos}"));
+        std::fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    fn make_preset(slug: &str, display_name: &str, priority: i32) -> ModelPreset {
+        ModelPreset {
+            slug: slug.into(),
+            display_name: display_name.into(),
+            priority,
+            ..ModelPreset::default()
+        }
+    }
 
     #[test]
     fn builtin_model_presets_load_from_bundled_json() {
@@ -129,5 +226,101 @@ mod tests {
     #[test]
     fn default_base_instructions_are_available() {
         assert!(!default_base_instructions().trim().is_empty());
+    }
+
+    #[test]
+    fn merge_by_slug_overrides_existing() {
+        let base = vec![make_preset("a", "Base A", 10)];
+        let overlay = vec![make_preset("a", "Overlay A", 20)];
+        let merged = merge_model_presets(base, overlay);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].display_name, "Overlay A");
+        assert_eq!(merged[0].priority, 20);
+    }
+
+    #[test]
+    fn merge_by_slug_appends_new() {
+        let base = vec![make_preset("a", "A", 10)];
+        let overlay = vec![make_preset("b", "B", 20)];
+        let merged = merge_model_presets(base, overlay);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].slug, "a");
+        assert_eq!(merged[1].slug, "b");
+    }
+
+    #[test]
+    fn merge_empty_overlay_does_nothing() {
+        let base = vec![make_preset("a", "A", 10)];
+        let merged = merge_model_presets(base, Vec::new());
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].display_name, "A");
+    }
+
+    #[test]
+    fn load_from_config_returns_builtin_when_no_filesystem_files() {
+        let root = unique_temp_dir("catalog-builtin-only");
+        let home = root.join("home").join(".devo");
+        std::fs::create_dir_all(&home).expect("create home");
+
+        let catalog =
+            PresetModelCatalog::load_from_config(&home, /*workspace_root*/ None).expect("load");
+        let models = catalog.into_inner();
+        assert!(!models.is_empty());
+        assert_eq!(models[0].slug, "qwen3-coder-next");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn load_from_config_seeds_user_file_when_missing() {
+        let root = unique_temp_dir("catalog-seed");
+        let home = root.join("home").join(".devo");
+        std::fs::create_dir_all(&home).expect("create home");
+
+        let user_file = home.join("models.json");
+        assert!(!user_file.exists());
+
+        let _catalog =
+            PresetModelCatalog::load_from_config(&home, /*workspace_root*/ None).expect("load");
+
+        assert!(user_file.exists());
+        let contents = std::fs::read_to_string(&user_file).expect("read");
+        assert!(contents.contains("qwen3-coder-next"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn load_from_config_does_not_overwrite_existing_user_file() {
+        let root = unique_temp_dir("catalog-no-overwrite");
+        let home = root.join("home").join(".devo");
+        std::fs::create_dir_all(&home).expect("create home");
+
+        let user_file = home.join("models.json");
+        std::fs::write(
+            &user_file,
+            "[{\"slug\":\"custom\",\"display_name\":\"Custom\"}]",
+        )
+        .expect("write");
+
+        let catalog =
+            PresetModelCatalog::load_from_config(&home, /*workspace_root*/ None).expect("load");
+        let models = catalog.into_inner();
+
+        assert!(models.iter().any(|m| m.slug == "custom"));
+        assert!(models.iter().any(|m| m.slug == "qwen3-coder-next"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn builtin_models_have_channel_fields() {
+        let models = load_builtin_models().expect("load builtin models");
+        let deepseek_models: Vec<_> = models
+            .iter()
+            .filter(|m| m.channel.as_deref() == Some("DeepSeek"))
+            .collect();
+        assert!(!deepseek_models.is_empty());
+        assert!(deepseek_models.iter().any(|m| m.slug == "deepseek-v4-pro"));
     }
 }

--- a/crates/core/src/model_preset.rs
+++ b/crates/core/src/model_preset.rs
@@ -75,6 +75,8 @@ pub struct ModelPreset {
     pub input_modalities: Vec<InputModality>,
     /// Whether the model supports original-resolution image detail.
     pub supports_image_detail_original: bool,
+    /// Grouping label used to organize models by vendor or family.
+    pub channel: Option<String>,
     /// Whether the user configured API access for this model.
     #[serde(rename = "supported_in_api")]
     pub api_configured: bool,
@@ -107,6 +109,7 @@ impl Default for ModelPreset {
             truncation_policy: TruncationPolicyConfig::default(),
             input_modalities: vec![InputModality::default()],
             supports_image_detail_original: false,
+            channel: None,
             api_configured: false,
             temperature: None,
             top_p: None,
@@ -148,6 +151,7 @@ impl From<ModelPreset> for Model {
             truncation_policy: value.truncation_policy,
             input_modalities: value.input_modalities,
             supports_image_detail_original: value.supports_image_detail_original,
+            channel: value.channel,
             temperature: value.temperature,
             top_p: value.top_p,
             top_k: value.top_k,

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -1377,6 +1377,7 @@ mod tests {
             },
             input_modalities: vec![],
             supports_image_detail_original: false,
+            channel: None,
             temperature: None,
             top_p: None,
             top_k: None,

--- a/crates/protocol/src/connection.rs
+++ b/crates/protocol/src/connection.rs
@@ -45,4 +45,6 @@ pub struct ServerCapabilities {
     pub turn_interrupt: bool,
     pub approval_requests: bool,
     pub event_streaming: bool,
+    pub model_catalog: bool,
+    pub model_saved: bool,
 }

--- a/crates/protocol/src/model.rs
+++ b/crates/protocol/src/model.rs
@@ -213,6 +213,8 @@ pub struct Model {
     pub input_modalities: Vec<InputModality>,
     /// Whether the model supports original-resolution image detail.
     pub supports_image_detail_original: bool,
+    /// Grouping label used to organize models by vendor or family.
+    pub channel: Option<String>,
     /// Default temperature to use when the model does not override it.
     pub temperature: Option<f64>,
     /// Default nucleus sampling value to use when the model does not override it.
@@ -239,6 +241,7 @@ impl Default for Model {
             truncation_policy: TruncationPolicyConfig::default(),
             input_modalities: vec![InputModality::default()],
             supports_image_detail_original: false,
+            channel: None,
             temperature: None,
             top_p: None,
             top_k: None,
@@ -503,6 +506,67 @@ pub enum ModelError {
     NoVisibleModels,
 }
 
+// ── model/catalog API ───────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ModelCatalogParams {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelCatalogResult {
+    pub models: Vec<ModelCatalogEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelCatalogEntry {
+    pub slug: String,
+    pub display_name: String,
+    pub channel: Option<String>,
+    pub description: Option<String>,
+    pub provider: ProviderWireApi,
+    pub context_window: u32,
+    pub thinking_capability: ThinkingCapability,
+    pub input_modalities: Vec<InputModality>,
+    pub max_tokens: Option<u32>,
+}
+
+impl From<&Model> for ModelCatalogEntry {
+    fn from(m: &Model) -> Self {
+        Self {
+            slug: m.slug.clone(),
+            display_name: m.display_name.clone(),
+            channel: m.channel.clone(),
+            description: m.description.clone(),
+            provider: m.provider,
+            context_window: m.context_window,
+            thinking_capability: m.thinking_capability.clone(),
+            input_modalities: m.input_modalities.clone(),
+            max_tokens: m.max_tokens,
+        }
+    }
+}
+
+// ── model/saved API ─────────────────────────────────────────────────
+
+/// Lists models that have been configured with credentials in `config.toml`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ModelSavedParams {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelSavedResult {
+    pub models: Vec<ModelSavedEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelSavedEntry {
+    pub slug: String,
+    pub display_name: String,
+    pub channel: Option<String>,
+    pub description: Option<String>,
+    pub provider_id: String,
+    pub wire_api: ProviderWireApi,
+    pub context_window: u32,
+}
+
 #[cfg(test)]
 mod tests {
     use crate::RequestRole;
@@ -538,6 +602,7 @@ mod tests {
             },
             input_modalities: vec![InputModality::Text],
             supports_image_detail_original: false,
+            channel: None,
             temperature: None,
             top_p: None,
             top_k: None,

--- a/crates/server/src/bootstrap.rs
+++ b/crates/server/src/bootstrap.rs
@@ -70,7 +70,10 @@ pub async fn run_server_process(args: ServerProcessArgs) -> Result<()> {
 
     let registry = handlers::build_registry_from_plan(&ToolPlanConfig::default());
     let provider = load_server_provider(&resolver.user_config_file(), None)?;
-    let model_catalog: Arc<dyn ModelCatalog> = Arc::new(PresetModelCatalog::load()?);
+    let model_catalog: Arc<dyn ModelCatalog> = Arc::new(PresetModelCatalog::load_from_config(
+        &resolver.user_config_dir(),
+        args.working_root.as_deref(),
+    )?);
     let skill_workspace_root = args.working_root.clone();
     let project_skill_base = skill_workspace_root
         .as_deref()
@@ -124,6 +127,7 @@ pub async fn run_server_process(args: ServerProcessArgs) -> Result<()> {
             skill_catalog,
             config.agents_md_config(),
             db,
+            resolver.user_config_file(),
         ),
     );
     tracing::info!("starting persisted session restore");

--- a/crates/server/src/execution.rs
+++ b/crates/server/src/execution.rs
@@ -56,6 +56,8 @@ pub struct ServerRuntimeDependencies {
     pub(crate) agents_md: AgentsMdConfig,
     /// SQLite database for session metadata, token stats, and pending queues.
     pub(crate) db: Arc<Database>,
+    /// Path to user config.toml used for listing configured models.
+    pub(crate) config_file: PathBuf,
 }
 
 impl ServerRuntimeDependencies {
@@ -70,6 +72,7 @@ impl ServerRuntimeDependencies {
         skill_catalog: Box<dyn SkillCatalog + Send>,
         agents_md: AgentsMdConfig,
         db: Arc<Database>,
+        config_file: PathBuf,
     ) -> Self {
         Self {
             provider,
@@ -80,6 +83,7 @@ impl ServerRuntimeDependencies {
             skill_catalog: StdMutex::new(skill_catalog),
             agents_md,
             db,
+            config_file,
         }
     }
 

--- a/crates/server/src/protocol.rs
+++ b/crates/server/src/protocol.rs
@@ -1,5 +1,7 @@
 pub use devo_protocol::{
-    ClientNotification, ClientRequest, ErrorResponse, NotificationEnvelope, ProtocolError,
-    ProtocolErrorCode, ServerRequestEnvelope, SkillChangedParams, SkillChangedResult,
-    SkillListParams, SkillListResult, SkillRecord, SkillSource, SuccessResponse,
+    ClientNotification, ClientRequest, ErrorResponse, ModelCatalogEntry, ModelCatalogParams,
+    ModelCatalogResult, ModelSavedEntry, ModelSavedParams, ModelSavedResult, NotificationEnvelope,
+    ProtocolError, ProtocolErrorCode, ServerRequestEnvelope, SkillChangedParams,
+    SkillChangedResult, SkillListParams, SkillListResult, SkillRecord, SkillSource,
+    SuccessResponse,
 };

--- a/crates/server/src/runtime.rs
+++ b/crates/server/src/runtime.rs
@@ -2380,7 +2380,13 @@ impl ServerRuntime {
                     QueryEvent::TurnComplete { .. } => {}
                 }
             }
-            if let (Some(item_id), Some(item_seq)) = (assistant_item_id, assistant_item_seq) {
+            // Complete any deferred items that the interrupt handler didn't already take.
+            // handle_interrupt takes deferred_assistant/deferred_reasoning from the session
+            // and completes them; if they're already None we must skip to avoid persisting duplicates.
+            if let Some((item_id, item_seq, text)) = {
+                let mut session = event_session_arc.lock().await;
+                session.deferred_assistant.take()
+            } {
                 runtime
                     .complete_item(
                         session_id,
@@ -2388,14 +2394,15 @@ impl ServerRuntime {
                         item_id,
                         item_seq,
                         ItemKind::AgentMessage,
-                        TurnItem::AgentMessage(TextItem {
-                            text: assistant_text.clone(),
-                        }),
-                        serde_json::json!({ "title": "Assistant", "text": assistant_text }),
+                        TurnItem::AgentMessage(TextItem { text: text.clone() }),
+                        serde_json::json!({ "title": "Assistant", "text": text }),
                     )
                     .await;
             }
-            if let (Some(item_id), Some(item_seq)) = (reasoning_item_id, reasoning_item_seq) {
+            if let Some((item_id, item_seq, text)) = {
+                let mut session = event_session_arc.lock().await;
+                session.deferred_reasoning.take()
+            } {
                 runtime
                     .complete_item(
                         session_id,
@@ -2403,10 +2410,8 @@ impl ServerRuntime {
                         item_id,
                         item_seq,
                         ItemKind::Reasoning,
-                        TurnItem::Reasoning(TextItem {
-                            text: reasoning_text.clone(),
-                        }),
-                        serde_json::json!({ "title": "Reasoning", "text": reasoning_text }),
+                        TurnItem::Reasoning(TextItem { text: text.clone() }),
+                        serde_json::json!({ "title": "Reasoning", "text": text }),
                     )
                     .await;
             }

--- a/crates/server/src/runtime.rs
+++ b/crates/server/src/runtime.rs
@@ -97,6 +97,7 @@ use crate::titles::build_title_generation_request;
 use crate::titles::derive_provisional_title;
 use crate::titles::normalize_generated_title;
 
+mod model_api;
 mod skills;
 
 pub struct ServerRuntime {
@@ -130,6 +131,8 @@ impl ServerRuntime {
                     turn_interrupt: true,
                     approval_requests: true,
                     event_streaming: true,
+                    model_catalog: true,
+                    model_saved: true,
                 },
             },
             deps,
@@ -462,6 +465,8 @@ impl ServerRuntime {
             "session/compact" => Some(self.handle_session_compact(id?, params).await),
             "skills/list" => Some(self.handle_skills_list(id?, params).await),
             "skills/changed" => Some(self.handle_skills_changed(id?, params).await),
+            "model/catalog" => Some(self.handle_model_catalog(id?, params).await),
+            "model/saved" => Some(self.handle_model_saved(id?, params).await),
             "turn/start" => Some(self.handle_turn_start(id?, params).await),
             "turn/interrupt" => Some(self.handle_turn_interrupt(id?, params).await),
             "turn/steer" => Some(self.handle_turn_steer(connection_id, id?, params).await),

--- a/crates/server/src/runtime/model_api.rs
+++ b/crates/server/src/runtime/model_api.rs
@@ -1,0 +1,95 @@
+use devo_core::ModelCatalogEntry;
+use devo_core::ModelCatalogParams;
+use devo_core::ModelCatalogResult;
+use devo_core::ModelSavedEntry;
+use devo_core::ModelSavedParams;
+use devo_core::ModelSavedResult;
+use devo_core::ProviderConfigFile;
+use devo_core::ProviderWireApi;
+use devo_core::parse_config_str;
+
+use crate::{ProtocolErrorCode, SuccessResponse};
+
+use super::ServerRuntime;
+
+impl ServerRuntime {
+    pub(super) async fn handle_model_catalog(
+        &self,
+        request_id: serde_json::Value,
+        params: serde_json::Value,
+    ) -> serde_json::Value {
+        if let Err(error) = serde_json::from_value::<ModelCatalogParams>(params) {
+            return self.error_response(
+                request_id,
+                ProtocolErrorCode::InvalidParams,
+                format!("invalid model/catalog params: {error}"),
+            );
+        }
+
+        let catalog = &self.deps.model_catalog;
+        let models: Vec<ModelCatalogEntry> = catalog
+            .list_visible()
+            .into_iter()
+            .map(ModelCatalogEntry::from)
+            .collect();
+
+        serde_json::to_value(SuccessResponse {
+            id: request_id,
+            result: ModelCatalogResult { models },
+        })
+        .expect("serialize model/catalog response")
+    }
+
+    pub(super) async fn handle_model_saved(
+        &self,
+        request_id: serde_json::Value,
+        params: serde_json::Value,
+    ) -> serde_json::Value {
+        if let Err(error) = serde_json::from_value::<ModelSavedParams>(params) {
+            return self.error_response(
+                request_id,
+                ProtocolErrorCode::InvalidParams,
+                format!("invalid model/saved params: {error}"),
+            );
+        }
+
+        let config = if self.deps.config_file.exists() {
+            match std::fs::read_to_string(&self.deps.config_file) {
+                Ok(contents) => parse_config_str(&contents).unwrap_or_default(),
+                Err(_) => ProviderConfigFile::default(),
+            }
+        } else {
+            ProviderConfigFile::default()
+        };
+
+        let catalog = &self.deps.model_catalog;
+        let mut models = Vec::new();
+
+        for (provider_id, provider_config) in &config.model_providers {
+            let wire_api = provider_config
+                .wire_api
+                .unwrap_or(ProviderWireApi::OpenAIChatCompletions);
+            for configured in &provider_config.models {
+                let slug = configured.model.clone();
+                let catalog_model = catalog.get(&slug);
+                models.push(ModelSavedEntry {
+                    slug: slug.clone(),
+                    display_name: catalog_model
+                        .map(|m| m.display_name.clone())
+                        .unwrap_or_else(|| slug.clone()),
+                    channel: catalog_model.and_then(|m| m.channel.clone()),
+                    description: catalog_model.and_then(|m| m.description.clone()),
+                    provider_id: provider_id.clone(),
+                    wire_api,
+                    context_window: catalog_model.map(|m| m.context_window).unwrap_or(200_000),
+                });
+            }
+        }
+
+        serde_json::to_value(SuccessResponse {
+            id: request_id,
+            result: ModelSavedResult { models },
+        })
+        .expect("serialize model/saved response")
+    }
+}

--- a/crates/server/tests/end_to_end.rs
+++ b/crates/server/tests/end_to_end.rs
@@ -211,6 +211,7 @@ async fn websocket_listener_supports_handshake_subscription_and_turn_lifecycle()
             Box::new(FileSystemSkillCatalog::new(SkillsConfig::default())),
             devo_core::AgentsMdConfig::default(),
             db,
+            std::env::temp_dir().join("config.toml"),
         ),
     );
     let listen = vec![format!("ws://{bind_address}")];

--- a/crates/server/tests/persistence_resume.rs
+++ b/crates/server/tests/persistence_resume.rs
@@ -1,17 +1,20 @@
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::task;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use futures::stream;
+use futures::stream::{self, Stream};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Duration, timeout};
 
 use devo_core::{FileSystemSkillCatalog, PresetModelCatalog, SkillsConfig};
 use devo_protocol::{
-    ModelRequest, ModelResponse, ResponseContent, ResponseMetadata, StopReason, StreamEvent, Usage,
+    ModelRequest, ModelResponse, ResponseContent, ResponseMetadata, SessionHistoryItemKind,
+    StopReason, StreamEvent, TurnStatus, Usage,
 };
 use devo_provider::ModelProviderSDK;
 use devo_server::{ClientTransportKind, ServerRuntime, ServerRuntimeDependencies};
@@ -99,6 +102,110 @@ impl ModelProviderSDK for CapturingProvider {
 
     fn name(&self) -> &str {
         "capturing-provider"
+    }
+}
+
+/// A stream that yields one TextDelta, then blocks on a oneshot until unblocked or
+/// cancelled, then yields MessageDone.  Used by tests that need to interrupt a turn
+/// mid-stream to exercise the deferred-item completion race.
+struct GatedStream {
+    block_rx: oneshot::Receiver<()>,
+    state: u8,
+}
+
+impl GatedStream {
+    fn new(block_rx: oneshot::Receiver<()>) -> Self {
+        Self { block_rx, state: 0 }
+    }
+}
+
+impl Stream for GatedStream {
+    type Item = Result<StreamEvent>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> task::Poll<Option<Self::Item>> {
+        match self.state {
+            0 => {
+                self.state = 1;
+                task::Poll::Ready(Some(Ok(StreamEvent::TextDelta {
+                    index: 0,
+                    text: "mid-interrupt content".into(),
+                })))
+            }
+            1 => match Pin::new(&mut self.block_rx).poll(cx) {
+                task::Poll::Ready(Ok(())) => {
+                    self.state = 2;
+                    task::Poll::Ready(Some(Ok(StreamEvent::MessageDone {
+                        response: ModelResponse {
+                            id: "resp-gated".into(),
+                            content: vec![ResponseContent::Text("mid-interrupt content".into())],
+                            stop_reason: Some(StopReason::EndTurn),
+                            usage: Usage::default(),
+                            metadata: ResponseMetadata::default(),
+                        },
+                    })))
+                }
+                task::Poll::Ready(Err(_)) => task::Poll::Ready(None),
+                task::Poll::Pending => task::Poll::Pending,
+            },
+            2 => {
+                self.state = 3;
+                task::Poll::Ready(None)
+            }
+            _ => task::Poll::Ready(None),
+        }
+    }
+}
+
+/// Provider whose stream blocks mid-way, letting the test send an interrupt while
+/// the assistant item is still in-progress.
+struct GatedProvider {
+    /// Kept alive so the oneshot receiver in GatedStream blocks forever
+    /// (or until the task is aborted, dropping the receiver).
+    _block_tx: Mutex<Option<oneshot::Sender<()>>>,
+    /// Receiver taken by the first completion_stream call.
+    block_rx: Mutex<Option<oneshot::Receiver<()>>>,
+}
+
+impl GatedProvider {
+    fn new() -> Self {
+        let (tx, rx) = oneshot::channel();
+        Self {
+            _block_tx: Mutex::new(Some(tx)),
+            block_rx: Mutex::new(Some(rx)),
+        }
+    }
+}
+
+#[async_trait]
+impl ModelProviderSDK for GatedProvider {
+    async fn completion(&self, _request: ModelRequest) -> Result<ModelResponse> {
+        Ok(ModelResponse {
+            id: "title-gated".into(),
+            content: vec![ResponseContent::Text("Gated title".to_string())],
+            stop_reason: Some(StopReason::EndTurn),
+            usage: Usage::default(),
+            metadata: ResponseMetadata::default(),
+        })
+    }
+
+    async fn completion_stream(
+        &self,
+        _request: ModelRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent>> + Send>>> {
+        let rx = self
+            .block_rx
+            .lock()
+            .expect("lock block_rx")
+            .take()
+            .expect("completion_stream called more than once");
+        Ok(Box::pin(GatedStream::new(rx)))
+    }
+
+    fn name(&self) -> &str {
+        "gated-provider"
     }
 }
 
@@ -1057,5 +1164,159 @@ async fn wait_for_notification_method(
     })
     .await
     .with_context(|| format!("timed out waiting for {method}"))??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn interrupt_mid_stream_does_not_duplicate_last_item_on_resume() -> Result<()> {
+    let data_root = TempDir::new()?;
+    let gated = Arc::new(GatedProvider::new());
+    let runtime = build_runtime_with_provider(data_root.path(), Arc::clone(&gated) as _)?;
+    let (connection_id, mut notifications_rx) = initialize_connection(&runtime).await?;
+
+    let start_response = runtime
+        .handle_incoming(
+            connection_id,
+            serde_json::json!({
+                "id": 1,
+                "method": "session/start",
+                "params": {
+                    "cwd": data_root.path(),
+                    "ephemeral": false,
+                    "title": null,
+                    "model": "test-model"
+                }
+            }),
+        )
+        .await
+        .context("session/start")?;
+    let session_id = serde_json::from_value::<
+        devo_server::SuccessResponse<devo_server::SessionStartResult>,
+    >(start_response)?
+    .result
+    .session
+    .session_id;
+
+    let turn_start_response = runtime
+        .handle_incoming(
+            connection_id,
+            serde_json::json!({
+                "id": 2,
+                "method": "turn/start",
+                "params": {
+                    "session_id": session_id,
+                    "input": [{ "type": "text", "text": "interrupt me" }],
+                    "model": null,
+                    "sandbox": null,
+                    "approval_policy": null,
+                    "cwd": null
+                }
+            }),
+        )
+        .await
+        .context("turn/start")?;
+    let turn_id = serde_json::from_value::<
+        devo_server::SuccessResponse<devo_server::TurnStartResult>,
+    >(turn_start_response)?
+    .result
+    .turn_id;
+
+    // Wait until the assistant item has started streaming.  The provider yields
+    // one TextDelta, then blocks, so once we see the delta notification we know
+    // deferred_assistant has been stored in the session.
+    wait_for_notification_method(&mut notifications_rx, "item/agentMessage/delta").await?;
+
+    // Now interrupt the turn while it is still in-progress.
+    let interrupt_response = runtime
+        .handle_incoming(
+            connection_id,
+            serde_json::json!({
+                "id": 3,
+                "method": "turn/interrupt",
+                "params": {
+                    "session_id": session_id,
+                    "turn_id": turn_id,
+                    "reason": "test duplicate bug"
+                }
+            }),
+        )
+        .await
+        .context("turn/interrupt")?;
+    let interrupt_result: devo_server::SuccessResponse<devo_server::TurnInterruptResult> =
+        serde_json::from_value(interrupt_response)?;
+    assert_eq!(interrupt_result.result.status, TurnStatus::Interrupted);
+
+    // The server broadcasts both turn/interrupted and turn/completed.
+    wait_for_notification_method(&mut notifications_rx, "turn/interrupted").await?;
+    wait_for_notification_method(&mut notifications_rx, "turn/completed").await?;
+
+    // Rebuild runtime (simulates restart) and resume the session.
+    let gated2 = Arc::new(GatedProvider::new());
+    let rebuilt = build_runtime_with_provider(data_root.path(), Arc::clone(&gated2) as _)?;
+    rebuilt.load_persisted_sessions().await?;
+    let (rebuilt_cid, _) = initialize_connection(&rebuilt).await?;
+
+    let resume_response = rebuilt
+        .handle_incoming(
+            rebuilt_cid,
+            serde_json::json!({
+                "id": 4,
+                "method": "session/resume",
+                "params": {
+                    "session_id": session_id
+                }
+            }),
+        )
+        .await
+        .context("session/resume")?;
+    let resume_result = serde_json::from_value::<
+        devo_server::SuccessResponse<devo_server::SessionResumeResult>,
+    >(resume_response)?
+    .result;
+
+    // The crucial assertion: no two consecutive items should have the same
+    // kind if they are Assistant or Reasoning — those are the types that
+    // were being duplicated by the event_task post-loop cleanup race.
+    let kinds: Vec<_> = resume_result
+        .history_items
+        .iter()
+        .map(|i| &i.kind)
+        .collect();
+    for window in kinds.windows(2) {
+        if window[0] == window[1] {
+            match window[0] {
+                SessionHistoryItemKind::Assistant | SessionHistoryItemKind::Reasoning => {
+                    anyhow::bail!(
+                        "duplicate consecutive {:?} items detected: indices {:?}",
+                        window[0],
+                        kinds
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(idx, k)| {
+                                if *k == window[0] { Some(idx) } else { None }
+                            })
+                            .collect::<Vec<_>>()
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Sanity: there should be exactly one User and one Assistant item.
+    let user_count = kinds
+        .iter()
+        .filter(|k| matches!(k, SessionHistoryItemKind::User))
+        .count();
+    let assistant_count = kinds
+        .iter()
+        .filter(|k| matches!(k, SessionHistoryItemKind::Assistant))
+        .count();
+    assert_eq!(user_count, 1, "expected exactly one User item");
+    assert_eq!(
+        assistant_count, 1,
+        "expected exactly one Assistant item, got history: {kinds:?}"
+    );
+
     Ok(())
 }

--- a/crates/server/tests/persistence_resume.rs
+++ b/crates/server/tests/persistence_resume.rs
@@ -944,6 +944,7 @@ fn build_runtime_with_provider(
             Box::new(FileSystemSkillCatalog::new(SkillsConfig::default())),
             devo_core::AgentsMdConfig::default(),
             db,
+            data_root.join("config.toml"),
         ),
     ))
 }

--- a/crates/server/tests/skills_integration.rs
+++ b/crates/server/tests/skills_integration.rs
@@ -157,6 +157,7 @@ fn build_runtime_with_registry(
             })),
             devo_core::AgentsMdConfig::default(),
             db,
+            data_root.join("config.toml"),
         ),
     )
 }

--- a/crates/tui/src/app_event.rs
+++ b/crates/tui/src/app_event.rs
@@ -103,6 +103,12 @@ pub(crate) enum AppEvent {
     /// Dismiss the terminal-title setup UI without changing config.
     TerminalTitleSetupCancelled,
 
+    #[allow(dead_code)]
+    /// Open the theme picker.
+    OpenThemePicker,
+    #[allow(dead_code)]
+    /// Apply a selected theme.
+    ThemeSelected { name: String },
     /// Result of computing a `/diff` command (ANSI-colored diff text).
     DiffResult(String),
 }

--- a/crates/tui/src/bottom_pane/app_link_view.rs
+++ b/crates/tui/src/bottom_pane/app_link_view.rs
@@ -6,6 +6,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Constraint;
 use ratatui::layout::Layout;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::widgets::Block;
@@ -75,10 +76,11 @@ pub(crate) struct AppLinkView {
     screen: AppLinkScreen,
     selected_action: usize,
     complete: bool,
+    accent_color: Color,
 }
 
 impl AppLinkView {
-    pub(crate) fn new(params: AppLinkViewParams, app_event_tx: AppEventSender) -> Self {
+    pub(crate) fn new(params: AppLinkViewParams, app_event_tx: AppEventSender, accent_color: Color) -> Self {
         let AppLinkViewParams {
             app_id,
             title,
@@ -106,6 +108,7 @@ impl AppLinkView {
             screen: AppLinkScreen::Link,
             selected_action: 0,
             complete: false,
+            accent_color,
         }
     }
 
@@ -469,6 +472,7 @@ impl crate::render::renderable::Renderable for AppLinkView {
                 &action_state,
                 action_rows.len().max(1),
                 "No actions",
+                self.accent_color,
             );
         }
 

--- a/crates/tui/src/bottom_pane/bottom_pane_view.rs
+++ b/crates/tui/src/bottom_pane/bottom_pane_view.rs
@@ -31,6 +31,10 @@ pub(crate) trait BottomPaneView: Renderable {
         None
     }
 
+    fn take_theme_selection(&mut self) -> Option<String> {
+        None
+    }
+
     /// Handle Ctrl-C while this view is active.
     fn on_ctrl_c(&mut self) -> CancellationEvent {
         CancellationEvent::NotHandled

--- a/crates/tui/src/bottom_pane/chat_composer.rs
+++ b/crates/tui/src/bottom_pane/chat_composer.rs
@@ -130,6 +130,8 @@ use ratatui::layout::Constraint;
 use ratatui::layout::Layout;
 use ratatui::layout::Margin;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::style::Style;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::text::Span;
@@ -349,6 +351,7 @@ pub(crate) struct ChatComposer {
     status_line_enabled: bool,
     // Agent label injected into the footer's contextual row when multi-agent mode is active.
     active_agent_label: Option<String>,
+    accent_color: Color,
 }
 
 #[derive(Clone, Debug)]
@@ -475,10 +478,15 @@ impl ChatComposer {
             status_line_value: None,
             status_line_enabled: false,
             active_agent_label: None,
+            accent_color: Color::Cyan,
         };
         // Apply configuration via the setter to keep side-effects centralized.
         this.set_disable_paste_burst(disable_paste_burst);
         this
+    }
+
+    pub(crate) fn set_accent_color(&mut self, color: Color) {
+        self.accent_color = color;
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -3203,16 +3211,19 @@ impl ChatComposer {
                     let personality_command_enabled = self.personality_command_enabled;
                     let realtime_conversation_enabled = self.realtime_conversation_enabled;
                     let audio_device_selection_enabled = self.audio_device_selection_enabled;
-                    let mut command_popup = CommandPopup::new(CommandPopupFlags {
-                        collaboration_modes_enabled,
-                        connectors_enabled,
-                        plugins_command_enabled,
-                        fast_command_enabled,
-                        personality_command_enabled,
-                        realtime_conversation_enabled,
-                        audio_device_selection_enabled,
-                        windows_degraded_sandbox_active: self.windows_degraded_sandbox_active,
-                    });
+                    let mut command_popup = CommandPopup::new(
+                        CommandPopupFlags {
+                            collaboration_modes_enabled,
+                            connectors_enabled,
+                            plugins_command_enabled,
+                            fast_command_enabled,
+                            personality_command_enabled,
+                            realtime_conversation_enabled,
+                            audio_device_selection_enabled,
+                            windows_degraded_sandbox_active: self.windows_degraded_sandbox_active,
+                        },
+                        self.accent_color,
+                    );
                     command_popup.on_composer_text_change(first_line.to_string());
                     self.active_popup = ActivePopup::Command(command_popup);
                 }
@@ -3245,7 +3256,7 @@ impl ChatComposer {
                 }
             }
             _ => {
-                let mut popup = FileSearchPopup::new();
+                let mut popup = FileSearchPopup::new(self.accent_color);
                 if query.is_empty() {
                     popup.set_empty_prompt();
                 } else {
@@ -3275,7 +3286,7 @@ impl ChatComposer {
         }
 
         {
-            let mut popup = SkillPopup::new(mentions);
+            let mut popup = SkillPopup::new(mentions, self.accent_color);
             popup.set_query(&query);
             self.active_popup = ActivePopup::Skill(popup);
         }
@@ -3763,9 +3774,9 @@ impl ChatComposer {
         if !textarea_rect.is_empty() {
             let prompt = if self.input_enabled {
                 if is_zellij {
-                    Span::styled("┃", style.fg(ratatui::style::Color::Cyan))
+                    Span::styled("┃", style.fg(self.accent_color))
                 } else {
-                    "┃".cyan()
+                    Span::styled("┃", Style::default().fg(self.accent_color))
                 }
             } else if is_zellij {
                 Span::styled("┃", style.fg(ratatui::style::Color::DarkGray))

--- a/crates/tui/src/bottom_pane/command_popup.rs
+++ b/crates/tui/src/bottom_pane/command_popup.rs
@@ -1,5 +1,6 @@
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
 use ratatui::widgets::WidgetRef;
 
 use super::popup_consts::MAX_POPUP_ROWS;
@@ -23,6 +24,7 @@ pub(crate) struct CommandPopup {
     command_filter: String,
     builtins: Vec<(&'static str, SlashCommand)>,
     state: ScrollState,
+    accent_color: Color,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -53,7 +55,7 @@ impl From<CommandPopupFlags> for slash_commands::BuiltinCommandFlags {
 }
 
 impl CommandPopup {
-    pub(crate) fn new(flags: CommandPopupFlags) -> Self {
+    pub(crate) fn new(flags: CommandPopupFlags, accent_color: Color) -> Self {
         // Keep built-in availability in sync with the composer.
         let builtins: Vec<(&'static str, SlashCommand)> =
             slash_commands::builtins_for_input(flags.into())
@@ -63,6 +65,7 @@ impl CommandPopup {
             command_filter: String::new(),
             builtins,
             state: ScrollState::new(),
+            accent_color,
         }
     }
 
@@ -223,6 +226,7 @@ impl WidgetRef for CommandPopup {
             &self.state,
             MAX_POPUP_ROWS,
             "no matches",
+            self.accent_color,
         );
     }
 }
@@ -234,14 +238,14 @@ mod tests {
 
     #[test]
     fn filter_returns_empty_for_unknown_prefix() {
-        let mut popup = CommandPopup::new(CommandPopupFlags::default());
+        let mut popup = CommandPopup::new(CommandPopupFlags::default(), Color::Cyan);
         popup.on_composer_text_change("/in".to_string());
         assert!(popup.filtered_items().is_empty());
     }
 
     #[test]
     fn exact_match_selects_model() {
-        let mut popup = CommandPopup::new(CommandPopupFlags::default());
+        let mut popup = CommandPopup::new(CommandPopupFlags::default(), Color::Cyan);
         popup.on_composer_text_change("/model".to_string());
 
         let selected = popup.selected_item();
@@ -253,7 +257,7 @@ mod tests {
 
     #[test]
     fn model_is_first_suggestion_for_mo() {
-        let mut popup = CommandPopup::new(CommandPopupFlags::default());
+        let mut popup = CommandPopup::new(CommandPopupFlags::default(), Color::Cyan);
         popup.on_composer_text_change("/mo".to_string());
         let matches = popup.filtered_items();
         match matches.first() {
@@ -264,7 +268,7 @@ mod tests {
 
     #[test]
     fn filtered_commands_keep_presentation_order_for_prefix() {
-        let mut popup = CommandPopup::new(CommandPopupFlags::default());
+        let mut popup = CommandPopup::new(CommandPopupFlags::default(), Color::Cyan);
         popup.on_composer_text_change("/m".to_string());
 
         let cmds: Vec<&str> = popup
@@ -279,7 +283,7 @@ mod tests {
 
     #[test]
     fn prefix_filter_limits_matches_for_ac() {
-        let mut popup = CommandPopup::new(CommandPopupFlags::default());
+        let mut popup = CommandPopup::new(CommandPopupFlags::default(), Color::Cyan);
         popup.on_composer_text_change("/ac".to_string());
 
         let cmds: Vec<&str> = popup
@@ -297,7 +301,7 @@ mod tests {
 
     #[test]
     fn exit_is_visible_for_matching_prefix() {
-        let mut popup = CommandPopup::new(CommandPopupFlags::default());
+        let mut popup = CommandPopup::new(CommandPopupFlags::default(), Color::Cyan);
         popup.on_composer_text_change("/ex".to_string());
 
         match popup.selected_item() {
@@ -308,7 +312,7 @@ mod tests {
 
     #[test]
     fn popup_lists_only_supported_commands() {
-        let mut popup = CommandPopup::new(CommandPopupFlags::default());
+        let mut popup = CommandPopup::new(CommandPopupFlags::default(), Color::Cyan);
         popup.on_composer_text_change("/".to_string());
 
         let cmds: Vec<&str> = popup
@@ -321,24 +325,27 @@ mod tests {
         assert_eq!(
             cmds,
             vec![
-                "model", "compact", "thinking", "resume", "new", "status", "clear", "onboard",
-                "diff", "btw", "exit",
+                "theme", "model", "compact", "thinking", "resume", "new", "status", "clear",
+                "onboard", "diff", "btw", "exit",
             ]
         );
     }
 
     #[test]
     fn settings_command_hidden_when_audio_device_selection_is_disabled() {
-        let mut popup = CommandPopup::new(CommandPopupFlags {
-            collaboration_modes_enabled: false,
-            connectors_enabled: false,
-            plugins_command_enabled: false,
-            fast_command_enabled: false,
-            personality_command_enabled: true,
-            realtime_conversation_enabled: true,
-            audio_device_selection_enabled: false,
-            windows_degraded_sandbox_active: false,
-        });
+        let mut popup = CommandPopup::new(
+            CommandPopupFlags {
+                collaboration_modes_enabled: false,
+                connectors_enabled: false,
+                plugins_command_enabled: false,
+                fast_command_enabled: false,
+                personality_command_enabled: true,
+                realtime_conversation_enabled: true,
+                audio_device_selection_enabled: false,
+                windows_degraded_sandbox_active: false,
+            },
+            Color::Cyan,
+        );
         popup.on_composer_text_change("/aud".to_string());
 
         let cmds: Vec<&str> = popup
@@ -357,7 +364,7 @@ mod tests {
 
     #[test]
     fn debug_commands_are_hidden_from_popup() {
-        let popup = CommandPopup::new(CommandPopupFlags::default());
+        let popup = CommandPopup::new(CommandPopupFlags::default(), Color::Cyan);
         let cmds: Vec<&str> = popup
             .filtered_items()
             .into_iter()

--- a/crates/tui/src/bottom_pane/file_search_popup.rs
+++ b/crates/tui/src/bottom_pane/file_search_popup.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use devo_file_search::FileMatch;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
 use ratatui::widgets::WidgetRef;
 
 use crate::render::Insets;
@@ -26,16 +27,18 @@ pub(crate) struct FileSearchPopup {
     matches: Vec<FileMatch>,
     /// Shared selection/scroll state.
     state: ScrollState,
+    accent_color: Color,
 }
 
 impl FileSearchPopup {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(accent_color: Color) -> Self {
         Self {
             display_query: String::new(),
             pending_query: String::new(),
             waiting: true,
             matches: Vec::new(),
             state: ScrollState::new(),
+            accent_color,
         }
     }
 
@@ -149,6 +152,7 @@ impl WidgetRef for &FileSearchPopup {
             &self.state,
             MAX_POPUP_ROWS,
             empty_message,
+            self.accent_color,
         );
     }
 }
@@ -171,7 +175,7 @@ mod tests {
 
     #[test]
     fn set_matches_keeps_only_the_first_page_of_results() {
-        let mut popup = FileSearchPopup::new();
+        let mut popup = FileSearchPopup::new(Color::Cyan);
         popup.set_query("file");
         popup.set_matches("file", (0..(MAX_POPUP_ROWS + 2)).map(file_match).collect());
 

--- a/crates/tui/src/bottom_pane/list_selection_view.rs
+++ b/crates/tui/src/bottom_pane/list_selection_view.rs
@@ -6,6 +6,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Constraint;
 use ratatui::layout::Layout;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::text::Span;
@@ -233,6 +234,8 @@ pub(crate) struct ListSelectionView {
 
     /// Called when the picker is dismissed via Esc/Ctrl+C without selecting.
     on_cancel: OnCancelCallback,
+
+    accent_color: Color,
 }
 
 impl ListSelectionView {
@@ -244,7 +247,11 @@ impl ListSelectionView {
     /// When search is enabled, rows without `search_value` will disappear as
     /// soon as the query is non-empty, which can look like dropped data unless
     /// callers intentionally populate that field.
-    pub fn new(params: SelectionViewParams, app_event_tx: AppEventSender) -> Self {
+    pub fn new(
+        params: SelectionViewParams,
+        app_event_tx: AppEventSender,
+        accent_color: Color,
+    ) -> Self {
         let mut header = params.header;
         if params.title.is_some() || params.subtitle.is_some() {
             let title = params.title.map(|title| Line::from(title.bold()));
@@ -282,6 +289,7 @@ impl ListSelectionView {
             preserve_side_content_bg: params.preserve_side_content_bg,
             on_selection_changed: params.on_selection_changed,
             on_cancel: params.on_cancel,
+            accent_color,
         };
         s.apply_filter();
         s
@@ -893,6 +901,7 @@ impl Renderable for ListSelectionView {
                     &self.state,
                     render_area.height as usize,
                     "no matches",
+                    self.accent_color,
                 ),
                 ColumnWidthMode::AutoAllRows => render_rows_stable_col_widths(
                     render_area,
@@ -901,6 +910,7 @@ impl Renderable for ListSelectionView {
                     &self.state,
                     render_area.height as usize,
                     "no matches",
+                    self.accent_color,
                 ),
                 ColumnWidthMode::Fixed => render_rows_with_col_width_mode(
                     render_area,
@@ -910,6 +920,7 @@ impl Renderable for ListSelectionView {
                     render_area.height as usize,
                     "no matches",
                     ColumnWidthMode::Fixed,
+                    self.accent_color,
                 ),
             };
         }

--- a/crates/tui/src/bottom_pane/mod.rs
+++ b/crates/tui/src/bottom_pane/mod.rs
@@ -7,6 +7,8 @@ use crossterm::event::KeyEventKind;
 use devo_protocol::user_input::TextElement;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::style::Style;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::widgets::Paragraph;
@@ -29,6 +31,7 @@ mod selection_popup_common;
 mod skill_popup;
 pub(crate) mod slash_commands;
 pub(crate) mod textarea;
+mod theme_picker;
 mod unified_exec_footer;
 
 pub(crate) use chat_composer::ChatComposer;
@@ -109,6 +112,9 @@ pub(crate) enum InputResult {
     },
     ModelSelected {
         model: String,
+    },
+    ThemeSelected {
+        name: String,
     },
     None,
 }
@@ -232,6 +238,7 @@ pub(crate) struct BottomPane {
     allow_empty_submit: bool,
     external_history_active: bool,
     external_history_draft: Option<String>,
+    accent_color: Color,
 }
 
 impl BottomPane {
@@ -277,7 +284,14 @@ impl BottomPane {
             allow_empty_submit: false,
             external_history_active: false,
             external_history_draft: None,
+            accent_color: Color::Cyan,
         }
+    }
+
+    pub(crate) fn set_accent_color(&mut self, color: Color) {
+        self.accent_color = color;
+        self.composer.set_accent_color(color);
+        self.request_redraw();
     }
 
     pub(crate) fn handle_key_event(&mut self, key: KeyEvent) -> InputResult {
@@ -451,7 +465,18 @@ impl BottomPane {
     }
 
     pub(crate) fn open_model_picker(&mut self, entries: Vec<ModelPickerEntry>) {
-        self.push_view(Box::new(ModelPickerView::new(entries)));
+        self.push_view(Box::new(ModelPickerView::new(entries, self.accent_color)));
+    }
+
+    pub(crate) fn open_theme_picker(
+        &mut self,
+        themes: &[crate::theme::Theme],
+        current_name: String,
+    ) {
+        self.push_view(Box::new(theme_picker::ThemePickerView::new(
+            themes,
+            current_name,
+        )));
     }
 
     pub(crate) fn restore_input_from_history(&mut self, text: Option<String>) {
@@ -609,10 +634,15 @@ impl BottomPane {
         if view_complete {
             let mut view = self.view_stack.pop().expect("active view exists");
             let selected_model = view.take_model_selection();
+            let selected_theme = view.take_theme_selection();
             self.request_redraw();
-            return selected_model
-                .map(|model| InputResult::ModelSelected { model })
-                .unwrap_or(InputResult::None);
+            if let Some(model) = selected_model {
+                return InputResult::ModelSelected { model };
+            }
+            if let Some(name) = selected_theme {
+                return InputResult::ThemeSelected { name };
+            }
+            return InputResult::None;
         }
 
         if view_in_paste_burst {
@@ -873,10 +903,11 @@ struct ModelPickerView {
     selection: usize,
     complete: bool,
     selected_model: Option<String>,
+    accent_color: Color,
 }
 
 impl ModelPickerView {
-    fn new(entries: Vec<ModelPickerEntry>) -> Self {
+    fn new(entries: Vec<ModelPickerEntry>, accent_color: Color) -> Self {
         let selection = entries
             .iter()
             .position(|entry| entry.is_current)
@@ -886,6 +917,7 @@ impl ModelPickerView {
             selection,
             complete: false,
             selected_model: None,
+            accent_color,
         }
     }
 
@@ -907,10 +939,11 @@ impl ModelPickerView {
     }
 
     fn render_lines(&self) -> Vec<Line<'static>> {
-        let mut lines = vec![Line::from("Select model").bold()];
+        let mut lines: Vec<Line<'static>> = Vec::new();
         for (index, entry) in self.entries.iter().enumerate() {
             let mut title = if index == self.selection {
-                Line::from(format!("  {}", entry.display_name)).bold()
+                Line::from(format!("  {}", entry.display_name))
+                    .style(Style::default().fg(self.accent_color).bold())
             } else {
                 Line::from(format!("  {}", entry.display_name)).dim()
             };

--- a/crates/tui/src/bottom_pane/multi_select_picker.rs
+++ b/crates/tui/src/bottom_pane/multi_select_picker.rs
@@ -33,6 +33,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Constraint;
 use ratatui::layout::Layout;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::text::Span;
@@ -157,6 +158,8 @@ pub(crate) struct MultiSelectPicker {
 
     /// Callback invoked when the user cancels the picker.
     on_cancel: Option<CancelCallback>,
+
+    accent_color: Color,
 }
 
 impl MultiSelectPicker {
@@ -574,6 +577,7 @@ impl Renderable for MultiSelectPicker {
                 &self.state,
                 render_area.height as usize,
                 "no matches",
+                self.accent_color,
             );
         }
 
@@ -628,6 +632,7 @@ pub(crate) struct MultiSelectPickerBuilder {
     on_change: Option<ChangeCallBack>,
     on_confirm: Option<ConfirmCallback>,
     on_cancel: Option<CancelCallback>,
+    accent_color: Color,
 }
 
 impl MultiSelectPickerBuilder {
@@ -644,7 +649,15 @@ impl MultiSelectPickerBuilder {
             on_change: None,
             on_confirm: None,
             on_cancel: None,
+            accent_color: Color::Cyan,
         }
+    }
+
+    /// Sets the accent color for highlighted selection rows.
+    #[allow(dead_code)]
+    pub fn accent_color(mut self, color: Color) -> Self {
+        self.accent_color = color;
+        self
     }
 
     /// Sets the list of selectable items.
@@ -755,6 +768,7 @@ impl MultiSelectPickerBuilder {
             on_change: self.on_change,
             on_confirm: self.on_confirm,
             on_cancel: self.on_cancel,
+            accent_color: self.accent_color,
         };
         view.apply_filter();
         view.update_preview_line();

--- a/crates/tui/src/bottom_pane/selection_popup_common.rs
+++ b/crates/tui/src/bottom_pane/selection_popup_common.rs
@@ -504,6 +504,7 @@ fn build_full_line(row: &GenericDisplayRow, desc_col: usize) -> Line<'static> {
 /// and behavior for selection popups.
 /// Returns the number of terminal lines actually rendered (including the
 /// single-line empty placeholder when shown).
+#[allow(clippy::too_many_arguments)]
 fn render_rows_inner(
     area: Rect,
     buf: &mut Buffer,
@@ -651,6 +652,7 @@ pub(crate) fn render_rows_stable_col_widths(
 /// This is the low-level entry point for callers that need to thread a mode
 /// through higher-level configuration.
 /// Returns the number of terminal lines actually rendered.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn render_rows_with_col_width_mode(
     area: Rect,
     buf: &mut Buffer,

--- a/crates/tui/src/bottom_pane/selection_popup_common.rs
+++ b/crates/tui/src/bottom_pane/selection_popup_common.rs
@@ -293,11 +293,16 @@ fn wrap_row_lines(row: &GenericDisplayRow, desc_col: usize, width: u16) -> Vec<L
     wrap_standard_row(row, desc_col, width)
 }
 
-fn apply_row_state_style(lines: &mut [Line<'static>], selected: bool, is_disabled: bool) {
+fn apply_row_state_style(
+    lines: &mut [Line<'static>],
+    selected: bool,
+    is_disabled: bool,
+    accent_color: Color,
+) {
     if selected {
         for line in lines.iter_mut() {
             line.spans.iter_mut().for_each(|span| {
-                span.style = Style::default().fg(Color::Cyan).bold();
+                span.style = Style::default().fg(accent_color).bold();
             });
         }
     }
@@ -507,6 +512,7 @@ fn render_rows_inner(
     max_results: usize,
     empty_message: &str,
     col_width_mode: ColumnWidthMode,
+    accent_color: Color,
 ) -> u16 {
     if rows_all.is_empty() {
         if area.height > 0 {
@@ -556,6 +562,7 @@ fn render_rows_inner(
             &mut wrapped,
             Some(i) == state.selected_idx && !row.is_disabled,
             row.is_disabled,
+            accent_color,
         );
 
         // Render the wrapped lines.
@@ -587,7 +594,6 @@ fn render_rows_inner(
 ///
 /// This function should be paired with [`measure_rows_height`] when reserving
 /// space; pairing it with a different measurement mode can cause clipping.
-/// Returns the number of terminal lines actually rendered.
 pub(crate) fn render_rows(
     area: Rect,
     buf: &mut Buffer,
@@ -595,6 +601,7 @@ pub(crate) fn render_rows(
     state: &ScrollState,
     max_results: usize,
     empty_message: &str,
+    accent_color: Color,
 ) -> u16 {
     render_rows_inner(
         area,
@@ -604,6 +611,7 @@ pub(crate) fn render_rows(
         max_results,
         empty_message,
         ColumnWidthMode::AutoVisible,
+        accent_color,
     )
 }
 
@@ -623,6 +631,7 @@ pub(crate) fn render_rows_stable_col_widths(
     state: &ScrollState,
     max_results: usize,
     empty_message: &str,
+    accent_color: Color,
 ) -> u16 {
     render_rows_inner(
         area,
@@ -632,6 +641,7 @@ pub(crate) fn render_rows_stable_col_widths(
         max_results,
         empty_message,
         ColumnWidthMode::AutoAllRows,
+        accent_color,
     )
 }
 
@@ -649,6 +659,7 @@ pub(crate) fn render_rows_with_col_width_mode(
     max_results: usize,
     empty_message: &str,
     col_width_mode: ColumnWidthMode,
+    accent_color: Color,
 ) -> u16 {
     render_rows_inner(
         area,
@@ -658,6 +669,7 @@ pub(crate) fn render_rows_with_col_width_mode(
         max_results,
         empty_message,
         col_width_mode,
+        accent_color,
     )
 }
 
@@ -673,6 +685,7 @@ pub(crate) fn render_rows_single_line(
     state: &ScrollState,
     max_results: usize,
     empty_message: &str,
+    accent_color: Color,
 ) -> u16 {
     if rows_all.is_empty() {
         if area.height > 0 {
@@ -721,7 +734,7 @@ pub(crate) fn render_rows_single_line(
         let mut full_line = build_full_line(row, desc_col);
         if Some(i) == state.selected_idx && !row.is_disabled {
             full_line.spans.iter_mut().for_each(|span| {
-                span.style = Style::default().fg(Color::Cyan).bold();
+                span.style = Style::default().fg(accent_color).bold();
             });
         }
         if row.is_disabled {

--- a/crates/tui/src/bottom_pane/skill_popup.rs
+++ b/crates/tui/src/bottom_pane/skill_popup.rs
@@ -3,6 +3,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Constraint;
 use ratatui::layout::Layout;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
 use ratatui::text::Line;
 use ratatui::widgets::Widget;
 use ratatui::widgets::WidgetRef;
@@ -34,14 +35,16 @@ pub(crate) struct SkillPopup {
     query: String,
     mentions: Vec<MentionItem>,
     state: ScrollState,
+    accent_color: Color,
 }
 
 impl SkillPopup {
-    pub(crate) fn new(mentions: Vec<MentionItem>) -> Self {
+    pub(crate) fn new(mentions: Vec<MentionItem>, accent_color: Color) -> Self {
         Self {
             query: String::new(),
             mentions,
             state: ScrollState::new(),
+            accent_color,
         }
     }
 
@@ -204,6 +207,7 @@ impl WidgetRef for SkillPopup {
             &self.state,
             MAX_POPUP_ROWS,
             "no matches",
+            self.accent_color,
         );
         if let Some(hint_area) = hint_area {
             let hint_area = Rect {

--- a/crates/tui/src/bottom_pane/theme_picker.rs
+++ b/crates/tui/src/bottom_pane/theme_picker.rs
@@ -1,0 +1,106 @@
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::Widget;
+
+use crate::render::renderable::Renderable;
+use crate::theme::Theme;
+
+use super::CancellationEvent;
+use super::bottom_pane_view::BottomPaneView;
+
+pub(crate) struct ThemePickerView {
+    entries: Vec<String>,
+    current_name: String,
+    selection: usize,
+    complete: bool,
+    selected_name: Option<String>,
+}
+
+impl ThemePickerView {
+    pub(crate) fn new(themes: &[Theme], current_name: String) -> Self {
+        let entries: Vec<String> = themes.iter().map(|t| t.name.clone()).collect();
+        let selection = entries
+            .iter()
+            .position(|name| *name == current_name)
+            .unwrap_or(0);
+        Self {
+            entries,
+            current_name,
+            selection,
+            complete: false,
+            selected_name: None,
+        }
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        if self.entries.is_empty() {
+            self.selection = 0;
+        } else {
+            self.selection =
+                (self.selection as isize + delta).rem_euclid(self.entries.len() as isize) as usize;
+        }
+    }
+
+    fn accept(&mut self) {
+        self.selected_name = self.entries.get(self.selection).cloned();
+        self.complete = true;
+    }
+
+    fn render_lines(&self) -> Vec<Line<'static>> {
+        self.entries
+            .iter()
+            .enumerate()
+            .map(|(index, name)| {
+                let mut line: Line<'static> = if name == &self.current_name {
+                    format!("  {name}  current").into()
+                } else {
+                    format!("  {name}").into()
+                };
+                if index == self.selection {
+                    line = line.bold();
+                }
+                line
+            })
+            .collect()
+    }
+}
+
+impl BottomPaneView for ThemePickerView {
+    fn handle_key_event(&mut self, key_event: KeyEvent) {
+        match key_event.code {
+            KeyCode::Esc => self.complete = true,
+            KeyCode::Up => self.move_selection(-1),
+            KeyCode::Down => self.move_selection(1),
+            KeyCode::Enter => self.accept(),
+            _ => {}
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.complete
+    }
+
+    fn on_ctrl_c(&mut self) -> CancellationEvent {
+        self.complete = true;
+        CancellationEvent::Handled
+    }
+
+    fn take_theme_selection(&mut self) -> Option<String> {
+        self.selected_name.take()
+    }
+}
+
+impl Renderable for ThemePickerView {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        Paragraph::new(self.render_lines()).render(area, buf);
+    }
+
+    fn desired_height(&self, _width: u16) -> u16 {
+        u16::try_from(self.render_lines().len()).unwrap_or(u16::MAX)
+    }
+}

--- a/crates/tui/src/chatwidget.rs
+++ b/crates/tui/src/chatwidget.rs
@@ -497,9 +497,6 @@ impl ChatWidget {
     ) {
         self.history.clear();
         self.next_history_flush_index = 0;
-        self.push_session_header(
-            /*is_first_run*/ false, /*startup_tooltip_override*/ None,
-        );
 
         tracing::trace!(
             session_id,
@@ -826,21 +823,18 @@ impl ChatWidget {
         if self.selection_mode {
             // Load the selected user message text into the composer for editing
             // and exit selection mode.
-            if let Some(idx) = self.selected_user_cell_index {
-                if let Some(history_idx) = self.user_cell_history_indices.get(idx) {
-                    if let Some(cell) = self.history.get(*history_idx) {
-                        if let Some(user_cell) = cell
-                            .as_ref()
-                            .as_any()
-                            .downcast_ref::<history_cell::UserHistoryCell>()
-                        {
-                            let text = user_cell.message.clone();
-                            self.bottom_pane.restore_input_from_history(Some(text));
-                            self.exit_selection_mode();
-                            return;
-                        }
-                    }
-                }
+            if let Some(idx) = self.selected_user_cell_index
+                && let Some(history_idx) = self.user_cell_history_indices.get(idx)
+                && let Some(cell) = self.history.get(*history_idx)
+                && let Some(user_cell) = cell
+                    .as_ref()
+                    .as_any()
+                    .downcast_ref::<history_cell::UserHistoryCell>()
+            {
+                let text = user_cell.message.clone();
+                self.bottom_pane.restore_input_from_history(Some(text));
+                self.exit_selection_mode();
+                return;
             }
         }
         self.exit_selection_mode();
@@ -1191,9 +1185,6 @@ impl ChatWidget {
                 self.total_input_tokens = 0;
                 self.total_output_tokens = 0;
                 self.prompt_token_estimate = 0;
-                self.push_session_header(
-                    /*is_first_run*/ false, /*startup_tooltip_override*/ None,
-                );
                 self.set_status_message("New session ready; send a prompt to start it");
             }
             WorkerEvent::SessionSwitched {

--- a/crates/tui/src/chatwidget.rs
+++ b/crates/tui/src/chatwidget.rs
@@ -14,6 +14,7 @@ use std::sync::Mutex;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyEventKind;
+use crossterm::event::KeyModifiers;
 use devo_protocol::InputItem;
 use devo_protocol::Model;
 use devo_protocol::ProviderWireApi;
@@ -64,6 +65,7 @@ use crate::markdown::append_markdown;
 use crate::render::renderable::Renderable;
 use crate::slash_command::SlashCommand;
 use crate::streaming::controller::StreamController;
+use crate::theme::ThemeSet;
 use crate::tui::frame_requester::FrameRequester;
 use devo_utils::ansi_escape::ansi_escape_line;
 
@@ -81,6 +83,7 @@ pub(crate) struct ChatWidgetInit {
     pub(crate) saved_model_slugs: Vec<String>,
     pub(crate) show_model_onboarding: bool,
     pub(crate) startup_tooltip_override: Option<String>,
+    pub(crate) initial_theme_name: Option<String>,
 }
 
 /// Resolved runtime session projection owned by the chat widget.
@@ -244,6 +247,8 @@ pub(crate) struct ChatWidget {
     resume_browser: Option<ResumeBrowserState>,
     resume_browser_loading: bool,
     picker_mode: Option<PickerMode>,
+    theme_set: ThemeSet,
+    active_theme_name: String,
     turn_count: usize,
     total_input_tokens: usize,
     total_output_tokens: usize,
@@ -252,6 +257,9 @@ pub(crate) struct ChatWidget {
     active_turn_id: Option<TurnId>,
     busy: bool,
     exit_layout_snapshot: Arc<Mutex<ExitLayoutSnapshot>>,
+    selection_mode: bool,
+    selected_user_cell_index: Option<usize>,
+    user_cell_history_indices: Vec<usize>,
 }
 
 impl ChatWidget {
@@ -265,6 +273,7 @@ impl ChatWidget {
         thinking_selection: Option<&str>,
         is_first_run: bool,
         startup_tooltip_override: Option<String>,
+        accent_color: Color,
     ) -> Box<dyn HistoryCell> {
         let model = model.cloned().unwrap_or_else(|| Model {
             slug: "unknown".to_string(),
@@ -284,6 +293,7 @@ impl ChatWidget {
             is_first_run,
             startup_tooltip_override,
             /*show_fast_status*/ false,
+            accent_color,
         ))
     }
 
@@ -371,18 +381,19 @@ impl ChatWidget {
         ])
     }
 
-    fn failed_dot_prefix() -> Line<'static> {
+    fn failed_dot_prefix(&self) -> Line<'static> {
+        let error_color = self.active_error_color();
         Line::from(vec![
-            Span::styled("▌", Style::default().fg(Color::Rgb(255, 110, 110))),
+            Span::styled("▌", Style::default().fg(error_color)),
             " ".into(),
         ])
     }
 
-    fn dot_prefix(status: DotStatus) -> Line<'static> {
+    fn dot_prefix(&self, status: DotStatus) -> Line<'static> {
         match status {
             DotStatus::Pending => Self::pending_dot_prefix(),
             DotStatus::Completed => Self::completed_dot_prefix(),
-            DotStatus::Failed => Self::failed_dot_prefix(),
+            DotStatus::Failed => self.failed_dot_prefix(),
         }
     }
 
@@ -466,12 +477,14 @@ impl ChatWidget {
         is_first_run: bool,
         startup_tooltip_override: Option<String>,
     ) {
+        let accent = self.active_accent_color();
         self.history.push(Self::build_header_box(
             &self.session.cwd,
             self.session.model.as_ref(),
             self.thinking_selection.as_deref(),
             is_first_run,
             startup_tooltip_override,
+            accent,
         ));
     }
 
@@ -558,6 +571,7 @@ impl ChatWidget {
             saved_model_slugs,
             show_model_onboarding,
             startup_tooltip_override,
+            initial_theme_name,
         } = common;
 
         // Prefer an explicit startup selection, but fall back to the model's default thinking mode.
@@ -574,8 +588,17 @@ impl ChatWidget {
             queued_user_messages.push_back(initial_user_message);
         }
 
+        let theme_set = ThemeSet::default();
+        let active_theme_name = initial_theme_name
+            .filter(|name| theme_set.find(name).is_some())
+            .unwrap_or_else(|| ThemeSet::default_theme().to_string());
+        let initial_accent_color = theme_set
+            .find(&active_theme_name)
+            .map(|t| t.accent_color)
+            .unwrap_or(Color::Cyan);
+
         // Build the bottom composer first, since the widget delegates all live input handling there.
-        let bottom_pane = BottomPane::new(BottomPaneParams {
+        let mut bottom_pane = BottomPane::new(BottomPaneParams {
             app_event_tx: app_event_tx.clone(),
             frame_requester: frame_requester.clone(),
             has_input_focus: true,
@@ -585,6 +608,7 @@ impl ChatWidget {
             skills: None,
             animations_enabled: true,
         });
+        bottom_pane.set_accent_color(initial_accent_color);
 
         let history: Vec<Box<dyn HistoryCell>> = vec![Self::build_header_box(
             &initial_session.cwd,
@@ -592,6 +616,7 @@ impl ChatWidget {
             thinking_selection.as_deref(),
             is_first_run,
             startup_tooltip_override,
+            initial_accent_color,
         )];
 
         // Assemble the full widget state from the initial session, composer, history, and queues.
@@ -621,6 +646,8 @@ impl ChatWidget {
             resume_browser: None,
             resume_browser_loading: false,
             picker_mode: None,
+            theme_set,
+            active_theme_name,
             turn_count: 0,
             total_input_tokens: 0,
             total_output_tokens: 0,
@@ -629,6 +656,9 @@ impl ChatWidget {
             active_turn_id: None,
             busy: false,
             exit_layout_snapshot: Arc::new(Mutex::new(ExitLayoutSnapshot::default())),
+            selection_mode: false,
+            selected_user_cell_index: None,
+            user_cell_history_indices: Vec::new(),
         };
 
         // Model onboarding can inject additional startup UI before the first frame is drawn.
@@ -651,6 +681,9 @@ impl ChatWidget {
         }
         if let Some(result) = self.bottom_pane.poll_onboarding_result() {
             self.handle_onboarding_result(result);
+        }
+        if self.handle_selection_mode_key(key) {
+            return;
         }
         match self.bottom_pane.handle_key_event(key) {
             InputResult::Submitted {
@@ -691,8 +724,132 @@ impl ChatWidget {
                 Some(PickerMode::Thinking) => self.apply_thinking_selection(model),
                 _ => self.apply_model_selection(model),
             },
+            InputResult::ThemeSelected { name } => {
+                self.apply_theme_selection(name);
+            }
             InputResult::None => {}
         }
+    }
+
+    fn handle_selection_mode_key(&mut self, key: KeyEvent) -> bool {
+        let alt_up = key.code == KeyCode::Up && key.modifiers.contains(KeyModifiers::ALT);
+        let alt_down = key.code == KeyCode::Down && key.modifiers.contains(KeyModifiers::ALT);
+
+        if !alt_up && !alt_down {
+            if !self.selection_mode {
+                return false;
+            }
+            match key.code {
+                KeyCode::Esc => {
+                    self.exit_selection_mode();
+                    return true;
+                }
+                KeyCode::Enter => {
+                    self.open_selection_action_menu();
+                    return true;
+                }
+                _ => return false,
+            }
+        }
+
+        if self.busy {
+            return false;
+        }
+
+        self.refresh_user_cell_indices();
+        let len = self.user_cell_history_indices.len();
+        if len == 0 {
+            return false;
+        }
+
+        if !self.selection_mode {
+            self.selection_mode = true;
+            // Start from the last user cell if no selection yet
+            self.selected_user_cell_index = Some(len - 1);
+            self.update_selection_status();
+            self.frame_requester.schedule_frame();
+            return true;
+        }
+
+        let current = self.selected_user_cell_index.unwrap_or(0);
+        let new = if alt_up {
+            current.saturating_sub(1)
+        } else {
+            (current + 1).min(len - 1)
+        };
+        if new != current {
+            self.selected_user_cell_index = Some(new);
+            self.update_selection_status();
+            self.frame_requester.schedule_frame();
+        }
+        true
+    }
+
+    fn exit_selection_mode(&mut self) {
+        self.selection_mode = false;
+        self.selected_user_cell_index = None;
+        self.bottom_pane
+            .set_status_line(Some(Line::from(self.session_summary_text()).dim()));
+        self.bottom_pane.set_status_line_enabled(true);
+        self.frame_requester.schedule_frame();
+    }
+
+    fn update_selection_status(&mut self) {
+        if let Some(idx) = self.selected_user_cell_index {
+            let turn_num = idx + 1;
+            self.bottom_pane.set_status_line(Some(
+                Line::from(format!(
+                    "Selected turn {turn_num} · Enter to act  Esc to cancel"
+                ))
+                .dim(),
+            ));
+            self.bottom_pane.set_status_line_enabled(true);
+        }
+    }
+
+    fn refresh_user_cell_indices(&mut self) {
+        self.user_cell_history_indices = self
+            .history
+            .iter()
+            .enumerate()
+            .filter_map(|(i, cell)| {
+                let cell_ref: &dyn HistoryCell = cell.as_ref();
+                cell_ref
+                    .as_any()
+                    .downcast_ref::<history_cell::UserHistoryCell>()
+                    .map(|_| i)
+            })
+            .collect();
+    }
+
+    fn open_selection_action_menu(&mut self) {
+        if self.selection_mode {
+            // Load the selected user message text into the composer for editing
+            // and exit selection mode.
+            if let Some(idx) = self.selected_user_cell_index {
+                if let Some(history_idx) = self.user_cell_history_indices.get(idx) {
+                    if let Some(cell) = self.history.get(*history_idx) {
+                        if let Some(user_cell) = cell
+                            .as_ref()
+                            .as_any()
+                            .downcast_ref::<history_cell::UserHistoryCell>()
+                        {
+                            let text = user_cell.message.clone();
+                            self.bottom_pane.restore_input_from_history(Some(text));
+                            self.exit_selection_mode();
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        self.exit_selection_mode();
+    }
+
+    pub(crate) fn handle_mouse_event(&mut self, _mouse: crossterm::event::MouseEvent) {
+        // Mouse events are only actionable in alt-screen mode.
+        // In inline mode, they are ignored.
+        self.frame_requester.schedule_frame();
     }
 
     pub(crate) fn handle_paste(&mut self, text: String) {
@@ -712,6 +869,9 @@ impl ChatWidget {
             AppEvent::SubmitUserInput { text } => self.submit_text(text),
             AppEvent::ModelSelected { model } => {
                 self.apply_model_selection(model);
+            }
+            AppEvent::ThemeSelected { name } => {
+                self.apply_theme_selection(name);
             }
             AppEvent::ThinkingSelected { value } => self.set_thinking_selection(value),
             AppEvent::StatusMessageChanged { message } => self.set_status_message(message),
@@ -746,6 +906,7 @@ impl ChatWidget {
             | AppEvent::RunSlashCommand { .. }
             | AppEvent::OpenModelPicker
             | AppEvent::OpenThinkingPicker
+            | AppEvent::OpenThemePicker
             | AppEvent::StatusLineBranchUpdated { .. }
             | AppEvent::StartFileSearch(_)
             | AppEvent::StatusLineSetup { .. }
@@ -890,7 +1051,7 @@ impl ChatWidget {
                 if !lines.is_empty() {
                     self.add_to_history(history_cell::AgentMessageCell::new_with_prefix(
                         lines,
-                        Self::dot_prefix(dot_status),
+                        self.dot_prefix(dot_status),
                         "  ",
                         false,
                     ));
@@ -911,7 +1072,7 @@ impl ChatWidget {
                 self.frame_requester.schedule_frame();
             }
             WorkerEvent::TurnFinished {
-                stop_reason: _,
+                stop_reason,
                 turn_count,
                 total_input_tokens,
                 total_output_tokens,
@@ -925,11 +1086,6 @@ impl ChatWidget {
                 self.total_input_tokens = total_input_tokens;
                 self.total_output_tokens = total_output_tokens;
                 self.prompt_token_estimate = prompt_token_estimate;
-                let elapsed = self
-                    .bottom_pane
-                    .status_widget()
-                    .map(|s| s.elapsed_seconds())
-                    .filter(|&secs| secs > 0);
                 let model_name = self
                     .session
                     .model
@@ -939,7 +1095,18 @@ impl ChatWidget {
                     .unwrap_or_default();
                 self.bottom_pane.set_task_running(false);
                 self.set_status_message("Ready");
-                self.add_to_history(history_cell::TurnSummaryCell::new(model_name, elapsed));
+                let was_interrupted = stop_reason.contains("Interrupted");
+                let cell = if was_interrupted {
+                    history_cell::TurnSummaryCell::new_interrupted(model_name)
+                } else {
+                    let elapsed = self
+                        .bottom_pane
+                        .status_widget()
+                        .map(|s| s.elapsed_seconds())
+                        .filter(|&secs| secs > 0);
+                    history_cell::TurnSummaryCell::new(model_name, elapsed)
+                };
+                self.add_to_history(cell);
             }
             WorkerEvent::TurnFailed {
                 message,
@@ -957,6 +1124,14 @@ impl ChatWidget {
                 self.total_input_tokens = total_input_tokens;
                 self.total_output_tokens = total_output_tokens;
                 self.prompt_token_estimate = prompt_token_estimate;
+                let model_name = self
+                    .session
+                    .model
+                    .as_ref()
+                    .map(|m| m.display_name.clone())
+                    .or_else(|| self.session.model.as_ref().map(|m| m.slug.clone()))
+                    .unwrap_or_default();
+                self.add_to_history(history_cell::TurnSummaryCell::new_interrupted(model_name));
                 self.add_to_history(history_cell::new_error_event(message));
                 self.bottom_pane.set_task_running(false);
                 self.set_status_message("Query failed; see error above");
@@ -1148,6 +1323,7 @@ impl ChatWidget {
             user_message.text_elements.clone(),
             local_image_paths,
             user_message.remote_image_urls.clone(),
+            self.active_accent_color(),
         ));
 
         self.app_event_tx
@@ -1184,35 +1360,33 @@ impl ChatWidget {
                 self.begin_onboarding();
             }
             SlashCommand::Status => {
-                let context_line = self.context_budget().map_or_else(
-                    || "  context:  n/a".to_string(),
-                    |(used, usable, total)| {
-                        format!(
-                            "  context:  {} / {} usable ({} total)",
-                            Self::format_token_count(used),
-                            Self::format_token_count(usable),
-                            Self::format_token_count(total)
-                        )
-                    },
-                );
-                self.add_to_history(PlainHistoryCell::new(vec![
-                    Line::from("Status".bold()),
+                let model = self
+                    .session
+                    .model
+                    .as_ref()
+                    .map(|m| m.slug.as_str())
+                    .unwrap_or("unknown");
+                let thinking = self.thinking_selection.as_deref().unwrap_or("default");
+                let cwd = self.session.cwd.display().to_string();
+                let turns = self.turn_count;
+                let tokens_in = Self::format_token_count(self.total_input_tokens);
+                let tokens_out = Self::format_token_count(self.total_output_tokens);
+                let lines = history_cell::with_border(vec![
+                    Line::from("Session Status".bold()),
                     Line::from(""),
+                    Line::from(format!("  model:       {model}")),
+                    Line::from(format!("  thinking:    {thinking}")),
+                    Line::from(format!("  cwd:         {cwd}")),
+                    Line::from(format!("  turns:       {turns}")),
                     Line::from(format!(
-                        "  model:    {}\n  thinking: {}\n  tokens:   {} in / {} out\n{}\n  busy:     {}",
-                        self.session
-                            .model
-                            .as_ref()
-                            .map(|model| model.slug.as_str())
-                            .unwrap_or("unknown"),
-                        self.thinking_selection.as_deref().unwrap_or("default"),
-                        self.total_input_tokens,
-                        self.total_output_tokens,
-                        context_line,
-                        self.busy
+                        "  tokens:      \u{2191}{tokens_in} \u{2193}{tokens_out}",
                     )),
-                ]));
+                ]);
+                self.add_to_history(PlainHistoryCell::new(lines));
                 self.set_status_message("Session status shown");
+            }
+            SlashCommand::Theme => {
+                self.open_theme_picker();
             }
             SlashCommand::Model => {
                 if argument.is_empty() {
@@ -1251,6 +1425,7 @@ impl ChatWidget {
                         Vec::new(),
                         Vec::new(),
                         Vec::new(),
+                        self.active_accent_color(),
                     ));
                     self.app_event_tx
                         .send(AppEvent::Command(AppCommand::SteerTurn {
@@ -1444,7 +1619,7 @@ impl ChatWidget {
             self.add_history_entry_without_redraw(Box::new(
                 history_cell::AgentMessageCell::new_ai_response_with_prefix(
                     lines,
-                    Self::dot_prefix(status),
+                    self.dot_prefix(status),
                     "  ",
                     false,
                 ),
@@ -1502,6 +1677,7 @@ impl ChatWidget {
                     Vec::new(),
                     Vec::new(),
                     Vec::new(),
+                    self.active_accent_color(),
                 )));
             }
             TranscriptItemKind::Assistant => {
@@ -1660,12 +1836,14 @@ impl ChatWidget {
         if self.history.is_empty() {
             return;
         }
+        let accent = self.active_accent_color();
         self.history[0] = Self::build_header_box(
             &self.session.cwd,
             self.session.model.as_ref(),
             self.thinking_selection.as_deref(),
             /*is_first_run*/ false,
             None,
+            accent,
         );
     }
 
@@ -1841,6 +2019,7 @@ impl ChatWidget {
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),
+                self.active_accent_color(),
             ));
         }
         self.queued_count = self.queued_count.saturating_sub(1);
@@ -1990,6 +2169,36 @@ impl ChatWidget {
             .collect();
         self.bottom_pane.open_model_picker(entries);
         self.set_status_message("Select a model");
+    }
+
+    fn open_theme_picker(&mut self) {
+        self.bottom_pane
+            .open_theme_picker(&self.theme_set.themes, self.active_theme_name.clone());
+        self.set_status_message("Select a theme");
+    }
+
+    fn apply_theme_selection(&mut self, name: String) {
+        if let Some(theme) = self.theme_set.find(&name).cloned() {
+            self.active_theme_name = name.clone();
+            self.bottom_pane.set_accent_color(theme.accent_color);
+            let _ = crate::onboarding::save_theme_selection(&name);
+            self.set_status_message(format!("Theme set to {name}"));
+            self.frame_requester.schedule_frame();
+        }
+    }
+
+    fn active_accent_color(&self) -> Color {
+        self.theme_set
+            .find(&self.active_theme_name)
+            .map(|t| t.accent_color)
+            .unwrap_or(Color::Cyan)
+    }
+
+    fn active_error_color(&self) -> Color {
+        self.theme_set
+            .find(&self.active_theme_name)
+            .map(|t| t.error_color)
+            .unwrap_or(Color::Rgb(0xF8, 0x51, 0x49))
     }
 
     fn apply_model_selection(&mut self, slug: String) {

--- a/crates/tui/src/chatwidget.rs
+++ b/crates/tui/src/chatwidget.rs
@@ -77,6 +77,8 @@ pub(crate) struct ChatWidgetInit {
     pub(crate) enhanced_keys_supported: bool,
     pub(crate) is_first_run: bool,
     pub(crate) available_models: Vec<Model>,
+    /// Configured model slugs from config.toml used by the /model picker.
+    pub(crate) saved_model_slugs: Vec<String>,
     pub(crate) show_model_onboarding: bool,
     pub(crate) startup_tooltip_override: Option<String>,
 }
@@ -237,6 +239,7 @@ pub(crate) struct ChatWidget {
     active_reasoning_cell: Option<history_cell::AgentMessageCell>,
     stream_controller: Option<StreamController>,
     available_models: Vec<Model>,
+    saved_model_slugs: Vec<String>,
     onboarding_step: Option<OnboardingStep>,
     resume_browser: Option<ResumeBrowserState>,
     resume_browser_loading: bool,
@@ -552,6 +555,7 @@ impl ChatWidget {
             enhanced_keys_supported,
             is_first_run,
             available_models,
+            saved_model_slugs,
             show_model_onboarding,
             startup_tooltip_override,
         } = common;
@@ -612,6 +616,7 @@ impl ChatWidget {
             active_reasoning_cell: None,
             stream_controller: None,
             available_models,
+            saved_model_slugs,
             onboarding_step: None,
             resume_browser: None,
             resume_browser_loading: false,
@@ -1969,12 +1974,17 @@ impl ChatWidget {
         self.picker_mode = Some(PickerMode::Model);
         let current_slug = self.session.model.as_ref().map(|model| model.slug.as_str());
         let entries = self
-            .available_models
+            .saved_model_slugs
             .iter()
+            .filter_map(|slug| {
+                self.available_models
+                    .iter()
+                    .find(|model| model.slug == *slug)
+            })
             .map(|model| ModelPickerEntry {
                 slug: model.slug.clone(),
                 display_name: model.display_name.clone(),
-                description: model.description.clone(),
+                description: model.channel.clone(),
                 is_current: current_slug == Some(model.slug.as_str()),
             })
             .collect();

--- a/crates/tui/src/chatwidget_tests.rs
+++ b/crates/tui/src/chatwidget_tests.rs
@@ -47,6 +47,7 @@ fn widget_with_model_and_thinking(
         saved_model_slugs: Vec::new(),
         show_model_onboarding: false,
         startup_tooltip_override: None,
+        initial_theme_name: None,
     });
     (widget, app_event_rx)
 }
@@ -68,6 +69,7 @@ fn onboarding_widget_with_model(
         saved_model_slugs: Vec::new(),
         show_model_onboarding: true,
         startup_tooltip_override: None,
+        initial_theme_name: None,
     });
     (widget, app_event_rx)
 }
@@ -966,6 +968,7 @@ fn slash_model_opens_model_picker_instead_of_printing_current_model() {
         saved_model_slugs: vec!["test-model".into(), "second-model".into()],
         show_model_onboarding: false,
         startup_tooltip_override: None,
+        initial_theme_name: None,
     });
 
     widget.handle_app_event(AppEvent::RunSlashCommand {
@@ -1085,6 +1088,7 @@ fn model_selection_updates_session_projection_and_emits_context_override() {
         saved_model_slugs: vec!["test-model".into(), "second-model".into()],
         show_model_onboarding: false,
         startup_tooltip_override: None,
+        initial_theme_name: None,
     });
 
     widget.handle_app_event(AppEvent::ModelSelected {

--- a/crates/tui/src/chatwidget_tests.rs
+++ b/crates/tui/src/chatwidget_tests.rs
@@ -638,7 +638,8 @@ fn session_switch_restores_header_and_double_blank_line_before_user_input() {
         })
         .collect::<Vec<_>>();
 
-    assert_eq!(1, committed_text.matches("directory:").count());
+    // The header box is rendered only once on initial launch, not on session switch.
+    assert_eq!(0, committed_text.matches("directory:").count());
     assert!(committed_text.contains("hello"));
     assert!(committed_text.contains("world"));
     assert!(!committed_text.contains("session 1 lingering line"));

--- a/crates/tui/src/chatwidget_tests.rs
+++ b/crates/tui/src/chatwidget_tests.rs
@@ -44,6 +44,7 @@ fn widget_with_model_and_thinking(
         enhanced_keys_supported: true,
         is_first_run: false,
         available_models: Vec::new(),
+        saved_model_slugs: Vec::new(),
         show_model_onboarding: false,
         startup_tooltip_override: None,
     });
@@ -64,6 +65,7 @@ fn onboarding_widget_with_model(
         enhanced_keys_supported: true,
         is_first_run: false,
         available_models: Vec::new(),
+        saved_model_slugs: Vec::new(),
         show_model_onboarding: true,
         startup_tooltip_override: None,
     });
@@ -961,6 +963,7 @@ fn slash_model_opens_model_picker_instead_of_printing_current_model() {
         enhanced_keys_supported: true,
         is_first_run: false,
         available_models: vec![model, alt_model],
+        saved_model_slugs: vec!["test-model".into(), "second-model".into()],
         show_model_onboarding: false,
         startup_tooltip_override: None,
     });
@@ -1079,6 +1082,7 @@ fn model_selection_updates_session_projection_and_emits_context_override() {
         enhanced_keys_supported: true,
         is_first_run: false,
         available_models: vec![model, alt_model.clone()],
+        saved_model_slugs: vec!["test-model".into(), "second-model".into()],
         show_model_onboarding: false,
         startup_tooltip_override: None,
     });

--- a/crates/tui/src/history_cell.rs
+++ b/crates/tui/src/history_cell.rs
@@ -26,6 +26,7 @@ use crate::render::line_utils::push_owned_lines;
 use crate::render::renderable::Renderable;
 use crate::style::user_message_style;
 use crate::text_formatting::truncate_text;
+use crate::theme::ThemeSet;
 use crate::ui_consts::LIVE_PREFIX_COLS;
 use crate::version::CLI_VERSION;
 use crate::wrapping::RtOptions;
@@ -202,6 +203,7 @@ pub(crate) struct UserHistoryCell {
     #[allow(dead_code)]
     pub local_image_paths: Vec<PathBuf>,
     pub remote_image_urls: Vec<String>,
+    pub accent_color: Color,
 }
 
 /// Build logical lines for a user message with styled text elements.
@@ -288,9 +290,10 @@ impl HistoryCell for UserHistoryCell {
             )
             .max(1);
 
+        let accent = self.accent_color;
         let style = user_message_style();
-        let element_style = style.fg(Color::Cyan);
-        let prefix_style = Style::default().fg(Color::Cyan);
+        let element_style = style.fg(accent);
+        let prefix_style = Style::default().fg(accent);
         let blank_prefixed_line = || {
             Line::from(vec![
                 Span::styled("┃ ", prefix_style),
@@ -970,6 +973,19 @@ impl HistoryCell for SessionInfoCell {
     }
 }
 
+#[allow(dead_code)]
+fn random_tip() -> String {
+    let tips = ThemeSet::tips();
+    if tips.is_empty() {
+        return String::new();
+    }
+    use rand::seq::IndexedRandom as _;
+    tips.choose(&mut rand::rng())
+        .copied()
+        .unwrap_or("")
+        .to_string()
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn new_session_info(
     cwd: &Path,
@@ -981,6 +997,7 @@ pub(crate) fn new_session_info(
     is_first_event: bool,
     tooltip_override: Option<String>,
     show_fast_status: bool,
+    accent_color: Color,
 ) -> SessionInfoCell {
     // Header box rendered as history (so it appears at the very top)
     let header = HeaderHistoryCell::new(
@@ -991,6 +1008,7 @@ pub(crate) fn new_session_info(
         show_fast_status,
         cwd.to_path_buf(),
         CLI_VERSION,
+        accent_color,
     );
     let mut parts: Vec<Box<dyn HistoryCell>> = vec![Box::new(header)];
 
@@ -1062,12 +1080,14 @@ pub(crate) fn new_user_prompt(
     text_elements: Vec<TextElement>,
     local_image_paths: Vec<PathBuf>,
     remote_image_urls: Vec<String>,
+    accent_color: Color,
 ) -> UserHistoryCell {
     UserHistoryCell {
         message,
         text_elements,
         local_image_paths,
         remote_image_urls,
+        accent_color,
     }
 }
 
@@ -1081,6 +1101,7 @@ pub(crate) struct HeaderHistoryCell {
     thinking_implementation: Option<ThinkingImplementation>,
     show_fast_status: bool,
     directory: PathBuf,
+    accent_color: Color,
 }
 
 impl HeaderHistoryCell {
@@ -1092,6 +1113,7 @@ impl HeaderHistoryCell {
         show_fast_status: bool,
         directory: PathBuf,
         version: &'static str,
+        accent_color: Color,
     ) -> Self {
         Self::new_with_style(
             model,
@@ -1102,6 +1124,7 @@ impl HeaderHistoryCell {
             show_fast_status,
             directory,
             version,
+            accent_color,
         )
     }
 
@@ -1115,6 +1138,7 @@ impl HeaderHistoryCell {
         show_fast_status: bool,
         directory: PathBuf,
         version: &'static str,
+        accent_color: Color,
     ) -> Self {
         Self {
             version,
@@ -1125,6 +1149,7 @@ impl HeaderHistoryCell {
             thinking_implementation,
             show_fast_status,
             directory,
+            accent_color,
         }
     }
 
@@ -1237,7 +1262,10 @@ impl HistoryCell for HeaderHistoryCell {
                 spans.push(Span::styled("fast", self.model_style.magenta()));
             }
             spans.push("   ".dim());
-            spans.push(CHANGE_MODEL_HINT_COMMAND.cyan());
+            spans.push(Span::styled(
+                CHANGE_MODEL_HINT_COMMAND,
+                Style::default().fg(self.accent_color),
+            ));
             spans.push(CHANGE_MODEL_HINT_EXPLANATION.dim());
             spans
         };
@@ -1561,11 +1589,12 @@ impl HistoryCell for FinalMessageSeparator {
 /// End-of-turn summary showing ▣ symbol, model name, and duration.
 ///
 /// Inspired by opencode's assistant message footer:
-/// `▣ model-name · 12.3s`
+/// `▣ model-name · 15s` or `▣ model-name · interrupted`
 #[derive(Debug)]
 pub struct TurnSummaryCell {
     pub model_name: String,
     pub duration: Option<u64>,
+    pub interrupted: bool,
 }
 
 impl TurnSummaryCell {
@@ -1573,7 +1602,31 @@ impl TurnSummaryCell {
         Self {
             model_name,
             duration,
+            interrupted: false,
         }
+    }
+
+    pub(crate) fn new_interrupted(model_name: String) -> Self {
+        Self {
+            model_name,
+            duration: None,
+            interrupted: true,
+        }
+    }
+}
+
+fn format_duration_largest_unit(duration_secs: u64) -> String {
+    if duration_secs >= 604_800 {
+        let weeks = duration_secs / 604_800;
+        format!("{weeks}w")
+    } else if duration_secs >= 86_400 {
+        let days = duration_secs / 86_400;
+        format!("{days}d")
+    } else if duration_secs >= 3_600 {
+        let hours = duration_secs / 3_600;
+        format!("{hours}h")
+    } else {
+        format!("{duration_secs}s")
     }
 }
 
@@ -1582,18 +1635,15 @@ impl HistoryCell for TurnSummaryCell {
         let _ = width;
         let mut spans: Vec<Span<'static>> = vec![
             Span::raw(" ".repeat(LIVE_PREFIX_COLS as usize)),
-            Span::styled("▣", Style::default().fg(Color::Cyan)),
+            Span::styled("▣", Style::default().fg(Color::Rgb(0x8B, 0x94, 0x9E))),
             Span::styled(" ", Style::default()),
             Span::styled(self.model_name.clone(), Style::default().dim()),
         ];
-        if let Some(duration) = self.duration {
-            let formatted = if duration < 60 {
-                format!("{duration}s")
-            } else {
-                let minutes = duration / 60;
-                let seconds = duration % 60;
-                format!("{minutes}m {seconds:02}s")
-            };
+        if self.interrupted {
+            spans.push(Span::styled(" · ", Style::default().dim()));
+            spans.push(Span::styled("interrupted", Style::default().dim()));
+        } else if let Some(duration) = self.duration {
+            let formatted = format_duration_largest_unit(duration);
             spans.push(Span::styled(" · ", Style::default().dim()));
             spans.push(Span::styled(formatted, Style::default().dim()));
         }

--- a/crates/tui/src/history_cell.rs
+++ b/crates/tui/src/history_cell.rs
@@ -1105,6 +1105,7 @@ pub(crate) struct HeaderHistoryCell {
 }
 
 impl HeaderHistoryCell {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         model: String,
         thinking_capability: ThinkingCapability,

--- a/crates/tui/src/host.rs
+++ b/crates/tui/src/host.rs
@@ -107,6 +107,8 @@ pub async fn run_interactive_tui(config: InteractiveTuiConfig) -> Result<AppExit
 
     let mut loop_state = InteractiveLoopState::default();
 
+    let initial_theme_name = crate::onboarding::load_theme_selection();
+
     // Create the root chat widget that owns visible TUI state and input handling.
     let mut chat_widget = ChatWidget::new_with_app_event(ChatWidgetInit {
         frame_requester: tui.frame_requester(),
@@ -125,6 +127,7 @@ pub async fn run_interactive_tui(config: InteractiveTuiConfig) -> Result<AppExit
         saved_model_slugs,
         show_model_onboarding: config.show_model_onboarding,
         startup_tooltip_override: Some(format!("Ready in {}", cwd.display())),
+        initial_theme_name,
     });
     tui.set_exit_layout_snapshot_handle(chat_widget.exit_layout_snapshot_handle());
 
@@ -284,8 +287,20 @@ fn handle_tui_event(
                 return Ok(LoopAction::Continue);
             }
 
+            if key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                if tui.is_alt_screen_active() {
+                    tui.leave_alt_screen()?;
+                } else {
+                    tui.enter_alt_screen()?;
+                }
+                return Ok(LoopAction::Continue);
+            }
+
             loop_state.last_ctrl_c_at = None;
             chat_widget.handle_key_event(key);
+        }
+        TuiEvent::Mouse(mouse_event) => {
+            chat_widget.handle_mouse_event(mouse_event);
         }
         TuiEvent::Paste(pasted) => {
             // Many terminals convert newlines to \r when pasting (e.g., iTerm2),

--- a/crates/tui/src/host.rs
+++ b/crates/tui/src/host.rs
@@ -92,6 +92,12 @@ pub async fn run_interactive_tui(config: InteractiveTuiConfig) -> Result<AppExit
         .cloned()
         .collect::<Vec<_>>();
 
+    let saved_model_slugs: Vec<String> = config
+        .saved_models
+        .iter()
+        .map(|entry| entry.model.clone())
+        .collect();
+
     let model = resolve_initial_model(&initial_session, &config.model_catalog);
     let cwd = initial_session.cwd.clone();
     let initial_provider = model.provider_wire_api();
@@ -116,6 +122,7 @@ pub async fn run_interactive_tui(config: InteractiveTuiConfig) -> Result<AppExit
         enhanced_keys_supported: tui.enhanced_keys_supported(),
         is_first_run: config.saved_models.is_empty(),
         available_models,
+        saved_model_slugs,
         show_model_onboarding: config.show_model_onboarding,
         startup_tooltip_override: Some(format!("Ready in {}", cwd.display())),
     });

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -41,6 +41,7 @@ mod style;
 mod terminal_palette;
 mod test_backend;
 mod text_formatting;
+mod theme;
 mod tui;
 mod ui_consts;
 mod version;

--- a/crates/tui/src/onboarding.rs
+++ b/crates/tui/src/onboarding.rs
@@ -96,6 +96,48 @@ pub(crate) fn save_thinking_selection(selection: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn save_theme_selection(name: &str) -> Result<()> {
+    let path = find_devo_home()
+        .context("could not determine user config path")?
+        .join("config.toml");
+    let mut root = if path.exists() {
+        let data = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        data.parse::<Value>()
+            .with_context(|| format!("failed to parse {}", path.display()))?
+    } else {
+        Value::Table(Default::default())
+    };
+    root = merge_theme_selection(root, name)?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let rendered = toml::to_string_pretty(&root)?;
+
+    std::fs::write(&path, rendered)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+pub(crate) fn load_theme_selection() -> Option<String> {
+    let path = find_devo_home().ok()?.join("config.toml");
+    let data = std::fs::read_to_string(&path).ok()?;
+    let root: Value = data.parse().ok()?;
+    root.get("theme")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn merge_theme_selection(mut root: Value, name: &str) -> Result<Value> {
+    let table = root
+        .as_table_mut()
+        .context("config root must be a TOML table")?;
+    table.insert("theme".to_string(), Value::String(name.to_string()));
+    Ok(root)
+}
+
 #[allow(dead_code)]
 fn merge_thinking_selection(mut root: Value, selection: Option<&str>) -> Result<Value> {
     let table = root

--- a/crates/tui/src/slash_command.rs
+++ b/crates/tui/src/slash_command.rs
@@ -1,6 +1,7 @@
 /// Commands that can be invoked by starting a message with a leading slash.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SlashCommand {
+    Theme,
     Model,
     Compact,
     Thinking,
@@ -17,6 +18,7 @@ pub enum SlashCommand {
 impl SlashCommand {
     pub fn description(self) -> &'static str {
         match self {
+            SlashCommand::Theme => "switch the UI theme",
             SlashCommand::Model => "choose the active model",
             SlashCommand::Compact => "compact the current session context",
             SlashCommand::Thinking => "choose the active thinking mode",
@@ -33,6 +35,7 @@ impl SlashCommand {
 
     pub fn command(self) -> &'static str {
         match self {
+            SlashCommand::Theme => "theme",
             SlashCommand::Model => "model",
             SlashCommand::Compact => "compact",
             SlashCommand::Thinking => "thinking",
@@ -52,7 +55,17 @@ impl SlashCommand {
     }
 
     pub fn available_during_task(self) -> bool {
-        !matches!(self, SlashCommand::Diff | SlashCommand::Compact)
+        !matches!(
+            self,
+            SlashCommand::Model
+                | SlashCommand::Theme
+                | SlashCommand::Thinking
+                | SlashCommand::Onboard
+                | SlashCommand::Compact
+                | SlashCommand::Diff
+                | SlashCommand::New
+                | SlashCommand::Resume
+        )
     }
 }
 
@@ -61,6 +74,7 @@ impl std::str::FromStr for SlashCommand {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
+            "theme" => Ok(Self::Theme),
             "model" => Ok(Self::Model),
             "compact" => Ok(Self::Compact),
             "thinking" => Ok(Self::Thinking),
@@ -79,6 +93,7 @@ impl std::str::FromStr for SlashCommand {
 
 pub fn built_in_slash_commands() -> Vec<(&'static str, SlashCommand)> {
     vec![
+        ("theme", SlashCommand::Theme),
         ("model", SlashCommand::Model),
         ("compact", SlashCommand::Compact),
         ("thinking", SlashCommand::Thinking),

--- a/crates/tui/src/state.rs
+++ b/crates/tui/src/state.rs
@@ -1,4 +1,5 @@
 use crate::events::TranscriptItem;
+use crate::theme::Theme;
 use std::collections::HashMap;
 
 #[derive(Debug, Default)]
@@ -14,14 +15,16 @@ pub(crate) struct TuiState {
     pub(crate) pending_assistant_index: Option<usize>,
     pub(crate) pending_reasoning_index: Option<usize>,
     pub(crate) pending_tool_items: HashMap<String, usize>,
+    pub(crate) active_theme: Theme,
 }
 
 impl TuiState {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new_with_theme(theme: Theme) -> Self {
         Self {
             title: "claw v2".to_string(),
             status_message: "Ready".to_string(),
             follow_output: true,
+            active_theme: theme,
             ..Default::default()
         }
     }

--- a/crates/tui/src/theme.rs
+++ b/crates/tui/src/theme.rs
@@ -1,0 +1,90 @@
+use ratatui::style::Color;
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub(crate) struct Theme {
+    pub(crate) name: String,
+    pub(crate) accent_color: Color,
+    pub(crate) cell_line_color: Color,
+    pub(crate) error_color: Color,
+    pub(crate) thinking_label_color: Color,
+    pub(crate) thinking_text_color: Color,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ThemeSet {
+    pub(crate) themes: Vec<Theme>,
+}
+
+impl Default for ThemeSet {
+    fn default() -> Self {
+        Self::builtin()
+    }
+}
+
+impl ThemeSet {
+    pub(crate) fn builtin() -> Self {
+        Self {
+            themes: vec![
+                Theme {
+                    name: "devo (default)".into(),
+                    accent_color: Color::Rgb(0x58, 0xA6, 0xFF), // blue
+                    cell_line_color: Color::Rgb(0x8B, 0x94, 0x9E), // gray
+                    error_color: Color::Rgb(0xF8, 0x51, 0x49),  // red
+                    thinking_label_color: Color::Rgb(0xD2, 0xA8, 0xFF), // purple
+                    thinking_text_color: Color::Rgb(0x8B, 0x94, 0x9E), // gray
+                },
+                Theme {
+                    name: "dark".into(),
+                    accent_color: Color::Rgb(0x58, 0xA6, 0xFF), // blue
+                    cell_line_color: Color::Rgb(0x48, 0x4F, 0x58), // muted gray
+                    error_color: Color::Rgb(0xDA, 0x36, 0x3B),  // warm red
+                    thinking_label_color: Color::Rgb(0xD2, 0xA8, 0xFF), // purple
+                    thinking_text_color: Color::Rgb(0x6E, 0x76, 0x81), // muted gray
+                },
+                Theme {
+                    name: "light".into(),
+                    accent_color: Color::Rgb(0x09, 0x6D, 0xD9), // vivid blue
+                    cell_line_color: Color::Rgb(0x8C, 0x95, 0x9E), // gray
+                    error_color: Color::Rgb(0xCF, 0x22, 0x2E),  // red
+                    thinking_label_color: Color::Rgb(0x82, 0x50, 0xDF), // purple
+                    thinking_text_color: Color::Rgb(0x65, 0x6D, 0x76), // gray
+                },
+                Theme {
+                    name: "aurora".into(),
+                    accent_color: Color::Rgb(0x78, 0xD0, 0xA8), // teal green
+                    cell_line_color: Color::Rgb(0x7B, 0x84, 0x92), // gray
+                    error_color: Color::Rgb(0xF7, 0x76, 0x8E),  // rose
+                    thinking_label_color: Color::Rgb(0xE0, 0xAF, 0x68), // warm gold
+                    thinking_text_color: Color::Rgb(0xA9, 0xB1, 0xBF), // light gray
+                },
+            ],
+        }
+    }
+
+    pub(crate) fn find(&self, name: &str) -> Option<&Theme> {
+        self.themes.iter().find(|t| t.name == name)
+    }
+
+    pub(crate) fn default_theme() -> &'static str {
+        "devo (default)"
+    }
+
+    pub(crate) fn tips() -> &'static [&'static str] {
+        &[
+            "Press Ctrl+T to toggle full-screen mode.",
+            "Type / to see available slash commands.",
+            "Use Esc to interrupt an active task.",
+            "Press Up/Down in the composer to browse input history.",
+            "Use /model to switch between configured models.",
+            "Use /theme to change the UI color scheme.",
+            "Use /status to see session configuration and token usage.",
+            "Use /compact to reclaim context window space.",
+            "Use /resume to pick up a previous chat.",
+            "Use /new to start a fresh session.",
+            "Ctrl+C or /exit to quit.",
+            "Alt+Up/Alt+Down to select turns in the transcript.",
+            "Use /diff to review changes.",
+            "Thinking effort can be configured via /model picker.",
+        ]
+    }
+}

--- a/crates/tui/src/tui.rs
+++ b/crates/tui/src/tui.rs
@@ -58,8 +58,10 @@ use crossterm::Command;
 use crossterm::SynchronizedUpdate;
 use crossterm::event::DisableBracketedPaste;
 use crossterm::event::DisableFocusChange;
+use crossterm::event::DisableMouseCapture;
 use crossterm::event::EnableBracketedPaste;
 use crossterm::event::EnableFocusChange;
+use crossterm::event::EnableMouseCapture;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyboardEnhancementFlags;
 use crossterm::event::PopKeyboardEnhancementFlags;
@@ -308,6 +310,7 @@ fn set_panic_hook() {
 pub enum TuiEvent {
     Key(KeyEvent),
     Paste(String),
+    Mouse(crossterm::event::MouseEvent),
     Draw,
 }
 
@@ -476,6 +479,7 @@ impl Tui {
         let _ = execute!(self.terminal.backend_mut(), EnterAlternateScreen);
         // Enable "alternate scroll" so terminals may translate wheel to arrows
         let _ = execute!(self.terminal.backend_mut(), EnableAlternateScroll);
+        let _ = execute!(self.terminal.backend_mut(), EnableMouseCapture);
         if let Ok(size) = self.terminal.size() {
             self.alt_saved_viewport = Some(self.terminal.viewport_area);
             self.terminal.set_viewport_area(ratatui::layout::Rect::new(
@@ -499,6 +503,7 @@ impl Tui {
             return Ok(());
         }
         // Disable alternate scroll when leaving alt-screen
+        let _ = execute!(self.terminal.backend_mut(), DisableMouseCapture);
         let _ = execute!(self.terminal.backend_mut(), DisableAlternateScroll);
         let _ = execute!(self.terminal.backend_mut(), LeaveAlternateScreen);
         if let Some(saved) = self.alt_saved_viewport.take() {

--- a/crates/tui/src/tui/event_stream.rs
+++ b/crates/tui/src/tui/event_stream.rs
@@ -236,7 +236,7 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
         }
     }
 
-    /// Map a crossterm event to a [`TuiEvent`], skipping events we don't use (mouse events, etc.).
+    /// Map a crossterm event to a [`TuiEvent`].
     fn map_crossterm_event(&mut self, event: Event) -> Option<TuiEvent> {
         match event {
             Event::Key(key_event) => {
@@ -249,6 +249,7 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
             }
             Event::Resize(_, _) => Some(TuiEvent::Draw),
             Event::Paste(pasted) => Some(TuiEvent::Paste(pasted)),
+            Event::Mouse(mouse_event) => Some(TuiEvent::Mouse(mouse_event)),
             Event::FocusGained => {
                 self.terminal_focused.store(true, Ordering::Relaxed);
                 self.needs_full_repaint.store(true, Ordering::Relaxed);
@@ -259,6 +260,7 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
                 self.terminal_focused.store(false, Ordering::Relaxed);
                 None
             }
+            #[allow(unreachable_patterns)]
             _ => None,
         }
     }

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -1,5 +1,5 @@
-# ClawCodeRust Design
-This document defines the specification for an SWE coding agent named devo, it is Claude Code / Codex Inspired. The documentation's goal is to guide implementation.
+# devo Design
+This document defines the specification for the devo coding agent. The documentation's goal is to guide implementation.
 
 ## 1. Overview
 Detailed specification: [Architecture Overview](./spec-overview-architecture.md)
@@ -10,8 +10,15 @@ The target crate split is:
 - `devo-tools`: built-in tool contracts and tool execution adapters
 - `devo-safety`: sandboxing, redaction, approvals, and safety policy
 - `devo-mcp`: MCP server lifecycle, discovery, and capability bridging
+- `devo-protocol`: shared structured types across crates (shell summaries, provider wire API enums, etc.)
 - `devo-server`: transport-neutral runtime API server
-- `devo-utils`: shared low-level utilities that are broadly reusable and not owned by a higher-level domain crate
+- `devo-client`: client library for connecting to devo-server
+- `devo-tui`: interactive terminal UI (ratatui/crossterm)
+- `devo-cli`: CLI binary entrypoint, config loading, command dispatch
+- `devo-utils`: shared low-level utilities (home dir, config paths, etc.)
+- `devo-arg0`: OS-specific arg0/binary path resolution
+- `devo-tasks`: background task state and long-running execution
+- `devo-file-search`: separate file-search binary for search functionality
 
 All crates must implement observability. At minimum, each crate must emit structured logs, useful tracing spans for long-running operations, and crate-appropriate metrics. Logging and observability are not optional add-ons; they are part of the baseline implementation contract.
 
@@ -192,10 +199,16 @@ Tools are a first-class subsystem. They are not just exposed model functions; th
 
 The first milestone should include at least:
 
-- shell command execution
-- file search
-- file reading
-- patch or file editing support
+- shell command execution (`bash` / `shell_command`)
+- file search (`glob` for filenames, `grep` for content)
+- file reading (`read`)
+- file writing (`write` / `file_write`)
+- patch or file editing support (`apply_patch`)
+- web content fetching (`webfetch`)
+- web search (`websearch`)
+- sub-agent task dispatch (`task`)
+- interactive user questions (`question`)
+- structured task list management (`todo_write`)
 
 Tool execution must follow a stable lifecycle:
 
@@ -234,7 +247,7 @@ The skills subsystem must support:
 Detailed specification: [Skills](./spec-skills.md)
 
 ## 1.8 Server API
-The agent runtime exposes a server API designed for integration with various user interfaces such as CLI tools, desktop applications, and IDE extensions. The API supports two transport: stdio (for local, process-based communication) and WebSocket (for networked or remote clients), follows a JSON-RPC 2.0 protocol (with the `"jsonrpc":"2.0"` header omitted on the wire). for structured request-response interactions. In addition to standard method calls for driving agent behavior (e.g., submitting user input, controlling execution), the API provides an event subscription mechanism, allowing clients to receive real-time updates such as streaming model outputs, tool execution progress, approval requests, and state changes.
+The agent runtime exposes a server API designed for integration with various user interfaces such as CLI tools, desktop applications, and IDE extensions. The API supports two transports: stdio (for local, process-based communication) and WebSocket (for networked or remote clients), follows a JSON-RPC 2.0 protocol (with the `"jsonrpc":"2.0"` header omitted on the wire) for structured request-response interactions. In addition to standard method calls for driving agent behavior (e.g., submitting user input, controlling execution), the API provides an event subscription mechanism, allowing clients to receive real-time updates such as streaming model outputs, tool execution progress, approval requests, and state changes.
 
 - stdio (`--listen stdio://`, default): newline-delimited JSON (JSONL)
 - websocket (`--listen ws://IP:PORT`): one JSON-RPC message per websocket text frame
@@ -304,4 +317,6 @@ The detailed specifications below are the implementation-facing source of truth 
 - [Skills](./spec-skills.md)
 - [Server API](./spec-server-api.md)
 - [App Config](./spec-app-config.md)
+- [Response Item IR](./spec-response-item.md)
+- [Interactive TUI](./spec-interactive-tui-v2.md)
 - [Observability via Architecture Overview](./spec-overview-architecture.md)

--- a/docs/spec-app-config.md
+++ b/docs/spec-app-config.md
@@ -115,24 +115,45 @@ pub struct UpdatesConfig {
 ## Partial Layer Format
 
 The filesystem loader reads a partial config layer from TOML and merges it into
-the normalized runtime config.
+the normalized runtime config. Merging is done via `toml::Value` table
+recursion, so any subset of config fields can be present in a partial layer file.
+
+## Provider Config (same file)
+
+The same `config.toml` file also holds provider and model configuration under
+`[model_providers.<id>]` sections:
 
 ```rust
-pub struct AppConfigOverrides {
-    pub enable_auxiliary_model: Option<bool>,
-    pub summary_model: Option<SummaryModelSelection>,
-    pub safety_policy_model: Option<SafetyPolicyModelSelection>,
-    pub context: Option<ContextManageOverrides>,
-    pub server: Option<ServerOverrides>,
-    pub logging: Option<LoggingOverrides>,
-    pub skills: Option<SkillsOverrides>,
-    pub updates: Option<UpdatesOverrides>,
-    pub project_root_markers: Option<Vec<String>>,
+pub struct ProviderConfigFile {
+    pub model_provider: Option<String>,
+    pub model: Option<String>,
+    pub model_thinking_selection: Option<String>,
+    pub model_auto_compact_token_limit: Option<u32>,
+    pub model_context_window: Option<u32>,
+    pub disable_response_storage: Option<bool>,
+    pub preferred_auth_method: Option<PreferredAuthMethod>,
+    pub model_providers: BTreeMap<String, ModelProviderConfig>,
+}
+
+pub struct ModelProviderConfig {
+    pub name: Option<String>,
+    pub base_url: Option<String>,
+    pub api_key: Option<String>,
+    pub wire_api: Option<ProviderWireApi>,
+    pub last_model: Option<String>,
+    pub default_model: Option<String>,
+    pub models: Vec<ConfiguredModel>,
+}
+
+pub struct ConfiguredModel {
+    pub model: String,
+    pub base_url: Option<String>,
+    pub api_key: Option<String>,
 }
 ```
 
-Nested override structs follow the same field structure as the normalized
-runtime structs, but every field is optional so file layers can merge cleanly.
+Provider settings are resolved via `resolve_provider_settings()` which selects
+the active provider and model from the config file.
 
 ## Loader Interface
 
@@ -177,8 +198,15 @@ for a newer `devo` version and how often a fresh network request is allowed.
 
 - user config: `DEVO_HOME/config.toml`
 - project config: `<workspace>/.devo/config.toml`
+- user model catalog: `DEVO_HOME/models.json` (JSON, seeded from builtin on first run)
+- project model catalog: `<workspace>/.devo/models.json` (JSON, optional override)
 
-Both files are optional. Missing files are not errors.
+Both TOML files are optional. Missing files are not errors.
+
+The `models.json` file uses the same merge semantics as `config.toml`:
+built-in defaults < user `models.json` < project `models.json`, merged by
+model `slug`. Users can override existing model entries (e.g. change
+`base_instructions` or `context_window`) or add custom models.
 
 ## Out Of Scope
 

--- a/docs/spec-context-management.md
+++ b/docs/spec-context-management.md
@@ -1,4 +1,4 @@
-# ClawCodeRust Detailed Specification: Context Management
+# devo Detailed Specification: Context Management
 
 ## Background and Goals
 

--- a/docs/spec-conversation.md
+++ b/docs/spec-conversation.md
@@ -1,4 +1,4 @@
-# ClawCodeRust Detailed Specification: Conversation
+# devo Detailed Specification: Conversation
 
 ## Background and Goals
 

--- a/docs/spec-interactive-tui-v2.md
+++ b/docs/spec-interactive-tui-v2.md
@@ -1,4 +1,4 @@
-# devo Detailed Specification: Interactive TUI v2
+# devo Detailed Specification: Interactive TUI
 
 ## Background and Goals
 
@@ -111,11 +111,31 @@ Requirements:
 - redraws must be explicitly scheduled rather than continuously repainting without state changes
 - the UI must preserve usable terminal scrollback rather than treating the entire session as disposable alternate-screen content
 - terminal restoration must occur on exit and on recoverable teardown paths
+- on exit — regardless of trigger (`/exit`, `Ctrl+C`, SIGKILL, panic) — the shell prompt must appear **directly below the bottom composer status line**, with no extra blank lines and no overlap with the transcript history above
+
+Exit position example (the `PS C:\...>` is the shell prompt):
+
+```
+  deepseek-v4-flash high  ↑0 ↓0  ░░░░░░░░░░ 0% (0) 
+PS C:\Users\lenovo\Desktop\devo>
+```
+
+The TUI must ensure the cursor is placed at the row immediately following the last visible status line before restoring the terminal.
 
 The terminal subsystem should:
 
 - tolerate terminals that do not support every keyboard enhancement capability
 - allow committed transcript history to move into normal scrollback while keeping the active interaction area live
+
+### Screen Modes
+
+The TUI supports two screen modes toggled by `Ctrl+T`:
+
+**Inline mode (default)** — the TUI renders directly into the terminal scrollback. Mouse interaction is not available. Tool output cells are collapsed by default and can be expanded via keyboard (`Enter` on a selected cell). This mode preserves usable terminal scrollback after exit.
+
+**Alternative screen mode** (`Ctrl+T` to enter) — the TUI switches to the terminal's alternate screen buffer. The transcript, composer, and all cells render identically to inline mode. Mouse events are captured so tool output cells can be clicked to expand or collapse. `Ctrl+T` toggles back to inline mode.
+
+On exit, if the TUI is in alternative screen mode, it must switch back to inline mode first, then restore the shell prompt position.
 
 ## Transcript Requirements
 
@@ -145,16 +165,175 @@ Requirements:
 - the composer must support paste input
 - the composer must submit user input through a normalized UI command path rather than invoking runtime calls directly
 - the composer must support slash command discovery and execution
-- the `/model` slash command opens a picker showing only configured models
-  (those with credentials in `config.toml`), not the full model catalog
+- typing `/` in the composer opens a command list popup above the input line;
+  the currently highlighted option is indicated by the theme's accent color:
+
+  ```
+  ┃ /
+
+    /theme     switch the UI theme
+    /model     choose the active model
+    /compact   compact the current session context
+    /resume    resume a saved chat
+    /new       start a new chat
+    /status    show current session configuration and token usage
+    /onboard   configure model provider connection
+  ```
+
+  `/thinking` is not included — thinking effort is configured through the `/model` picker instead.
+
+- the `/model` slash command opens a popup picker above the input line with two steps:
+
+  1. **Model picker** — list of configured models with vendor name and a `current` marker
+     on the active model; no header title:
+
+     ```
+       deepseek-v4-flash
+         DeepSeek
+       deepseek-v4-pro  current
+         DeepSeek
+       qwen3-coder-next
+         Qwen
+     ```
+
+     The currently highlighted row uses the theme's accent color.
+
+  2. **Thinking effort picker** — shown only if the selected model supports thinking;
+     lists effort levels with descriptions and a `current` marker:
+
+     ```
+       Off
+         Disable thinking for this turn
+       High  current
+         More deliberate for harder tasks
+       Max
+         Most deliberate, highest effort
+     ```
+
+     The highlighted row uses the theme's accent color. After selecting, the picker confirms and closes.
+- the `/theme` slash command opens a popup picker above the input line showing available themes with a `current` marker:
+
+  ```
+    devo (default)
+    dark
+    light  current
+    aurora
+  ```
+
+  The highlighted row uses the theme's accent color. Selecting a theme applies it immediately to all themed elements (borders, separators, accents, composer `┃`, cell `▌`). The selection persists across sessions.
+- the `/resume` slash command enters an alternative full-screen session picker:
+
+  ```
+  Devo Sessions
+  Resume Session
+  Use Up/Down to select a session, Enter to resume.
+  Esc to go back.
+
+    Title                                 Session ID                            Updated
+    ------------------------------------  ------------------------------------  -------------------
+    Hello, investigate the project , wi…  019ddc5f-7fa1-7622-b342-9439ea181a7c  2026-04-30 03:15:47 UTC
+    Hello, explain the project in chine…  019ddc39-f13f-7072-8fe7-3f7ed7344b6a  2026-04-30 02:31:18 UTC
+    Investigate the project, then answe…  019dd8b9-c85a-79b0-b97b-bcfb1dc40dc5  2026-04-29 10:12:36 UTC
+  ```
 - the composer must support browsing input history
+- the `/status` slash command renders a header-box-style info panel in the transcript showing current session configuration:
+
+  ```
+  ╭──────────────────────────────────────────────────────╮
+  │ Session Status                                       │
+  │                                                      │
+  │ model:       deepseek-v4-flash                       │
+  │ thinking:    high                                    │
+  │ cwd:         ~\Desktop\devo                          │
+  │ turns:       3                                       │
+  │ tokens:      ↑1,234 ↓45,678  ░░░░░░░░░░ 12% (58K)    │
+  ╰──────────────────────────────────────────────────────╯
+  ```
+
+  The panel reuses the header-box border style (`╭──╮` / `╰──╯`). Contents update to reflect current live state.
 - the composer must expose status or helper text when onboarding or popup flows need to steer the user
 
 Rules:
 
 - composer state changes that affect visible UI must trigger frame requests
 - popup behavior must be dismissible from the keyboard
+- during active processing (generating, compacting), configuration-changing slash commands (`/model`, `/onboard`, etc.) must be disabled; if the user invokes them, a single-line message is inserted into the transcript: `Cannot change model while generating`
 - the bottom pane must remain focused on devo-supported workflows and must not expose orphaned UI surfaces from imported code that devo does not support
+
+## Keybindings
+
+| Key | Context | Action |
+|-----|---------|--------|
+| `Enter` | composer | submit turn |
+| `Esc` | generating / compacting | interrupt active processing |
+| `Esc` | picker / popup / onboarding | go back or cancel |
+| `Up` / `Down` | composer | browse input history |
+| `Up` / `Down` | picker list | navigate options |
+| `Enter` | picker list | confirm selection |
+| `Enter` | tool cell (inline mode, selected) | expand / collapse tool output |
+| `Alt+Up` / `Alt+Down` | any | enter selection mode; move between user cells |
+| `Enter` | selection mode (on a user cell) | open action menu (Rollback / Fork / Cancel) |
+| `Esc` | selection mode | exit selection mode, return to composer |
+| Mouse click | tool cell (alt-screen mode) | expand / collapse tool output |
+| `Ctrl+T` | any | toggle inline / alternative screen mode |
+| `Ctrl+C` | any | exit TUI |
+| `/exit` | composer | exit TUI |
+| `/` | composer | open slash command list |
+| `Type to search` | onboarding model list | filter list by text |
+
+All pickers and popups are dismissible via `Esc`. The `/` slash list closes on `Esc` or on selecting a command.
+
+## History Interaction
+
+The user can browse, select, and act on past turns in the transcript.
+
+### Selection Mode
+
+`Alt+Up` / `Alt+Down` enters selection mode and moves the selection cursor between **user message cells** in the transcript. When in selection mode:
+
+- the selected user cell is visually highlighted — the `┃` prefix and the text use the theme's **accent color**
+- the status line updates to indicate the active selection:
+
+  ```
+  Selected turn 3 · Enter to act  Esc to cancel
+  ```
+
+- `Esc` exits selection mode and returns focus to the composer without action
+- `Enter` on a selected cell opens an action menu popup above the composer
+
+### Action Menu
+
+The action menu appears as a popup above the composer:
+
+```
+  ┃ Rollback
+  ┃ Fork
+  ┃ Cancel
+```
+
+The highlighted option uses the theme's accent color. `Up`/`Down` to navigate, `Enter` to confirm, `Esc` to dismiss.
+
+### Rollback
+
+Truncates the current session to the selected turn:
+
+- all turns after the selected one are discarded
+- the selected user message text is loaded into the composer for editing and re-submission
+- the transcript shows only content up to and including the selected turn
+
+### Fork
+
+Creates a new session from the selected turn:
+
+- a new session is created containing all transcript content from the beginning up to the selected turn
+- the selected user message text is loaded into the composer
+- the TUI switches to the new session immediately
+- the original session remains intact and accessible via `/resume`
+
+Rules:
+
+- selection mode is unavailable during active processing (generating, compacting)
+- Rollback and Fork are disabled on the **most recent** user turn (there is nothing to roll back from)
 
 ## Onboarding Requirements
 
@@ -279,6 +458,198 @@ This specification is satisfied when:
 - the worker cleanly bridges the UI to the runtime without leaking transport details into widgets
 - shell activity can be summarized through shared parsed-command types instead of renderer-only string heuristics
 - the user-visible interactive surface is limited to devo-supported behaviors rather than partially exposing foreign product features
+
+## Visual Style
+
+Below is the complete annotated layout of the TUI at launch (no prior interaction), with each visual region labeled.
+
+```
+                                                                              cell / region
+═══════════════════════════════════════════════════════════════════════════════════════════
+PS C:\Users\lenovo\Desktop\devo> .\target\debug\devo                                     │ shell prompt (pre-launch)
+                                                                                         │
+╭──────────────────────────────────────────────────────╮                                │
+│ >_  Devo (v0.1.3)                                    │  HEADER BOX                    │
+│                                                      │  - version from Cargo.toml     │
+│ model:     <model-name> <effort>   /model to change  │  - model + effort (live)       │
+│ directory: ~\Desktop\devo                            │  - cwd (live)                  │
+╰──────────────────────────────────────────────────────╯  - rendered only once on       │
+                                                           initial launch                │
+                                                                                         │
+  Tip: Random tip text here.                                     TIP AREA                │
+                                                                  - random from array     │
+                                                                                         │
+                                                                                         │
+                                                                  3 blank lines           │
+                                                                                         │
+┃ Ask Devo                                                     COMPOSER                 │
+                                                                  - ┃ in accent color     │
+  <model-name> <effort>  ↑0 ↓0  ░░░░░░░░░░ 0% (0)               STATUS LINE             │
+                                                                                         │
+PS C:\Users\lenovo\Desktop\devo>                                                        │ shell prompt (post-exit)
+```
+
+### Header Box
+
+- version must be in sync with the crate version in `Cargo.toml`
+- model name and thinking-reasoning-effort label must reflect the current active configuration
+- cwd must be shown and kept in sync with runtime state
+- rendered **only once** on initial TUI launch; switching or resuming a session must not re-render it
+
+### Tip Area
+
+- tips are stored in a configurable array
+- on each start, one tip is picked at random
+- prefixed with `  Tip:`
+
+### Composer Region
+
+- separated from content above by **three blank lines**
+- one blank line above the input line, one below
+- `┃` at the left edge of the input line in the theme's accent color
+- status line below shows: model name, effort, token usage (`↑` sent / `↓` received), context-window bar with percentage and approximate count
+
+### Transcript Cells (populated during a session)
+
+Each cell (user message, thinking, tool-ran, assistant reply) has:
+
+- a left vertical line (`▌`) in a color distinct from the composer's `┃`
+- adjacent cells separated by one blank line
+- identical rendering whether produced live or loaded from history
+
+#### User Message Cells
+
+```
+┃ Hello, explain the project in Chinese.
+```
+
+- `┃` uses the same composer accent color to visually tie user input to the composer
+- text is rendered in the default foreground color
+- no left `▌` line — user cells use `┃` instead to distinguish them from system/assistant cells
+
+#### Thinking and Tool Cells
+
+```
+▌ Thinking: The user wants me to explain the project in Chinese.
+```
+
+- `▌` is the left vertical line
+- `Thinking:` is italic with a distinct color
+- the rest of the text is gray
+
+Tool-ran cells follow the same convention. Tool output is rendered collapsed by default. In inline mode, use keyboard (`Enter` on a selected cell) to expand or collapse. In alternative screen mode, the cell is clickable to expand or collapse.
+
+The tool cell distinguishes success and failure:
+
+- **Success** — normal color:
+
+  ```
+  ▌ Ran bash cloc --version … +4 lines (exit 0)
+  ```
+
+- **Failure** — the entire `▌ Ran <command>` line renders in the theme's **error color**:
+
+  ```
+  ▌ Ran bash cloc --version 2>nul && cloc crates/ --by-file --quiet --hide-rate
+    working directory does not exist:
+  ```
+
+  A non-zero exit code or a runtime error triggers error coloring. The output content below the line is unaffected.
+
+#### Working Indicator
+
+During active processing (streaming, tool execution, thinking), a live working indicator must appear in the status line area:
+
+```
+  ⠴ Working (3s • esc to interrupt)
+```
+
+Requirements:
+
+- the leftmost character is a frame-based spinner animation (e.g. `⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏`)
+- the duration in seconds is live-updating
+- the hint `esc to interrupt` informs the user they can press Escape to cancel
+
+### Turn Footer
+
+The bottom of every completed turn (spanning thinking, tool calls, and assistant reply) includes a footer. Note that thinking content is model-dependent and may not appear in every turn.
+
+```
+  ▣ <model-name> · 15s
+```
+
+Requirements:
+
+- model name matches the model that generated the turn
+- if the turn completed normally, duration uses the largest appropriate unit: `s`, `h`, `d`, or `w`
+- if the turn was interrupted, the footer shows `interrupted` in place of the duration:
+
+```
+  ▣ <model-name> · interrupted
+```
+
+### Exit Position
+
+Regardless of exit method (`/exit`, `Ctrl+C`, kill, panic), the shell prompt must appear directly below the status line with no extra blank lines and no overlap with transcript history:
+
+```
+  <model-name> <effort>  ↑0 ↓0  ░░░░░░░░░░ 0% (0)
+PS C:\Users\lenovo\Desktop\devo>
+```
+
+The cursor must be placed at the row immediately following the last visible status line before terminal restoration.
+
+### General Appearance
+
+All borders, separators, and accents respect a configurable theme so the color scheme can be changed without altering layout logic. Each theme must define at minimum: an **accent color** (composer `┃`, highlighted list options), a **cell-line color** (transcript `▌`), and an **error color** (failed tool command lines). Themes are defined in a named set (built-in and user-defined in config). The active theme persists across sessions and is switched via `/theme`.
+
+### Onboarding Screen
+
+The onboarding screen uses an alternative full-screen layout with four vertical sections.
+
+#### Section 1 — Title
+
+```
+  Welcome to Devo
+  Choose a model to get started.
+```
+
+#### Section 2 — Search
+
+```
+  ▌ Search models...
+```
+
+A search input with the themed vertical line.
+
+#### Section 3 — Selectable List
+
+```
+  minimax-m2.7
+  glm-5.1
+  deepseek-v4-flash
+  deepseek-v4-pro
+```
+
+This section is scrollable with Up/Down navigation. The onboarding flow uses this same list layout sequentially:
+
+1. **Channel picker** — list of vendor groups (from the `channel` field in the model catalog)
+2. **Model picker** — models within the selected channel
+3. **Thinking effort picker** — shown only if the selected model supports thinking; lists available effort levels (e.g., `low`, `high`)
+4. **Provider SDK picker** — available provider SDKs for the chosen model
+5. **Base URL** — text input field
+6. **API key** — text input field
+
+No "Custom Model" entry appears in the model list. Users who need a custom model must add it manually via `model.json`.
+
+#### Section 4 — Bottom Hints
+
+```
+  ↑↓ Navigate  Enter Select  Type to search  Esc Cancel
+  To add a custom model, refer to model.json
+```
+
+The second line is an additional hint directing users to `model.json` for custom model registration. `Esc` exits the onboarding process.
 
 ## Open Questions and Follow-Up Work
 

--- a/docs/spec-interactive-tui-v2.md
+++ b/docs/spec-interactive-tui-v2.md
@@ -1,4 +1,4 @@
-# ClawCodeRust Detailed Specification: Interactive TUI v2
+# devo Detailed Specification: Interactive TUI v2
 
 ## Background and Goals
 
@@ -27,17 +27,17 @@ Out of scope:
 
 - desktop-only or GUI-only experiences
 - provider-specific API payload details
-- full approval-modal design for features not currently present in Claw
-- plugin, marketplace, or external product surfaces that are not part of Claw's runtime contract
+- full approval-modal design for features not currently present in devo
+- plugin, marketplace, or external product surfaces that are not part of devo's runtime contract
 
 ## Design Goals
 
 The interactive TUI must:
 
-- feel like a first-class Claw interface rather than a partial port
+- feel like a first-class devo interface rather than a partial port
 - keep terminal interaction responsive during streaming and long-running work
 - preserve clear ownership boundaries between UI, worker, and protocol/runtime code
-- expose only Claw-supported actions to the user
+- expose only devo-supported actions to the user
 - represent tool and shell activity in a human-readable form without depending on renderer-only heuristics
 
 ## Module Responsibilities and Boundaries
@@ -54,7 +54,7 @@ The interactive TUI must:
 - frame scheduling and redraw orchestration
 - transcript rendering
 - composer, popups, and onboarding interaction
-- Claw-local UI command and event types
+- devo-local UI command and event types
 - mapping runtime events into user-visible history cells and status indicators
 
 `devo-tui::worker` owns:
@@ -145,7 +145,8 @@ Requirements:
 - the composer must support paste input
 - the composer must submit user input through a normalized UI command path rather than invoking runtime calls directly
 - the composer must support slash command discovery and execution
-- the composer must support model selection from within the TUI
+- the `/model` slash command opens a picker showing only configured models
+  (those with credentials in `config.toml`), not the full model catalog
 - the composer must support browsing input history
 - the composer must expose status or helper text when onboarding or popup flows need to steer the user
 
@@ -153,7 +154,7 @@ Rules:
 
 - composer state changes that affect visible UI must trigger frame requests
 - popup behavior must be dismissible from the keyboard
-- the bottom pane must remain focused on Claw-supported workflows and must not expose orphaned UI surfaces from imported code that Claw does not support
+- the bottom pane must remain focused on devo-supported workflows and must not expose orphaned UI surfaces from imported code that devo does not support
 
 ## Onboarding Requirements
 
@@ -161,7 +162,10 @@ The TUI must support provider onboarding for first-run or forced-onboarding flow
 
 Requirements:
 
-- onboarding must allow the user to choose or enter a model
+- onboarding must allow the user to choose a channel (vendor group) first,
+  then a model within that channel
+- onboarding must present channels derived from the `channel` field in
+  the model catalog
 - onboarding must allow collection of optional base URL and API key values when required
 - onboarding must validate provider settings before they replace the active runtime configuration
 - successful onboarding must persist the resulting provider selection through the existing config path
@@ -169,7 +173,7 @@ Requirements:
 
 ## UI Command and Event Contract
 
-The interactive TUI must define a Claw-local command and event model.
+The interactive TUI must define a devo-local command and event model.
 
 Requirements for UI-to-host commands:
 
@@ -184,7 +188,7 @@ Requirements for internal app events:
 
 Rules:
 
-- the command/event surface must be Claw-owned and must not import large foreign product enums wholesale
+- the command/event surface must be devo-owned and must not import large foreign product enums wholesale
 - app commands must describe user intent, not renderer actions
 - app events must describe UI coordination, not transport protocol payloads
 
@@ -233,7 +237,7 @@ Rules:
 
 ## Supported UX Surface
 
-The first-class Claw interactive UI must support:
+The first-class devo interactive UI must support:
 
 - text chat turns
 - transcript rendering with streaming updates
@@ -242,13 +246,13 @@ The first-class Claw interactive UI must support:
 - thinking selection
 - slash-command initiated actions
 - shell command display and summary
-- session-level actions that Claw currently supports
+- session-level actions that devo currently supports
 
-The Claw interactive UI must not require support for:
+The devo interactive UI must not require support for:
 
 - plugin marketplace flows
-- external product approval overlays that Claw has not implemented
-- non-Claw request-user-input surfaces imported from other products
+- external product approval overlays that devo has not implemented
+- non-devo request-user-input surfaces imported from other products
 - unrelated experimental or promotional popups
 
 ## Testing Requirements
@@ -269,12 +273,12 @@ Rules:
 
 This specification is satisfied when:
 
-- `devo` launches into a Claw-owned interactive TUI flow backed by typed UI commands and events
+- `devo` launches into a devo-owned interactive TUI flow backed by typed UI commands and events
 - the TUI can onboard, submit turns, stream results, interrupt work, and shut down cleanly
 - terminal behavior remains responsive and restores correctly on exit
 - the worker cleanly bridges the UI to the runtime without leaking transport details into widgets
 - shell activity can be summarized through shared parsed-command types instead of renderer-only string heuristics
-- the user-visible interactive surface is limited to Claw-supported behaviors rather than partially exposing foreign product features
+- the user-visible interactive surface is limited to devo-supported behaviors rather than partially exposing foreign product features
 
 ## Open Questions and Follow-Up Work
 

--- a/docs/spec-language-model.md
+++ b/docs/spec-language-model.md
@@ -36,12 +36,11 @@ The overview defines the model contract and budget knobs but does not prescribe 
 
 ## Module Responsibilities and Boundaries
 
-`devo-core::model` owns:
+`devo-core::model_catalog` and `devo-core::model_preset` own:
 
-- Model catalog loading.
-- Capability lookup.
-- Provider-specific request normalization.
-- Fallback model resolution.
+- Model catalog loading from embedded JSON and filesystem overrides.
+- Capability lookup and model resolution.
+- Conversion from raw `ModelPreset` to runtime `Model`.
 
 `devo-core` owns:
 
@@ -51,7 +50,7 @@ The overview defines the model contract and budget knobs but does not prescribe 
 
 ## Model Catalog File Format
 
-The overview requires a config JSON file containing an array of model configs.
+The built-in model catalog is embedded at compile time from `crates/core/models.json`. At runtime, optional override files are merged on top:
 
 Required path:
 
@@ -65,99 +64,108 @@ Optional project override:
 <workspace>/.devo/models.json
 ```
 
-Merge order:
+Merge order by `slug`: built-in defaults < user file < project file. On first
+run, the built-in catalog is automatically copied to `~/.devo/models.json`.
 
-1. Built-in defaults compiled into the binary
-2. User-level file
-3. Project-level file
+```rust
+pub struct Model {
+    pub slug: String,
+    pub display_name: String,
+    pub provider: ProviderWireApi,
+    pub channel: Option<String>,           // vendor/brand grouping (e.g. "DeepSeek")
+    ...
+}
+```
 
-Model `slug` is the merge key.
+The `channel` field groups models by vendor for UI display (onboarding,
+model picker).
 
 ## Core Data Structures
 
 ```rust
-pub struct ModelConfig {
+pub struct Model {
     pub slug: String,
     pub display_name: String,
+    pub provider: ProviderWireApi,
     pub description: Option<String>,
-    pub default_reasoning_level: ReasoningLevel,
-    pub supported_reasoning_levels: Vec<ReasoningLevel>,
+    pub thinking_capability: ThinkingCapability,
+    pub default_reasoning_effort: Option<ReasoningEffort>,
+    pub thinking_implementation: Option<ThinkingImplementation>,
     pub base_instructions: String,
-    pub model_messages: Option<Vec<ModelMessageTemplate>>,
-    pub shell_type: ShellToolType,
-    pub apply_patch_tool_type: ApplyPatchToolType,
-    pub web_search_tool_type: WebSearchToolType,
-    pub supports_parallel_tool_calls: bool,
-    pub supports_search_tool: bool,
-    pub experimental_supported_tools: Vec<String>,
-    pub support_verbosity: bool,
-    pub default_verbosity: Verbosity,
-    pub supports_reasoning_summaries: bool,
-    pub default_reasoning_summary: ReasoningSummaryMode,
     pub context_window: u32,
-    pub effective_context_window_percent: u8,
-    pub auto_compact_token_limit: Option<u32>,
+    pub effective_context_window_percent: Option<u8>,
     pub truncation_policy: TruncationPolicyConfig,
     pub input_modalities: Vec<InputModality>,
     pub supports_image_detail_original: bool,
-    pub visibility: ModelVisibility,
-    pub supported_in_api: bool,
-    pub priority: i32,
-    pub availability_nux: Option<String>,
-    pub upgrade: Option<String>,
-    pub used_fallback_model_metadata: bool,
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub top_k: Option<f64>,
+    pub max_tokens: Option<u32>,
 }
 ```
 
-Enums must be explicit and closed:
+```rust
+pub struct ModelPreset {
+    pub slug: String,
+    pub display_name: String,
+    pub provider: ProviderWireApi,
+    pub description: Option<String>,
+    pub thinking_capability: ThinkingCapability,
+    pub supported_reasoning_levels: Vec<ReasoningEffort>,
+    pub default_reasoning_effort: Option<ReasoningEffort>,
+    pub thinking_implementation: Option<ThinkingImplementation>,
+    pub base_instructions: String,
+    pub context_window: u32,
+    pub effective_context_window_percent: Option<u8>,
+    pub truncation_policy: TruncationPolicyConfig,
+    pub input_modalities: Vec<InputModality>,
+    pub supports_image_detail_original: bool,
+    pub api_configured: bool,
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub top_k: Option<f64>,
+    pub max_tokens: Option<u32>,
+    pub priority: i32,
+}
+```
 
-- `ReasoningLevel = Low | Medium | High | XHigh`
-- `Verbosity = Low | Medium | High`
+`ModelPreset` is deserialized from the JSON catalog and converted into the runtime `Model` type via `From<ModelPreset>`. The runtime works exclusively with `Model`.
+
+Relevant enums:
+
+- `ThinkingCapability = Unsupported | Toggle | ToggleWithLevels(Vec<ReasoningEffort>) | Levels(Vec<ReasoningEffort>)`
+- `ReasoningEffort = Low | Medium | High | XHigh`
 - `InputModality = Text | Image`
-- `ModelVisibility = Visible | Hidden | Experimental`
+- `ProviderWireApi = OpenAIChatCompletions | OpenAIResponses | AnthropicMessages`
 
 ## Interface Definitions
 
 ```rust
 pub trait ModelCatalog {
-    fn list_visible(&self) -> Vec<&ModelConfig>;
-    fn get(&self, slug: &str) -> Option<&ModelConfig>;
-    fn resolve_for_turn(&self, requested: Option<&str>) -> Result<&ModelConfig, ModelConfigError>;
+    fn list_visible(&self) -> Vec<&Model>;
+    fn get(&self, slug: &str) -> Option<&Model>;
+    fn resolve_for_turn(&self, requested: Option<&str>) -> Result<&Model, ModelError>;
 }
 ```
 
 ```rust
-pub struct ResolvedTurnModel {
-    pub config: ModelConfig,
-    pub effective_compact_limit: u32,
-    pub effective_input_budget: u32,
-    pub tool_capabilities: ToolCapabilitySet,
+pub struct PresetModelCatalog {
+    models: Vec<Model>,
 }
 ```
 
-Provider request interface additions:
-
-```rust
-pub struct ModelInvocation {
-    pub model: String,
-    pub system: PromptEnvelope,
-    pub messages: Vec<RequestMessage>,
-    pub tools: Vec<ToolDefinition>,
-    pub settings: TurnModelSettings,
-}
-```
+`PresetModelCatalog` is the concrete implementation. It loads the built-in model catalog from embedded JSON (`crates/core/models.json`) at compile time as a fallback. At runtime, user-level and project-level `models.json` files may override or extend the catalog.
 
 ## Prompt Assembly
 
 Prompt assembly inputs, in order:
 
-1. Base instructions from `ModelConfig.base_instructions`
-2. Optional structured `model_messages`
-3. Safety constraint messages
-4. Context summary items
-5. Full recent conversation items
-6. Current user input
-7. Tool definitions
+1. Base instructions from `Model.base_instructions`
+2. Safety constraint messages
+3. Context summary items
+4. Full recent conversation items
+5. Current user input
+6. Tool definitions
 
 Requirements:
 
@@ -218,34 +226,25 @@ Rules:
 
 Model resolution for a turn:
 
-1. Load catalog.
-2. Resolve requested slug or default highest-priority visible model.
+1. Load catalog via `PresetModelCatalog::load()`.
+2. Resolve requested slug or fall back to the highest-priority visible model.
 3. Validate turn-level overrides.
 4. Derive effective context budget and tool capability set.
-5. Pass `ResolvedTurnModel` to prompt builder and provider.
+5. Pass resolved `Model` to prompt builder and provider.
 
 Fallback behavior:
 
 1. Provider error indicates unsupported model or routing failure.
 2. Resolve fallback candidate by same provider family or configured upgrade target.
-3. Record `used_fallback_model_metadata = true` in turn metadata.
+3. Record fallback metadata in turn metadata.
 4. Rebuild request if capabilities differ.
 
 ## Error Handling Strategy
 
-`ModelConfigError` variants:
+`ModelError` variants:
 
 - `ModelNotFound`
-- `InvalidCatalog`
-- `UnsupportedTurnOverride`
-- `ContextBudgetInvalid`
-- `CapabilityMismatch`
-
-`ProviderSelectionError` variants:
-
-- `ProviderUnavailable`
-- `FallbackUnavailable`
-- `ProviderModelMismatch`
+- `NoVisibleModels`
 
 ## Concurrency and Async Model
 
@@ -310,8 +309,7 @@ Acceptance criteria:
 
 Assumptions:
 
-- Model catalogs remain JSON for compatibility with the overview.
-- `model_messages` is provider-neutral and interpreted by prompt assembly, not by provider adapters directly.
+- Model catalogs remain JSON for compatibility.
 
 Open questions:
 .

--- a/docs/spec-overview-architecture.md
+++ b/docs/spec-overview-architecture.md
@@ -47,15 +47,21 @@ Out of scope:
 
 ## Target Crate Responsibilities
 
-| Crate | Responsibility | Mandatory Additions |
-| --- | --- | --- |
-| `devo-core` | Session, turn, item model, main loop, model integration, context management, persistence / rollout, event emission, coding workflow orchestration, long-running execution, background task state, and completion routing | Add explicit session repository, turn state machine, model catalog, provider adapters, tokenizer estimation hooks, compaction machinery, turn-linked task registry, execution lifecycle management, and completion notification flow |
-| `devo-tools` | Tool traits, registry, orchestration, execution metadata, common tools like fuzzy search, shell command, read_file, write_file, patch_file, web_search etc | Add typed tool-call journal records and approval integration points |
-| `devo-safety` | Policy evaluation, rules, approval scopes, secret redaction contracts, and sandbox integration | Add resource-scoped approvals, rule persistence, policy snapshots, and platform safety adapters |
-| `devo-mcp` | MCP connection management and dynamic capability ingestion | Expand from placeholder into server registry and bridge adapters |
-| `devo-server` | Transport-neutral runtime server, JSON-RPC v2.0, lifecycle, subscriptions, and connection management. tokio+axum+jsonwebtoken | Add stdio and WebSocket listeners, session routing, approval response plumbing, and event fanout |
-| `devo-cli` | Local bootstrap, config loading, REPL, and human-oriented terminal UX, TUI+crossterm | Add client-side server bootstrap hooks and approval UX adapters | Claude Code / Codex Inspired. |
-| `devo-utils` | Cross-cutting low-level helpers with no stable domain owner | Add shared path normalization, absolute-path, approval-presets, cache, cargo-bin, cli, elapsed, fuzzy-match, home-dir, image, json-to-toml, oss, output-truncation, path-utils, plugins, pty, readiness, rustls-provider, sandbox-summary, sleep-inhibitor, stream-parser, string, template etc |
+| Crate | Responsibility |
+| --- | --- |
+| `devo-core` | Session, turn, item model, main loop, model integration, context management, persistence / rollout, event emission, coding workflow orchestration, config loading, and runtime state |
+| `devo-tools` | Tool traits, registry, orchestration, execution metadata, built-in tools (shell command, file search, read, write, patch) |
+| `devo-safety` | Policy evaluation, rules, approval scopes, secret redaction contracts, and sandbox integration |
+| `devo-mcp` | MCP server lifecycle, capability discovery, and bridging |
+| `devo-protocol` | Shared structured types across crates (shell summaries, provider wire API enums, token usage, etc.) |
+| `devo-server` | Transport-neutral runtime server, JSON-RPC 2.0, lifecycle, subscriptions, and connection management |
+| `devo-client` | Client library for connecting to devo-server over stdio or WebSocket |
+| `devo-tui` | Interactive terminal UI (ratatui + crossterm) |
+| `devo-cli` | Local bootstrap, config loading, command dispatch, and terminal UX entrypoint |
+| `devo-utils` | Cross-cutting low-level helpers (home dir, config paths, path normalization, etc.) |
+| `devo-arg0` | OS-specific arg0/binary path resolution |
+| `devo-tasks` | Background task state and long-running execution |
+| `devo-file-search` | Separate file-search binary for search functionality |
 
 ## Shared Vocabulary
 

--- a/docs/spec-response-item.md
+++ b/docs/spec-response-item.md
@@ -1,52 +1,61 @@
-# Detail Specification: Response Item
+# devo Detailed Specification: Response Item
 
-This specification defines:
+## Background and Goals
 
-- The response IR (ResponseItem) – a unified representation of LLM conversation items.
-- A history management system that holds a sequence of ResponseItems together with token usage metadata, environment context, and provides utilities for mutation, normalisation, and prompt preparation.
-- A compaction method that summarises history via a separate LLM call when the token budget is exceeded.
+This specification defines the response IR (`ResponseItem`) — a unified
+representation of LLM conversation items used in prompt construction and
+history management.
 
-Implementations must reuse existing code where possible.
+## ResponseItem Variants
 
-The response IR should be defined as `ResponseItem` enum, currently it has Reason / Message / ToolCall / ToolCallOutput.
+The response IR is defined as a `ResponseItem` enum with these variants:
 
-- Reason is model reasonning output, some model has, some did not.
-- Message is user sent Message and model reply message, including Text and Image.
-- ToolCall is model tool call request.
-- ToolCallOutput is the tool call response.
-
-The implementation should reuse the current codebase. such as current code already defined Image message, text message, should implement reuse as possible.
+- `Reason` — model reasoning output (thinking/reasoning content)
+- `Message` — user messages and model replies, including Text and Image content
+- `ToolCall` — model tool-call request
+- `ToolCallOutput` — tool-call result
 
 ## History Management
 
-based on ResponseItem, there is a history management for context.
+History management holds a sequence of `ResponseItem`s with token usage metadata.
 
-Should have a normalize module, here is requirements.
-1. `ToolCall` and `ToolCallOutput` should be paired. That is, for a `ResponseItem` container, if remove an item, if remove `ToolCall`, then should remove the corresponding `ToolCallOutput`. If remove `ToolCallOutput`, then should remove the corresponding `TooCall` item.
-2. For a model, there is a modality array, contains Text / Image / Video modality, the normalize module should provider a method / function to remove the `ResponseItem` acording to the modality array.
+### Normalization Rules
 
-For the history management, should support the function, to remove the tail UserMessage, the goal is to remove the user message from tail (user drawback serveral last messages.) .
+1. `ToolCall` and `ToolCallOutput` items must remain paired. Removing a
+   `ToolCall` must also remove its corresponding `ToolCallOutput`, and vice versa.
+2. Items with unsupported modalities (e.g., images for a text-only model) should
+   be filtered according to the model's `input_modalities` configuration.
 
-The history management should have a item array, `Vec<ResponseItem>`, should pertain the token info, describing the current total token info. The token info stores info returned by LLM provider, since the current project is LLM provider agnostic, then here is my design for token info.
+### Token Info
 
-- input token: the input token count, returns by llm provider, supported by OpenAI chat completions, OpenAI responses, Anthropic messages API.
-- cached input token: the cached input token count, returns by llm provider, supported by OpenAI chat completions, OpenAI responses, Anthropic messages API.
-- output token: the output token count, returns by llm provider, supported by OpenAI chat completions, OpenAI responses, Anthropic messages API.
+The token info tracks counts reported by the LLM provider, abstracted across
+provider APIs:
 
-the history management should have a reference to context item, utilize for diff when context changed, containing os, shell, timezone, model, thinking effort, persona, date, etc.
+- `input_tokens` — input token count (supported by OpenAI chat completions,
+  OpenAI responses, Anthropic messages APIs)
+- `cached_input_tokens` — cached input token count
+- `output_tokens` — output token count
 
-the context item should have diff method to produce 'diff prompt' for context item.
+### Context Items
 
-the history management should have a `for prompt` method to prepare prompt for a LLM call.
+History management maintains a reference to context items (OS, shell, timezone,
+model, thinking effort, persona, date, etc.) for detecting context changes and
+generating diff prompts.
 
 ## Compaction
 
-For the context management, there should be a compaction module, it is a seprate LLM call.
+Compaction is a separate LLM call that summarizes history when the context
+window threshold is exceeded:
 
-The LLM call compact the current history, it it exceeds the context window, then it remove the oldest history item and retry.
+1. Estimate current token usage.
+2. If over the auto-compact threshold, select oldest eligible history items.
+3. Build a summarization prompt.
+4. Invoke the model to generate a summary.
+5. Replace compacted history with the summary, preserving recent turns.
 
-The compaction result should have a prefix prompt to indicate this is the compaction of history.
+The compaction result includes a prefix prompt indicating the content is a
+historical summary. The system preserves a configurable number of recent turns
+(`preserve_recent_turns`) after compaction.
 
-And what's more, we should have a limit token buget for pertain user rencent message after compaction.
-
-For the compaction, I think we'd better filterd Reason, only keep Message (Text / Image / Video (only when model support image/viode)), ToolCall, ToolCallOutput.
+During compaction, `Reason` items may be filtered out, keeping only `Message`,
+`ToolCall`, and `ToolCallOutput` items to reduce token usage.

--- a/docs/spec-safety.md
+++ b/docs/spec-safety.md
@@ -1,4 +1,4 @@
-# ClawCodeRust Detailed Specification: Safety
+# devo Detailed Specification: Safety
 
 ## Background and Goals
 

--- a/docs/spec-server-api.md
+++ b/docs/spec-server-api.md
@@ -1,4 +1,4 @@
-# ClawCodeRust Detailed Specification: Server API
+# devo Detailed Specification: Server API
 
 ## Background and Goals
 
@@ -197,7 +197,9 @@ Rules:
 - returns the currently discovered user and workspace skills
 - skill records include `id`, `name`, `description`, `path`, `enabled`, and `source`
 
-### `skills/changed`
+## Model Methods
+
+### `model/catalog`
 
 Request fields:
 
@@ -205,12 +207,28 @@ Request fields:
 
 Response fields:
 
-- `skills`
+- `models`
 
 Rules:
 
-- re-runs skill discovery and returns the latest skill snapshot
-- this method is poll-style for now; it does not require filesystem watch support
+- returns the merged model catalog (builtin + user `models.json` + project `models.json`)
+- each entry includes `slug`, `display_name`, `channel`, `description`, `provider`, `context_window`, `thinking_capability`, `input_modalities`, `max_tokens`
+
+### `model/saved`
+
+Request fields:
+
+- none
+
+Response fields:
+
+- `models`
+
+Rules:
+
+- returns only models that have been configured with credentials in `config.toml`
+- each entry includes `slug`, `display_name`, `channel`, `description`, `provider_id`, `wire_api`, `context_window`
+- cross-references the model catalog for display metadata
 
 ## Turn Methods
 

--- a/docs/spec-tools.md
+++ b/docs/spec-tools.md
@@ -1,4 +1,4 @@
-# ClawCodeRust Detailed Specification: Tools
+# devo Detailed Specification: Tools
 
 ## Background and Goals
 
@@ -159,20 +159,14 @@ pub enum ToolContent {
 
 ```rust
 #[async_trait]
-pub trait Tool: Send + Sync {
-    fn definition(&self) -> ToolDefinition;
+pub trait ToolHandler: Send + Sync {
+    fn tool_kind(&self) -> ToolHandlerKind;
 
-    async fn validate(
+    async fn handle(
         &self,
-        input: &serde_json::Value,
-    ) -> Result<(), ToolInputError>;
-
-    async fn execute(
-        &self,
-        input: serde_json::Value,
-        ctx: ToolExecutionContext,
-        reporter: Arc<dyn ToolProgressReporter>,
-    ) -> Result<ToolExecutionOutcome, ToolExecuteError>;
+        invocation: ToolInvocation,
+        progress: Option<ToolProgressSender>,
+    ) -> Result<Box<dyn ToolOutput>, ToolExecutionError>;
 }
 ```
 
@@ -212,21 +206,22 @@ Rules:
 
 ## Built-in Tool Set
 
-The first milestone should define these built-in tools:
+The current built-in tools in `devo-tools` include:
 
-- `shell_command`
-- `file_search`
-- `apply_patch`
-- `read_file`
-- `write_file` only if explicitly separated from `apply_patch`
-
-The design below makes `shell_command` and `file_search` mandatory because they are core to coding-agent behavior and have strong Codex reference material.
-
-Boundary rules:
-
-- built-in tools are owned and implemented directly in `devo-tools`
-- MCP-contributed capabilities are specified in [spec-mcp.md](./spec-mcp.md) and only enter this layer after normalization
-- skills are not tools and must not be modeled as tool definitions in `devo-tools`
+- `bash` / `shell_command` — shell command execution
+- `apply_patch` — file editing via patch application
+- `read` — file reading
+- `write` / `file_write` — file writing
+- `glob` — filename pattern matching
+- `grep` — content search with regex
+- `webfetch` — HTTP content fetching
+- `websearch` — web search
+- `task` — sub-agent task dispatch
+- `question` — interactive user questions
+- `todo_write` — structured task list management
+- `skill` — skill loading
+- `plan` — plan mode support
+- `lsp` — language server protocol integration
 
 ## Shell Command Tool
 


### PR DESCRIPTION
- server: event_task post-loop cleanup uses session.deferred_assistant.take() instead of local vars — prevents handle_interrupt from racing to complete the same items and pushing duplicate SessionHistoryItem entries.
- test: GatedProvider/GatedStream integration test verifies no duplicate Assistant/Reasoning items after interrupt + rebuild + resume.
- tui: header box rendered only once on initial launch (no re-render on session switch/resume), per spec.