### PR TITLE
Add prompt JSON output formats

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -24,6 +24,7 @@ mod prompt_command;
 
 use agent_command::run_agent;
 use doctor_command::run_doctor;
+use prompt_command::PromptOutputFormat;
 use prompt_command::run_prompt;
 
 /// Top-level `devo` command that dispatches to interactive agent mode or one
@@ -34,6 +35,10 @@ use prompt_command::run_prompt;
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
+
+    /// Override the model used for this session.
+    #[arg(long, global = true)]
+    model: Option<String>,
 
     /// Override the logging level for this process.
     #[arg(
@@ -148,10 +153,10 @@ async fn run_cli() -> Result<()> {
             }
             Ok(())
         }
-        Some(Command::Prompt { input }) => {
+        Some(Command::Prompt { input, format }) => {
             maybe_print_startup_update(&cli).await;
             let _logging = install_logging(&cli)?;
-            run_prompt(input, log_level.as_deref()).await
+            run_prompt(input, cli.model.as_deref(), log_level.as_deref(), *format).await
         }
         Some(Command::Doctor) => {
             let _logging = install_logging(&cli)?;
@@ -212,6 +217,9 @@ enum Command {
     },
     /// Send a single prompt to the model and print the response (non-interactive).
     Prompt {
+        /// Output format for non-interactive prompt execution.
+        #[arg(long, value_enum, default_value_t = PromptOutputFormat::Text)]
+        format: PromptOutputFormat,
         /// The prompt text to send to the model.
         input: String,
     },
@@ -313,6 +321,7 @@ mod tests {
 
     use super::Cli;
     use super::Command;
+    use super::PromptOutputFormat;
     use super::cli_logging_overrides;
     use super::exit_messages;
     use super::format_token_usage_line;
@@ -351,6 +360,7 @@ mod tests {
         ] {
             let cli = Cli {
                 command: None,
+                model: None,
                 log_level: Some(level),
             };
 
@@ -372,16 +382,20 @@ mod tests {
         for cli in [
             Cli {
                 command: None,
+                model: None,
                 log_level: None,
             },
             Cli {
                 command: Some(Command::Onboard),
+                model: None,
                 log_level: None,
             },
             Cli {
                 command: Some(Command::Prompt {
                     input: "hello".to_string(),
+                    format: PromptOutputFormat::Text,
                 }),
+                model: None,
                 log_level: None,
             },
         ] {
@@ -399,6 +413,7 @@ mod tests {
     fn startup_update_check_scope_skips_server_and_doctor() {
         let doctor = Cli {
             command: Some(Command::Doctor),
+            model: None,
             log_level: None,
         };
         let server = Cli {
@@ -406,6 +421,7 @@ mod tests {
                 working_root: None,
                 transport: devo_server::ServerTransportMode::Config,
             }),
+            model: None,
             log_level: None,
         };
 
@@ -434,6 +450,20 @@ mod tests {
         match cli.command {
             Some(Command::Resume { session_id: actual }) => assert_eq!(actual, session_id),
             other => panic!("expected resume command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_prompt_jsonl_output_format() {
+        let cli =
+            Cli::try_parse_from(["devo", "prompt", "--format", "jsonl", "hello"]).expect("parse");
+
+        match cli.command {
+            Some(Command::Prompt { input, format }) => {
+                assert_eq!(input, "hello");
+                assert_eq!(format, PromptOutputFormat::Jsonl);
+            }
+            other => panic!("expected prompt command, got {other:?}"),
         }
     }
 

--- a/crates/cli/src/prompt_command.rs
+++ b/crates/cli/src/prompt_command.rs
@@ -1,16 +1,35 @@
 use anyhow::Result;
+use clap::ValueEnum;
 use devo_core::AgentsMdConfig;
 use devo_core::AppConfig;
 use devo_core::AppConfigLoader;
+use devo_core::EventCallback;
 use devo_core::FileSystemAppConfigLoader;
 use devo_core::ModelCatalog;
 use devo_core::PresetModelCatalog;
+use devo_core::QueryEvent;
 use devo_core::tools::ToolPlanConfig;
 use devo_core::tools::handlers;
 use devo_mcp::manager::RmcpMcpManager;
 use devo_utils::find_devo_home;
+use serde::Serialize;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
 
-pub(crate) async fn run_prompt(input: &str, log_level: Option<&str>) -> Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum PromptOutputFormat {
+    Text,
+    Json,
+    Jsonl,
+}
+
+pub(crate) async fn run_prompt(
+    input: &str,
+    model_override: Option<&str>,
+    log_level: Option<&str>,
+    output_format: PromptOutputFormat,
+) -> Result<()> {
     if let Some(level) = log_level {
         let _ = tracing_subscriber::fmt()
             .with_env_filter(tracing_subscriber::EnvFilter::new(level))
@@ -26,8 +45,10 @@ pub(crate) async fn run_prompt(input: &str, log_level: Option<&str>) -> Result<(
     let app_config = FileSystemAppConfigLoader::new(home_dir.clone())
         .load(Some(cwd.as_path()))
         .unwrap_or_else(|_| AppConfig::default());
-    let provider = devo_server::load_server_provider(&app_config, None, &home_dir)?;
-    let selected_model = provider.default_model.clone();
+    let provider = devo_server::load_server_provider(&app_config, model_override, &home_dir)?;
+    let selected_model = model_override
+        .map(ToString::to_string)
+        .unwrap_or_else(|| provider.default_model.clone());
 
     let mut session_state = SessionState::new(
         SessionConfig {
@@ -76,22 +97,61 @@ pub(crate) async fn run_prompt(input: &str, log_level: Option<&str>) -> Result<(
 
     eprintln!("devo [prompt] model={selected_model} sending...");
 
+    if output_format == PromptOutputFormat::Jsonl {
+        write_jsonl(&PromptJsonlEvent::SessionStarted {
+            session_id: session_state.id.as_str(),
+            model: selected_model.as_str(),
+            cwd: cwd.as_path(),
+        })?;
+        write_jsonl(&PromptJsonlEvent::TurnStarted {
+            session_id: session_state.id.as_str(),
+            model: selected_model.as_str(),
+        })?;
+    }
+
+    let session_id_for_events = session_state.id.clone();
     let result = devo_core::query(
         &mut session_state,
         &turn_config,
         provider.provider.clone(),
         registry,
         &runtime,
-        None,
+        jsonl_event_callback(output_format, session_id_for_events),
     )
     .await;
 
     match result {
         Ok(()) => match latest_assistant_text(&session_state.messages) {
-            Some(text) => println!("{}", text),
+            Some(text) => match output_format {
+                PromptOutputFormat::Text => println!("{}", text),
+                PromptOutputFormat::Json => write_json(&PromptResult {
+                    r#type: "result",
+                    status: "completed",
+                    session_id: session_state.id.as_str(),
+                    model: selected_model.as_str(),
+                    message: text,
+                    usage: PromptUsage::from_session(&session_state),
+                })?,
+                PromptOutputFormat::Jsonl => write_jsonl(&PromptJsonlEvent::Result {
+                    session_id: session_state.id.as_str(),
+                    status: "completed",
+                    message: text,
+                    usage: PromptUsage::from_session(&session_state),
+                })?,
+            },
             None => eprintln!("devo [prompt] empty response"),
         },
         Err(e) => {
+            if output_format == PromptOutputFormat::Jsonl {
+                write_jsonl(&PromptJsonlEvent::Error {
+                    session_id: session_state.id.as_str(),
+                    message: &e.to_string(),
+                })?;
+                write_jsonl(&PromptJsonlEvent::TurnFailed {
+                    session_id: session_state.id.as_str(),
+                    message: &e.to_string(),
+                })?;
+            }
             anyhow::bail!("prompt failed: {e}");
         }
     }
@@ -99,17 +159,287 @@ pub(crate) async fn run_prompt(input: &str, log_level: Option<&str>) -> Result<(
     Ok(())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct PromptUsage {
+    input_tokens: usize,
+    output_tokens: usize,
+    cache_creation_input_tokens: usize,
+    cache_read_input_tokens: usize,
+}
+
+impl PromptUsage {
+    fn from_session(session: &devo_core::SessionState) -> Self {
+        Self {
+            input_tokens: session.total_input_tokens,
+            output_tokens: session.total_output_tokens,
+            cache_creation_input_tokens: session.total_cache_creation_tokens,
+            cache_read_input_tokens: session.total_cache_read_tokens,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct PromptResult<'a> {
+    r#type: &'static str,
+    status: &'static str,
+    session_id: &'a str,
+    model: &'a str,
+    message: &'a str,
+    usage: PromptUsage,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum PromptJsonlEvent<'a> {
+    #[serde(rename = "session.started")]
+    SessionStarted {
+        session_id: &'a str,
+        model: &'a str,
+        cwd: &'a Path,
+    },
+    #[serde(rename = "turn.started")]
+    TurnStarted { session_id: &'a str, model: &'a str },
+    #[serde(rename = "item.updated")]
+    AssistantMessageDelta {
+        session_id: &'a str,
+        item_type: &'static str,
+        delta: &'a str,
+    },
+    #[serde(rename = "item.updated")]
+    ReasoningDelta {
+        session_id: &'a str,
+        item_type: &'static str,
+        delta: &'a str,
+    },
+    #[serde(rename = "item.completed")]
+    ReasoningCompleted {
+        session_id: &'a str,
+        item_type: &'static str,
+    },
+    #[serde(rename = "item.started")]
+    ToolCallStarted {
+        session_id: &'a str,
+        item_type: &'static str,
+        tool_call_id: &'a str,
+        tool_name: &'a str,
+        input: &'a serde_json::Value,
+    },
+    #[serde(rename = "item.updated")]
+    ToolProgress {
+        session_id: &'a str,
+        item_type: &'static str,
+        tool_call_id: &'a str,
+        delta: &'a str,
+    },
+    #[serde(rename = "item.completed")]
+    ToolResult {
+        session_id: &'a str,
+        item_type: &'static str,
+        tool_call_id: &'a str,
+        tool_name: &'a str,
+        input: &'a serde_json::Value,
+        content: &'a devo_core::tools::ToolContent,
+        display_content: &'a Option<String>,
+        is_error: bool,
+        summary: &'a str,
+    },
+    #[serde(rename = "turn.usage_delta")]
+    UsageDelta {
+        session_id: &'a str,
+        usage: PromptUsageDelta,
+    },
+    #[serde(rename = "turn.usage")]
+    Usage {
+        session_id: &'a str,
+        usage: PromptUsageDelta,
+    },
+    #[serde(rename = "turn.completed")]
+    TurnCompleted {
+        session_id: &'a str,
+        stop_reason: &'a devo_core::StopReason,
+    },
+    #[serde(rename = "turn.failed")]
+    TurnFailed {
+        session_id: &'a str,
+        message: &'a str,
+    },
+    #[serde(rename = "error")]
+    Error {
+        session_id: &'a str,
+        message: &'a str,
+    },
+    #[serde(rename = "result")]
+    Result {
+        session_id: &'a str,
+        status: &'static str,
+        message: &'a str,
+        usage: PromptUsage,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+struct PromptUsageDelta {
+    input_tokens: usize,
+    output_tokens: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_creation_input_tokens: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_read_input_tokens: Option<usize>,
+}
+
+impl PromptUsageDelta {
+    fn new(
+        input_tokens: usize,
+        output_tokens: usize,
+        cache_creation_input_tokens: Option<usize>,
+        cache_read_input_tokens: Option<usize>,
+    ) -> Self {
+        Self {
+            input_tokens,
+            output_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
+        }
+    }
+}
+
+fn jsonl_event_callback(
+    output_format: PromptOutputFormat,
+    session_id: String,
+) -> Option<EventCallback> {
+    if output_format != PromptOutputFormat::Jsonl {
+        return None;
+    }
+
+    Some(Arc::new(move |event| {
+        if let Err(error) = write_query_event_jsonl(session_id.as_str(), &event) {
+            eprintln!("devo [prompt] failed to write jsonl event: {error}");
+        }
+    }))
+}
+
+fn write_query_event_jsonl(session_id: &str, event: &QueryEvent) -> Result<()> {
+    match event {
+        QueryEvent::TextDelta(text) => write_jsonl(&PromptJsonlEvent::AssistantMessageDelta {
+            session_id,
+            item_type: "agent_message",
+            delta: text,
+        }),
+        QueryEvent::ReasoningDelta(text) => write_jsonl(&PromptJsonlEvent::ReasoningDelta {
+            session_id,
+            item_type: "reasoning",
+            delta: text,
+        }),
+        QueryEvent::ReasoningCompleted => write_jsonl(&PromptJsonlEvent::ReasoningCompleted {
+            session_id,
+            item_type: "reasoning",
+        }),
+        QueryEvent::UsageDelta {
+            input_tokens,
+            output_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
+        } => write_jsonl(&PromptJsonlEvent::UsageDelta {
+            session_id,
+            usage: PromptUsageDelta::new(
+                *input_tokens,
+                *output_tokens,
+                *cache_creation_input_tokens,
+                *cache_read_input_tokens,
+            ),
+        }),
+        QueryEvent::ToolUseStart { id, name, input } => {
+            write_jsonl(&PromptJsonlEvent::ToolCallStarted {
+                session_id,
+                item_type: "tool_call",
+                tool_call_id: id,
+                tool_name: name,
+                input,
+            })
+        }
+        QueryEvent::ToolProgress {
+            tool_use_id,
+            content,
+        } => write_jsonl(&PromptJsonlEvent::ToolProgress {
+            session_id,
+            item_type: "tool_result",
+            tool_call_id: tool_use_id,
+            delta: content,
+        }),
+        QueryEvent::ToolResult {
+            tool_use_id,
+            tool_name,
+            input,
+            content,
+            display_content,
+            is_error,
+            summary,
+        } => write_jsonl(&PromptJsonlEvent::ToolResult {
+            session_id,
+            item_type: "tool_result",
+            tool_call_id: tool_use_id,
+            tool_name,
+            input,
+            content,
+            display_content,
+            is_error: *is_error,
+            summary,
+        }),
+        QueryEvent::TurnComplete { stop_reason } => write_jsonl(&PromptJsonlEvent::TurnCompleted {
+            session_id,
+            stop_reason,
+        }),
+        QueryEvent::Usage {
+            input_tokens,
+            output_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
+        } => write_jsonl(&PromptJsonlEvent::Usage {
+            session_id,
+            usage: PromptUsageDelta::new(
+                *input_tokens,
+                *output_tokens,
+                *cache_creation_input_tokens,
+                *cache_read_input_tokens,
+            ),
+        }),
+    }
+}
+
+fn write_json<T: Serialize>(value: &T) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    serde_json::to_writer(&mut stdout, value)?;
+    writeln!(stdout)?;
+    Ok(())
+}
+
+fn write_jsonl<T: Serialize>(value: &T) -> Result<()> {
+    write_json(value)
+}
+
 fn latest_assistant_text(messages: &[devo_core::Message]) -> Option<&str> {
     messages.iter().rev().find_map(|message| {
         if message.role != devo_core::Role::Assistant {
             return None;
         }
-        message.content.iter().find_map(|block| match block {
-            devo_core::ContentBlock::Reasoning { text } => Some(text.as_str()),
-            devo_core::ContentBlock::Text { text } => Some(text.as_str()),
-            devo_core::ContentBlock::ToolUse { .. }
-            | devo_core::ContentBlock::ToolResult { .. } => None,
-        })
+        message
+            .content
+            .iter()
+            .find_map(|block| match block {
+                devo_core::ContentBlock::Text { text } => Some(text.as_str()),
+                devo_core::ContentBlock::Reasoning { .. }
+                | devo_core::ContentBlock::ToolUse { .. }
+                | devo_core::ContentBlock::ToolResult { .. } => None,
+            })
+            .or_else(|| {
+                message.content.iter().find_map(|block| match block {
+                    devo_core::ContentBlock::Reasoning { text } => Some(text.as_str()),
+                    devo_core::ContentBlock::Text { .. }
+                    | devo_core::ContentBlock::ToolUse { .. }
+                    | devo_core::ContentBlock::ToolResult { .. } => None,
+                })
+            })
     })
 }
 
@@ -118,9 +448,45 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::latest_assistant_text;
+    use super::{PromptResult, PromptUsage};
     use devo_core::ContentBlock;
     use devo_core::Message;
     use devo_core::Role;
+
+    #[test]
+    fn prompt_result_serializes_completed_json_shape() {
+        let value = serde_json::to_value(PromptResult {
+            r#type: "result",
+            status: "completed",
+            session_id: "session-1",
+            model: "model-1",
+            message: "done",
+            usage: PromptUsage {
+                input_tokens: 3,
+                output_tokens: 5,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 2,
+            },
+        })
+        .expect("serialize prompt result");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "type": "result",
+                "status": "completed",
+                "session_id": "session-1",
+                "model": "model-1",
+                "message": "done",
+                "usage": {
+                    "input_tokens": 3,
+                    "output_tokens": 5,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 2
+                }
+            })
+        );
+    }
 
     #[test]
     fn latest_assistant_text_returns_none_for_empty_messages() {
@@ -180,5 +546,22 @@ mod tests {
         }];
 
         assert_eq!(latest_assistant_text(&messages), Some("first text"));
+    }
+
+    #[test]
+    fn latest_assistant_text_prefers_text_over_reasoning() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::Reasoning {
+                    text: "internal summary".to_string(),
+                },
+                ContentBlock::Text {
+                    text: "final answer".to_string(),
+                },
+            ],
+        }];
+
+        assert_eq!(latest_assistant_text(&messages), Some("final answer"));
     }
 }


### PR DESCRIPTION
## 概要

本 PR 为 `devo prompt` 增加结构化输出能力，参考 Codex 的 CLI 输出模式，让 Devo 更容易被 Multica 这类 agent runtime 或自动化平台集成。

新增输出模式：
- `--format text`：保持现有默认行为，输出人类可读文本。
- `--format json`：执行完成后输出一次最终 JSON 结果对象，便于程序读取最终回答。
- `--format jsonl`：执行过程中按 JSON Lines 流式输出事件，包含 session/turn 生命周期、assistant 文本增量、reasoning 增量、tool 调用/结果、usage、最终 result 和 error。

## 设计说明

- 默认仍然是 `text`，不影响现有 CLI 使用方式。
- 机器可解析内容走 stdout，诊断信息走 stderr，避免污染 JSON/JSONL 输出。
- JSONL 事件复用 Devo 当前已有的 `QueryEvent` 流，不另起一套执行路径。
- 同时保留 `--model` 参数，方便外部 runtime 在非交互 prompt 模式下指定模型。

## 验证

- `cargo fmt`
- `cargo test -p devo-cli`
- `cargo check --workspace`
- `git diff --check upstream/main..HEAD`