### PR TITLE
feat(core): make code-search an optional feature

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -5,9 +5,17 @@ license.workspace = true
 name = "devo-core"
 version.workspace = true
 
+[features]
+default = ["code-search"]
+# Semantic code search tool (`code_search`). Optional because it pulls in heavy
+# dependencies (tokenizers, model2vec, hf-hub/hf-xet, hnsw_rs and the full
+# tree-sitter grammar set). Disable with `--no-default-features` for a slim
+# build that omits the entire code-search stack.
+code-search = ["dep:devo-code-search"]
+
 [dependencies]
 devo-config = { workspace = true }
-devo-code-search = { workspace = true }
+devo-code-search = { workspace = true, optional = true }
 devo-network-proxy = { workspace = true }
 devo-protocol = { workspace = true }
 devo-provider = { workspace = true }

--- a/crates/core/src/tools/handlers/mod.rs
+++ b/crates/core/src/tools/handlers/mod.rs
@@ -1,6 +1,7 @@
 mod agent;
 mod apply_patch;
 mod bash;
+#[cfg(feature = "code-search")]
 mod code_search;
 mod exec_command;
 mod file_write;
@@ -23,6 +24,7 @@ mod websearch;
 pub use agent::register_agent_tools;
 pub use apply_patch::ApplyPatchHandler;
 pub use bash::BashHandler;
+#[cfg(feature = "code-search")]
 pub use code_search::CodeSearchHandler;
 pub use exec_command::{ExecCommandHandler, WriteStdinHandler};
 pub use file_write::WriteHandler;
@@ -130,7 +132,14 @@ fn build_registry_from_builder(
     for (kind, name) in handlers {
         let handler: Arc<dyn ToolHandler> = match kind {
             ToolHandlerKind::Bash => Arc::new(BashHandler::new()),
+            #[cfg(feature = "code-search")]
             ToolHandlerKind::CodeSearch => Arc::new(CodeSearchHandler::new()),
+            // When the `code-search` feature is disabled the planner never emits
+            // this handler kind (see registry_plan), so the arm is unreachable.
+            #[cfg(not(feature = "code-search"))]
+            ToolHandlerKind::CodeSearch => {
+                unreachable!("code_search handler requested but `code-search` feature is disabled")
+            }
             ToolHandlerKind::ShellCommand => Arc::new(ShellCommandHandler::new()),
             ToolHandlerKind::Read => Arc::new(ReadHandler::new()),
             ToolHandlerKind::Write => Arc::new(WriteHandler::new()),

--- a/crates/core/src/tools/registry_plan.rs
+++ b/crates/core/src/tools/registry_plan.rs
@@ -258,6 +258,7 @@ fn grep_schema() -> JsonSchema {
     )
 }
 
+#[cfg(feature = "code-search")]
 fn code_search_schema() -> JsonSchema {
     let enum_string = |description: &str, values: &[&str]| {
         let mut schema = JsonSchema::string(Some(description));
@@ -333,6 +334,7 @@ fn code_search_schema() -> JsonSchema {
     )
 }
 
+#[cfg(feature = "code-search")]
 pub(crate) fn code_search_tool_spec() -> ToolSpec {
     ToolSpec {
         name: "code_search".to_string(),
@@ -737,6 +739,7 @@ pub fn build_tool_registry_plan(config: &ToolPlanConfig) -> ToolRegistryPlan {
         ToolHandlerKind::Grep,
     );
 
+    #[cfg(feature = "code-search")]
     if config.code_search {
         plan.push(code_search_tool_spec(), ToolHandlerKind::CodeSearch);
     }


### PR DESCRIPTION
## Summary

`devo-code-search` pulls in a heavy dependency stack — `tokenizers`, `model2vec`, `hf-hub`/`hf-xet`/`xet-*`, `hnsw_rs`, `bm25`, and 24 `tree-sitter-*` grammars — that adds **~48 MB** to a release binary. It is currently a non-optional dependency of `devo-core`, so embedders that don't need semantic code search (e.g. a lightweight remote diagnostic agent) cannot opt out.

This PR makes it an **optional, default-on feature**:

- `devo-code-search` → `optional = true`
- new `code-search` feature, `default = ["code-search"]` (existing builds unchanged)
- `#[cfg(feature = "code-search")]` on the one handler module, its `pub use`, the registry-plan emission, and the schema/spec helpers; the `build_registry_from_builder` match keeps an `unreachable!()` arm when the feature is off (the planner never emits `CodeSearch` then)

`default-features = false` now yields a slim build that omits the entire stack.

## Verification

Minimal binary that only calls `build_registry_from_plan`:

| build | stripped size |
|---|---|
| default (code-search on) | 54.6 MB |
| `--no-default-features` | **6.6 MB** |

`cargo tree` with the feature off confirms `tree-sitter*` / `hf-hub` / `hf-xet` / `xet-*` / `tokenizers` / `model2vec` / `hnsw_rs` are all gone. Both `--features code-search` and `--no-default-features` compile.
