### PR TITLE
Fix explicit onboarding exit flow and onboarding viewport

### DIFF
--- a/apps/web/content/docs/contributors/architecture-overview.mdx
+++ b/apps/web/content/docs/contributors/architecture-overview.mdx
@@ -75,8 +75,9 @@ When a user runs `devo`:
    model, model binding id, provider wire API, reasoning effort selection, permission
    preset, and working directory.
 
-`devo onboard` follows the same path, but forces the TUI into provider
-onboarding mode.
+`devo onboard` follows the same setup path, forces provider onboarding mode,
+and exits after the provider/model binding is saved. The CLI then prompts the
+user to run `devo` so the next process starts from the freshly written config.
 
 `devo resume <session_id>` follows the same path with an initial session id.
 

--- a/apps/web/content/docs/contributors/architecture-overview.zh.mdx
+++ b/apps/web/content/docs/contributors/architecture-overview.zh.mdx
@@ -66,7 +66,9 @@ flowchart TD
 4. `run_agent` 调用 `devo_tui::run_interactive_tui`。
 5. TUI 以 `InitialTuiSession` 启动，其中包含当前 session id、model、model binding id、provider wire API、reasoning effort selection、permission preset 和 working directory。
 
-`devo onboard` 使用同一路径，但强制 TUI 进入 provider onboarding mode。
+`devo onboard` 使用同一条 setup 路径，但会强制进入 provider onboarding
+mode，并在 provider/model binding 保存后退出。CLI 随后提示用户运行 `devo`，
+让下一个进程从新写入的配置启动。
 
 `devo resume <session_id>` 使用同一路径，并传入 initial session id。
 

--- a/crates/cli/src/agent_command.rs
+++ b/crates/cli/src/agent_command.rs
@@ -20,11 +20,12 @@ use devo_util_paths::find_devo_home;
 /// Runs the interactive coding-agent entrypoint.
 ///
 /// `force_onboarding` forces the TUI to start in provider onboarding mode even
-/// when a provider config already exists. `log_level` is forwarded to the
-/// background server process, and `model_override` replaces the resolved model
-/// for this session without mutating the stored provider config.
+/// when a provider config already exists. `exit_after_onboarding` exits after a
+/// successful onboarding save instead of continuing into the interactive TUI.
+/// `log_level` is forwarded to the background server process.
 pub(crate) async fn run_agent(
     force_onboarding: bool,
+    exit_after_onboarding: bool,
     log_level: Option<&str>,
     initial_session_id: Option<SessionId>,
 ) -> Result<devo_tui::AppExit> {
@@ -107,6 +108,7 @@ pub(crate) async fn run_agent(
         model_catalog,
         saved_models,
         show_model_onboarding: onboarding_mode,
+        exit_after_onboarding,
         startup_warnings,
     })
     .await?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -146,6 +146,28 @@ fn exit_messages(exit: &devo_tui::AppExit, color_enabled: bool) -> Vec<String> {
     lines
 }
 
+fn onboarding_exit_messages(exit: &devo_tui::AppExit, color_enabled: bool) -> Vec<String> {
+    if !exit.onboarding_completed {
+        return Vec::new();
+    }
+    let complete = if color_enabled {
+        "\u{1b}[1;32mConfiguration complete\u{1b}[0m".to_string()
+    } else {
+        "Configuration complete".to_string()
+    };
+    let command = if color_enabled {
+        "\u{1b}[1;36mdevo\u{1b}[0m".to_string()
+    } else {
+        "devo".to_string()
+    };
+    vec![
+        complete,
+        String::new(),
+        "Next step:".to_string(),
+        format!("  {command}"),
+    ]
+}
+
 async fn run_cli() -> Result<()> {
     let cli = Cli::parse();
     let log_level = cli.log_level.map(|level| level.to_string());
@@ -155,8 +177,14 @@ async fn run_cli() -> Result<()> {
             // Resolve logging config early, install the process-wide file subscriber,
             // and keep its non-blocking writer guard alive for the command lifetime.
             let _logging = install_logging(&cli)?;
-            let exit = run_agent(/*force_onboarding*/ true, log_level.as_deref(), None).await?;
-            for line in exit_messages(&exit, /*color_enabled*/ true) {
+            let exit = run_agent(
+                /*force_onboarding*/ true,
+                /*exit_after_onboarding*/ true,
+                log_level.as_deref(),
+                None,
+            )
+            .await?;
+            for line in onboarding_exit_messages(&exit, /*color_enabled*/ true) {
                 println!("{line}");
             }
             Ok(())
@@ -176,6 +204,7 @@ async fn run_cli() -> Result<()> {
             let _logging = install_logging(&cli)?;
             let exit = run_agent(
                 /*force_onboarding*/ false,
+                /*exit_after_onboarding*/ false,
                 log_level.as_deref(),
                 Some(*session_id),
             )
@@ -202,7 +231,13 @@ async fn run_cli() -> Result<()> {
             maybe_print_startup_update(&cli).await;
             let _logging = install_logging(&cli)?;
             tracing::info!("default interactive command starting");
-            let exit = run_agent(/*force_onboarding*/ false, log_level.as_deref(), None).await?;
+            let exit = run_agent(
+                /*force_onboarding*/ false,
+                /*exit_after_onboarding*/ false,
+                log_level.as_deref(),
+                None,
+            )
+            .await?;
             let exit_lines = exit_messages(&exit, /*color_enabled*/ true);
             tracing::info!(
                 line_count = exit_lines.len(),
@@ -339,6 +374,7 @@ mod tests {
     use super::cli_logging_overrides;
     use super::exit_messages;
     use super::format_token_usage_line;
+    use super::onboarding_exit_messages;
 
     #[test]
     fn cli_parses_supported_log_levels() {
@@ -527,6 +563,7 @@ mod tests {
         let session_id = SessionId::new();
         let exit = devo_tui::AppExit {
             session_id: Some(session_id),
+            onboarding_completed: false,
             turn_count: 1,
             total_input_tokens: 10,
             total_output_tokens: 2,
@@ -549,6 +586,7 @@ mod tests {
         let session_id = SessionId::new();
         let exit = devo_tui::AppExit {
             session_id: Some(session_id),
+            onboarding_completed: false,
             turn_count: 1,
             total_input_tokens: 10,
             total_output_tokens: 2,
@@ -560,5 +598,66 @@ mod tests {
 
         let lines = exit_messages(&exit, /*color_enabled*/ true);
         assert!(lines[1].contains("\u{1b}["));
+    }
+
+    #[test]
+    fn onboarding_exit_messages_include_next_step_after_success() {
+        let session_id = SessionId::new();
+        let exit = devo_tui::AppExit {
+            session_id: Some(session_id),
+            onboarding_completed: true,
+            turn_count: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_read_tokens: 0,
+        };
+
+        let lines = onboarding_exit_messages(&exit, /*color_enabled*/ false);
+
+        assert_eq!(
+            lines,
+            vec![
+                "Configuration complete".to_string(),
+                String::new(),
+                "Next step:".to_string(),
+                "  devo".to_string(),
+            ]
+        );
+        assert_eq!(lines.iter().any(|line| line.contains("devo resume")), false);
+    }
+
+    #[test]
+    fn onboarding_exit_messages_are_empty_without_success() {
+        let session_id = SessionId::new();
+        let exit = devo_tui::AppExit {
+            session_id: Some(session_id),
+            onboarding_completed: false,
+            turn_count: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_read_tokens: 0,
+        };
+
+        assert_eq!(
+            onboarding_exit_messages(&exit, /*color_enabled*/ false),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn colorized_onboarding_exit_messages_include_ansi_sequences() {
+        let exit = devo_tui::AppExit {
+            session_id: None,
+            onboarding_completed: true,
+            turn_count: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_read_tokens: 0,
+        };
+
+        let lines = onboarding_exit_messages(&exit, /*color_enabled*/ true);
+
+        assert!(lines[0].contains("\u{1b}["));
+        assert!(lines[3].contains("\u{1b}["));
     }
 }

--- a/crates/server/src/runtime/command_exec.rs
+++ b/crates/server/src/runtime/command_exec.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -15,6 +16,7 @@ use crate::ProtocolErrorCode;
 use crate::ServerEvent;
 use crate::SuccessResponse;
 use crate::runtime::ServerRuntime;
+use crate::runtime::connection::SubscriptionFilter;
 use devo_protocol::CommandExecExitedPayload;
 use devo_protocol::CommandExecOutputDeltaPayload;
 use devo_protocol::CommandExecOutputStream;
@@ -341,6 +343,23 @@ impl ServerRuntime {
             Ok(cwd) => cwd,
             Err((code, message)) => return self.error_response(request_id, code, message),
         };
+        let command_exec_event_types = HashSet::from([
+            "command/exec/outputDelta".to_string(),
+            "command/exec/exited".to_string(),
+        ]);
+        if let Some(connection) = self.connections.lock().await.get_mut(&connection_id) {
+            let already = connection.subscriptions.iter().any(|subscription| {
+                subscription.session_id == params.session_id
+                    && subscription.event_types == command_exec_event_types
+            });
+            if !already {
+                connection.subscriptions.push(SubscriptionFilter {
+                    session_id: params.session_id,
+                    event_types: command_exec_event_types,
+                    include_child_agents: false,
+                });
+            }
+        }
         match self
             .command_exec_manager
             .start(Arc::clone(self), connection_id, params, cwd)

--- a/crates/server/tests/command_exec.rs
+++ b/crates/server/tests/command_exec.rs
@@ -298,28 +298,60 @@ async fn wait_for_command_exec_exit(
             .await
             .context("timed out waiting for command/exec notification")?
             .context("notification channel closed before command/exec exited")?;
-        match notification["method"].as_str() {
-            Some("command/exec/outputDelta") => {
-                if notification["params"]["process_id"] != serde_json::json!(process_id) {
+        let payload = {
+            let method = notification["method"].as_str();
+            match method {
+                Some(method) if method.starts_with("_devo/") => {
+                    let inner_method = method
+                        .strip_prefix("_devo/")
+                        .expect("starts_with checked prefix");
+                    Some((inner_method, &notification["params"]))
+                }
+                Some("session/update") => {
+                    let meta = &notification["params"]["_meta"];
+                    let original_method = meta["devo/originalMethod"].as_str();
+                    let original_event = &meta["devo/originalEvent"];
+                    original_method.map(|method| {
+                        let event_payload = if original_event.get("process_id").is_some() {
+                            original_event
+                        } else {
+                            match method {
+                                "command/exec/outputDelta" => {
+                                    &original_event["CommandExecOutputDelta"]
+                                }
+                                "command/exec/exited" => &original_event["CommandExecExited"],
+                                _ => original_event,
+                            }
+                        };
+                        (method, event_payload)
+                    })
+                }
+                Some(method) => Some((method, &notification["params"])),
+                None => None,
+            }
+        };
+        match payload {
+            Some(("command/exec/outputDelta", params)) => {
+                if params["process_id"] != serde_json::json!(process_id) {
                     continue;
                 }
-                assert_notification_session(&notification["params"], session_id);
-                assert_eq!(notification["params"]["stream"], "pty");
-                let delta_base64 = notification["params"]["delta_base64"]
+                assert_notification_session(params, session_id);
+                assert_eq!(params["stream"], "pty");
+                let delta_base64 = params["delta_base64"]
                     .as_str()
                     .context("delta_base64 should be a string")?;
                 let bytes = BASE64_STANDARD.decode(delta_base64)?;
                 output.push_str(&String::from_utf8_lossy(&bytes));
             }
-            Some("command/exec/exited") => {
-                if notification["params"]["process_id"] != serde_json::json!(process_id) {
+            Some(("command/exec/exited", params)) => {
+                if params["process_id"] != serde_json::json!(process_id) {
                     continue;
                 }
-                assert_notification_session(&notification["params"], session_id);
-                assert_eq!(notification["params"]["exit_code"], 0);
+                assert_notification_session(params, session_id);
+                assert_eq!(params["exit_code"], 0);
                 return Ok(output);
             }
-            Some("session/started") if session_id.is_none() => {
+            Some(("session/started", _)) if session_id.is_none() => {
                 anyhow::bail!("sessionless command/exec unexpectedly created a session")
             }
             _ => {}

--- a/crates/server/tests/end_to_end.rs
+++ b/crates/server/tests/end_to_end.rs
@@ -430,6 +430,8 @@ async fn second_stdio_server_process_proxies_to_singleton() -> Result<()> {
 
 #[tokio::test]
 async fn websocket_listener_supports_handshake_subscription_and_turn_lifecycle() -> Result<()> {
+    let workspace = TempDir::new()?;
+    let test_cwd = workspace.path().to_string_lossy().into_owned();
     let port = {
         let listener = StdTcpListener::bind("127.0.0.1:0")?;
         let port = listener.local_addr()?.port();
@@ -485,7 +487,7 @@ async fn websocket_listener_supports_handshake_subscription_and_turn_lifecycle()
                 "id": 2,
                 "method": "session/new",
                 "params": {
-                    "cwd": "C:/repo",
+                    "cwd": test_cwd,
                     "additionalDirectories": [],
                     "mcpServers": []
                 }
@@ -515,7 +517,7 @@ async fn websocket_listener_supports_handshake_subscription_and_turn_lifecycle()
         .to_string();
     assert_eq!(
         session_response["result"]["_meta"]["devo/session"]["cwd"],
-        serde_json::json!("C:/repo")
+        serde_json::json!(test_cwd)
     );
 
     socket

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -11,6 +11,8 @@ use devo_protocol::SessionId;
 pub struct AppExit {
     /// Active session identifier at exit, when one exists.
     pub session_id: Option<SessionId>,
+    /// Whether provider onboarding completed successfully during this TUI run.
+    pub onboarding_completed: bool,
     /// Total turns completed in the session.
     pub turn_count: usize,
     /// Total input tokens accumulated in the session.
@@ -58,6 +60,8 @@ pub struct InteractiveTuiConfig {
     pub saved_models: Vec<SavedModelEntry>,
     /// Whether to open the model picker on startup.
     pub show_model_onboarding: bool,
+    /// Whether successful onboarding should exit the TUI immediately.
+    pub exit_after_onboarding: bool,
     /// Non-fatal startup warnings to show in the transcript before user input.
     pub startup_warnings: Vec<String>,
 }

--- a/crates/tui/src/app_event.rs
+++ b/crates/tui/src/app_event.rs
@@ -28,6 +28,9 @@ pub(crate) enum AppEvent {
     /// Request to exit the TUI.
     Exit(ExitMode),
 
+    /// Provider onboarding completed successfully.
+    OnboardingCompleted,
+
     /// Submit the current composer text.
     SubmitUserInput { text: String },
 

--- a/crates/tui/src/chatwidget.rs
+++ b/crates/tui/src/chatwidget.rs
@@ -106,6 +106,7 @@ pub(crate) struct ChatWidgetInit {
     /// Configured model bindings from config.toml used by the /model picker.
     pub(crate) saved_models: Vec<SavedModelEntry>,
     pub(crate) show_model_onboarding: bool,
+    pub(crate) exit_after_onboarding: bool,
     pub(crate) startup_tooltip_override: Option<String>,
     pub(crate) initial_theme_name: Option<String>,
 }
@@ -266,6 +267,7 @@ pub(crate) struct ChatWidget {
     acp_config_options: Vec<AcpSessionConfigOption>,
     acp_usage: Option<(u64, u64, Option<AcpCost>)>,
     onboarding: Option<OnboardingWidget>,
+    exit_after_onboarding: bool,
     resume_browser: Option<ResumeBrowserState>,
     resume_browser_loading: bool,
     subagent_monitor: SubagentMonitorState,
@@ -324,6 +326,7 @@ impl ChatWidget {
             available_models,
             saved_models,
             show_model_onboarding,
+            exit_after_onboarding,
             startup_tooltip_override,
             initial_theme_name,
         } = common;
@@ -416,6 +419,7 @@ impl ChatWidget {
             acp_config_options: Vec::new(),
             acp_usage: None,
             onboarding: None,
+            exit_after_onboarding,
             resume_browser: None,
             resume_browser_loading: false,
             subagent_monitor: SubagentMonitorState::default(),

--- a/crates/tui/src/chatwidget/input.rs
+++ b/crates/tui/src/chatwidget/input.rs
@@ -257,6 +257,7 @@ impl ChatWidget {
                 self.frame_requester.schedule_frame();
             }
             AppEvent::Exit(_)
+            | AppEvent::OnboardingCompleted
             | AppEvent::OpenSlashCommandPopup
             | AppEvent::ClosePopup
             | AppEvent::OpenModelPicker
@@ -345,47 +346,53 @@ impl ChatWidget {
     }
 
     pub(super) fn handle_onboarding_result(&mut self, result: OnboardingResult) {
-        match result {
+        let (model_slug, model_name, display_name, message, hint) = match result {
             OnboardingResult::ValidationSucceeded {
                 model_slug,
                 model_name,
                 display_name,
-            } => {
-                self.apply_session_model_name(model_slug, model_name, display_name);
-                self.add_to_history(history_cell::new_info_event(
-                    "Provider configured successfully".to_string(),
-                    Some("onboarding complete".to_string()),
-                ));
-                self.onboarding = None;
-                self.push_session_header(/*is_first_run*/ false, None);
-                self.bottom_pane
-                    .set_composer_input_enabled(/*enabled*/ true, /*placeholder*/ None);
-                self.set_default_placeholder();
-                self.set_status_message("Onboarding complete");
-            }
+            } => (
+                model_slug,
+                model_name,
+                display_name,
+                "Provider configured successfully".to_string(),
+                Some("onboarding complete".to_string()),
+            ),
             OnboardingResult::ValidationBypassed {
                 model_slug,
                 model_name,
                 display_name,
-            } => {
-                self.apply_session_model_name(model_slug, model_name, display_name);
-                self.add_to_history(history_cell::new_info_event(
-                    "Provider added without validation".to_string(),
-                    Some("onboarding validation skipped".to_string()),
-                ));
-                self.onboarding = None;
-                self.push_session_header(/*is_first_run*/ false, None);
-                self.bottom_pane
-                    .set_composer_input_enabled(/*enabled*/ true, /*placeholder*/ None);
-                self.set_default_placeholder();
-                self.set_status_message("Onboarding complete");
-            }
+            } => (
+                model_slug,
+                model_name,
+                display_name,
+                "Provider added without validation".to_string(),
+                Some("onboarding validation skipped".to_string()),
+            ),
             OnboardingResult::Cancelled => {
                 self.onboarding = None;
                 self.app_event_tx
                     .send(AppEvent::Exit(crate::app_event::ExitMode::ShutdownFirst));
+                return;
             }
+        };
+
+        self.apply_session_model_name(model_slug, model_name, display_name);
+        self.add_to_history(history_cell::new_info_event(message, hint));
+        self.onboarding = None;
+        self.set_status_message("Onboarding complete");
+        self.app_event_tx.send(AppEvent::OnboardingCompleted);
+
+        if self.exit_after_onboarding {
+            self.app_event_tx
+                .send(AppEvent::Exit(crate::app_event::ExitMode::ShutdownFirst));
+            return;
         }
+
+        self.push_session_header(/*is_first_run*/ false, None);
+        self.bottom_pane
+            .set_composer_input_enabled(/*enabled*/ true, /*placeholder*/ None);
+        self.set_default_placeholder();
     }
 
     pub(super) fn drain_onboarding_transcript_events(&mut self) {
@@ -513,7 +520,6 @@ impl ChatWidget {
         self.frame_requester.schedule_frame();
     }
 
-    #[cfg(test)]
     #[cfg(test)]
     pub(crate) fn last_plan_progress_for_test(&self) -> Option<(usize, usize)> {
         self.last_plan_progress

--- a/crates/tui/src/chatwidget/render.rs
+++ b/crates/tui/src/chatwidget/render.rs
@@ -51,6 +51,11 @@ impl Renderable for ChatWidget {
             return;
         }
 
+        if let Some(onboarding) = &self.onboarding {
+            onboarding.render(area, buf);
+            return;
+        }
+
         let bottom_height = self
             .bottom_pane
             .desired_height(area.width)
@@ -58,9 +63,7 @@ impl Renderable for ChatWidget {
         let [history_area, bottom_area] =
             Layout::vertical([Constraint::Min(1), Constraint::Length(bottom_height)]).areas(area);
 
-        if let Some(onboarding) = &self.onboarding {
-            onboarding.render(history_area, buf);
-        } else {
+        {
             if tracing::enabled!(tracing::Level::DEBUG)
                 && let Some(snapshot) = self.active_assistant_render_snapshot(area)
             {
@@ -113,10 +116,7 @@ impl Renderable for ChatWidget {
 
     fn desired_height(&self, width: u16) -> u16 {
         if let Some(onboarding) = &self.onboarding {
-            return onboarding
-                .desired_height(width.max(1))
-                .saturating_add(self.bottom_pane.desired_height(width))
-                .saturating_add(2);
+            return onboarding.desired_height(width.max(1));
         }
         if self.resume_browser.is_some() || self.is_subagent_selector_open() {
             return u16::MAX;
@@ -132,17 +132,15 @@ impl Renderable for ChatWidget {
         if self.resume_browser.is_some() || self.is_subagent_selector_open() {
             return None;
         }
+        if let Some(onboarding) = &self.onboarding {
+            return onboarding.cursor_pos(area);
+        }
         let bottom_height = self
             .bottom_pane
             .desired_height(area.width)
             .min(area.height.saturating_sub(1).max(3));
-        let [history_area, bottom_area] =
+        let [_history_area, bottom_area] =
             Layout::vertical([Constraint::Min(1), Constraint::Length(bottom_height)]).areas(area);
-        if let Some(onboarding) = &self.onboarding
-            && let Some(cursor) = onboarding.cursor_pos(history_area)
-        {
-            return Some(cursor);
-        }
         self.bottom_pane.cursor_pos(bottom_area)
     }
 }

--- a/crates/tui/src/chatwidget/session_header.rs
+++ b/crates/tui/src/chatwidget/session_header.rs
@@ -554,6 +554,7 @@ mod tests {
             available_models: Vec::new(),
             saved_models: Vec::new(),
             show_model_onboarding: false,
+            exit_after_onboarding: false,
             startup_tooltip_override: None,
             initial_theme_name: None,
         });
@@ -590,6 +591,7 @@ mod tests {
             available_models: Vec::new(),
             saved_models: Vec::new(),
             show_model_onboarding: false,
+            exit_after_onboarding: false,
             startup_tooltip_override: None,
             initial_theme_name: None,
         });

--- a/crates/tui/src/chatwidget_tail_follow_tests.rs
+++ b/crates/tui/src/chatwidget_tail_follow_tests.rs
@@ -29,6 +29,7 @@ fn widget_with_model(model: Model, cwd: PathBuf) -> ChatWidget {
         available_models: Vec::new(),
         saved_models: Vec::new(),
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     })

--- a/crates/tui/src/chatwidget_tests.rs
+++ b/crates/tui/src/chatwidget_tests.rs
@@ -26,6 +26,7 @@ use tokio::sync::mpsc;
 
 use crate::app_command::AppCommand;
 use crate::app_event::AppEvent;
+use crate::app_event::ExitMode;
 use crate::app_event_sender::AppEventSender;
 use crate::chatwidget::ChatWidget;
 use crate::chatwidget::ChatWidgetInit;
@@ -65,6 +66,7 @@ fn widget_with_model_and_reasoning_effort(
         available_models: Vec::new(),
         saved_models: Vec::new(),
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });
@@ -102,6 +104,7 @@ fn onboarding_widget_with_model(
         available_models: Vec::new(),
         saved_models: Vec::new(),
         show_model_onboarding: true,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });
@@ -111,6 +114,16 @@ fn onboarding_widget_with_model(
 fn onboarding_widget_with_available_model(
     model: Model,
     cwd: PathBuf,
+) -> (ChatWidget, mpsc::UnboundedReceiver<AppEvent>) {
+    onboarding_widget_with_available_model_and_exit_after_onboarding(
+        model, cwd, /*exit_after_onboarding*/ false,
+    )
+}
+
+fn onboarding_widget_with_available_model_and_exit_after_onboarding(
+    model: Model,
+    cwd: PathBuf,
+    exit_after_onboarding: bool,
 ) -> (ChatWidget, mpsc::UnboundedReceiver<AppEvent>) {
     let (app_event_tx, app_event_rx) = mpsc::unbounded_channel();
     let widget = ChatWidget::new_with_app_event(ChatWidgetInit {
@@ -125,6 +138,7 @@ fn onboarding_widget_with_available_model(
         available_models: vec![model],
         saved_models: Vec::new(),
         show_model_onboarding: true,
+        exit_after_onboarding,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });
@@ -1595,6 +1609,7 @@ fn permissions_command_marks_initial_project_preset_current() {
         available_models: Vec::new(),
         saved_models: Vec::new(),
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });
@@ -2931,6 +2946,11 @@ fn onboarding_validation_succeeded_waits_for_provider_upsert() {
         }),
     });
 
+    assert_eq!(
+        app_event_rx.try_recv().expect("onboarding completed"),
+        AppEvent::OnboardingCompleted
+    );
+    assert_eq!(app_event_rx.try_recv().is_err(), true);
     assert_eq!(widget.is_onboarding_active(), false);
     assert_eq!(widget.placeholder_text(), "Ask Devo");
     assert_eq!(
@@ -2940,6 +2960,146 @@ fn onboarding_validation_succeeded_waits_for_provider_upsert() {
     assert_eq!(
         widget.status_summary_text().contains("DeepSeek-V4-Flash"),
         true
+    );
+}
+
+#[test]
+fn onboarding_validation_succeeded_exits_when_configured() {
+    let cwd = std::env::current_dir().expect("current directory is available");
+    let model = Model {
+        slug: "deepseek-v4-flash".to_string(),
+        display_name: "Deepseek V4 Flash".to_string(),
+        ..Model::default()
+    };
+    let (mut widget, mut app_event_rx) =
+        onboarding_widget_with_available_model_and_exit_after_onboarding(
+            model, cwd, /*exit_after_onboarding*/ true,
+        );
+
+    let _ = app_event_rx.try_recv().expect("provider list command");
+    widget.handle_worker_event(crate::events::WorkerEvent::ProviderVendorsListed {
+        provider_vendors: vec![ProviderVendor {
+            name: "Deepseek".to_string(),
+            base_url: Some("https://api.deepseek.com".to_string()),
+            credential: Some("deepseek_api_key".to_string()),
+            headers: None,
+            wire_apis: vec![ProviderWireApi::OpenAIChatCompletions],
+            enabled: true,
+        }],
+    });
+    widget.handle_key_event(press_key(KeyCode::Enter));
+    widget.handle_key_event(press_key(KeyCode::Enter));
+    widget.handle_key_event(press_key(KeyCode::Enter));
+    widget.handle_key_event(press_key(KeyCode::Enter));
+    widget.handle_key_event(press_key(KeyCode::Enter));
+    let _ = app_event_rx.try_recv().expect("onboard command");
+
+    widget.handle_worker_event(crate::events::WorkerEvent::ProviderValidationSucceeded {
+        reply_preview: "OK".to_string(),
+    });
+    widget.handle_worker_event(crate::events::WorkerEvent::ProviderVendorUpserted {
+        provider_vendor: ProviderVendor {
+            name: "Deepseek".to_string(),
+            base_url: Some("https://api.deepseek.com".to_string()),
+            credential: Some("deepseek_api_key".to_string()),
+            headers: None,
+            wire_apis: vec![ProviderWireApi::OpenAIChatCompletions],
+            enabled: true,
+        },
+        model_binding: Some(ProviderModelBinding {
+            binding_id: "deepseek-v4-flash-deepseek".to_string(),
+            model_slug: "deepseek-v4-flash".to_string(),
+            provider: "Deepseek".to_string(),
+            model_name: "DeepSeek-V4-Flash".to_string(),
+            display_name: Some("DeepSeek-V4-Flash".to_string()),
+            invocation_method: ProviderWireApi::OpenAIChatCompletions,
+            default_reasoning_effort: None,
+            enabled: true,
+        }),
+    });
+
+    assert_eq!(widget.is_onboarding_active(), false);
+    assert_eq!(
+        app_event_rx.try_recv().expect("onboarding completed"),
+        AppEvent::OnboardingCompleted
+    );
+    assert_eq!(
+        app_event_rx.try_recv().expect("exit event"),
+        AppEvent::Exit(ExitMode::ShutdownFirst)
+    );
+}
+
+#[test]
+fn onboarding_validation_bypassed_exits_when_configured() {
+    let cwd = std::env::current_dir().expect("current directory is available");
+    let model = Model {
+        slug: "deepseek-v4-flash".to_string(),
+        display_name: "Deepseek V4 Flash".to_string(),
+        ..Model::default()
+    };
+    let (mut widget, mut app_event_rx) =
+        onboarding_widget_with_available_model_and_exit_after_onboarding(
+            model, cwd, /*exit_after_onboarding*/ true,
+        );
+
+    let _ = app_event_rx.try_recv().expect("provider list command");
+    widget.handle_worker_event(crate::events::WorkerEvent::ProviderVendorsListed {
+        provider_vendors: vec![ProviderVendor {
+            name: "Deepseek".to_string(),
+            base_url: Some("https://api.deepseek.com".to_string()),
+            credential: Some("deepseek_api_key".to_string()),
+            headers: None,
+            wire_apis: vec![ProviderWireApi::OpenAIChatCompletions],
+            enabled: true,
+        }],
+    });
+    widget.handle_key_event(press_key(KeyCode::Enter));
+    widget.handle_key_event(press_key(KeyCode::Enter));
+    widget.handle_key_event(press_key(KeyCode::Enter));
+    widget.handle_key_event(press_key(KeyCode::Enter));
+    widget.handle_key_event(press_key(KeyCode::Enter));
+    let _ = app_event_rx.try_recv().expect("onboard command");
+
+    widget.handle_worker_event(crate::events::WorkerEvent::ProviderValidationFailed {
+        message: "validation failed".to_string(),
+    });
+    widget.handle_key_event(press_key(KeyCode::Enter));
+    match app_event_rx.try_recv().expect("skip validation command") {
+        AppEvent::Command(AppCommand::RunUserShellCommand { command }) => {
+            assert_eq!(command.starts_with("onboard-skip-validation "), true);
+        }
+        other => panic!("expected skip validation command, got {other:?}"),
+    }
+
+    widget.handle_worker_event(crate::events::WorkerEvent::ProviderVendorUpserted {
+        provider_vendor: ProviderVendor {
+            name: "Deepseek".to_string(),
+            base_url: Some("https://api.deepseek.com".to_string()),
+            credential: Some("deepseek_api_key".to_string()),
+            headers: None,
+            wire_apis: vec![ProviderWireApi::OpenAIChatCompletions],
+            enabled: true,
+        },
+        model_binding: Some(ProviderModelBinding {
+            binding_id: "deepseek-v4-flash-deepseek".to_string(),
+            model_slug: "deepseek-v4-flash".to_string(),
+            provider: "Deepseek".to_string(),
+            model_name: "DeepSeek-V4-Flash".to_string(),
+            display_name: Some("DeepSeek-V4-Flash".to_string()),
+            invocation_method: ProviderWireApi::OpenAIChatCompletions,
+            default_reasoning_effort: None,
+            enabled: true,
+        }),
+    });
+
+    assert_eq!(widget.is_onboarding_active(), false);
+    assert_eq!(
+        app_event_rx.try_recv().expect("onboarding completed"),
+        AppEvent::OnboardingCompleted
+    );
+    assert_eq!(
+        app_event_rx.try_recv().expect("exit event"),
+        AppEvent::Exit(ExitMode::ShutdownFirst)
     );
 }
 
@@ -4873,6 +5033,7 @@ fn slash_model_opens_model_picker_instead_of_printing_current_model() {
             saved_model_entry("second-model"),
         ],
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });
@@ -5544,6 +5705,7 @@ fn model_selection_updates_session_projection_and_emits_context_override() {
             saved_model_entry("second-model"),
         ],
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });
@@ -5616,6 +5778,7 @@ fn model_selection_with_reasoning_effort_support_waits_for_second_step() {
         available_models: vec![alt_model.clone()],
         saved_models: vec![saved_model_entry("second-model")],
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });
@@ -5670,6 +5833,7 @@ fn model_selection_without_reasoning_effort_support_finishes_immediately() {
         available_models: vec![alt_model.clone()],
         saved_models: vec![saved_model_entry("plain-model")],
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });

--- a/crates/tui/src/inline_onboarding_tests.rs
+++ b/crates/tui/src/inline_onboarding_tests.rs
@@ -102,7 +102,7 @@ fn scrollback_plain_lines(lines: &[crate::history_cell::ScrollbackLine]) -> Vec<
 }
 
 #[test]
-fn first_run_onboarding_starts_with_logo_and_renders_inline() {
+fn first_run_onboarding_starts_with_logo_and_hides_composer() {
     let cwd = std::env::current_dir().expect("current directory is available");
     let (mut widget, _app_event_rx) = onboarding_widget_with_available_model(test_model(), cwd);
 
@@ -113,7 +113,8 @@ fn first_run_onboarding_starts_with_logo_and_renders_inline() {
 
     let rows = rendered_rows(&widget, 100, 24).join("\n");
     assert!(rows.contains("Choose model profile"));
-    assert!(rows.contains("Complete onboarding to start chatting"));
+    assert!(!rows.contains("Complete onboarding to start chatting"));
+    assert!(!rows.contains("SHIFT+TAB switch"));
     assert!(widget.desired_height(100) < u16::MAX);
 }
 

--- a/crates/tui/src/inline_onboarding_tests.rs
+++ b/crates/tui/src/inline_onboarding_tests.rs
@@ -27,17 +27,25 @@ fn onboarding_widget_with_available_model(
     model: Model,
     cwd: PathBuf,
 ) -> (ChatWidget, mpsc::UnboundedReceiver<AppEvent>) {
+    onboarding_widget_with_models(vec![model.clone()], Some(model), cwd)
+}
+
+fn onboarding_widget_with_models(
+    models: Vec<Model>,
+    initial_model: Option<Model>,
+    cwd: PathBuf,
+) -> (ChatWidget, mpsc::UnboundedReceiver<AppEvent>) {
     let (app_event_tx, app_event_rx) = mpsc::unbounded_channel();
     let widget = ChatWidget::new_with_app_event(ChatWidgetInit {
         frame_requester: FrameRequester::test_dummy(),
         app_event_tx: AppEventSender::new(app_event_tx),
-        initial_session: TuiSessionState::new(cwd, Some(model.clone())),
+        initial_session: TuiSessionState::new(cwd, initial_model),
         initial_reasoning_effort_selection: None,
         initial_permission_preset: devo_protocol::PermissionPreset::Default,
         initial_user_message: None,
         enhanced_keys_supported: true,
         is_first_run: false,
-        available_models: vec![model],
+        available_models: models,
         saved_models: Vec::new(),
         show_model_onboarding: true,
         exit_after_onboarding: false,
@@ -113,9 +121,42 @@ fn first_run_onboarding_starts_with_logo_and_hides_composer() {
 
     let rows = rendered_rows(&widget, 100, 24).join("\n");
     assert!(rows.contains("Choose model profile"));
+    assert!(rows.contains("Enter select  ·  Esc cancel"));
     assert!(!rows.contains("Complete onboarding to start chatting"));
     assert!(!rows.contains("SHIFT+TAB switch"));
     assert!(widget.desired_height(100) < u16::MAX);
+
+    let rows = rendered_rows(&widget, 100, widget.desired_height(100)).join("\n");
+    assert!(rows.contains("Enter select  ·  Esc cancel"));
+}
+
+#[test]
+fn model_selection_footer_stays_visible_in_short_viewport() {
+    let cwd = std::env::current_dir().expect("current directory is available");
+    let models = (0..12)
+        .map(|idx| Model {
+            slug: format!("model-{idx:02}"),
+            display_name: format!("Model {idx:02} Display Name"),
+            ..Model::default()
+        })
+        .collect::<Vec<_>>();
+    let initial_model = models.first().cloned();
+    let (mut widget, _app_event_rx) = onboarding_widget_with_models(models, initial_model, cwd);
+
+    for _ in 0..10 {
+        widget.handle_key_event(press_key(KeyCode::Down));
+    }
+
+    let rows = rendered_rows(&widget, 80, 8).join("\n");
+    assert!(
+        rows.contains("model-10"),
+        "expected selected model in:\n{rows}"
+    );
+    assert!(
+        rows.contains("Enter select  ·  Esc cancel"),
+        "expected fixed onboarding footer in:\n{rows}"
+    );
+    assert!(!rows.contains("Complete onboarding to start chatting"));
 }
 
 #[test]

--- a/crates/tui/src/inline_onboarding_tests.rs
+++ b/crates/tui/src/inline_onboarding_tests.rs
@@ -40,6 +40,7 @@ fn onboarding_widget_with_available_model(
         available_models: vec![model],
         saved_models: Vec::new(),
         show_model_onboarding: true,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });

--- a/crates/tui/src/interactive.rs
+++ b/crates/tui/src/interactive.rs
@@ -109,6 +109,7 @@ fn normalized_display_name(
 #[derive(Debug, Default)]
 struct InteractiveLoopState {
     session_id: Option<devo_core::SessionId>,
+    onboarding_completed: bool,
     turn_count: usize,
     total_input_tokens: usize,
     total_output_tokens: usize,
@@ -296,6 +297,7 @@ pub async fn run_interactive_tui(config: InteractiveTuiConfig) -> Result<AppExit
         available_models,
         saved_models: config.saved_models.clone(),
         show_model_onboarding: config.show_model_onboarding,
+        exit_after_onboarding: config.exit_after_onboarding,
         startup_tooltip_override: Some(format!("Ready in {}", cwd.display())),
         initial_theme_name,
     });
@@ -380,6 +382,7 @@ pub async fn run_interactive_tui(config: InteractiveTuiConfig) -> Result<AppExit
     tracing::info!("worker shutdown completed; returning app exit");
     Ok(AppExit {
         session_id: loop_state.session_id,
+        onboarding_completed: loop_state.onboarding_completed,
         turn_count: loop_state.turn_count,
         total_input_tokens: loop_state.total_input_tokens,
         total_output_tokens: loop_state.total_output_tokens,
@@ -743,6 +746,11 @@ fn handle_app_event(
     if let AppEvent::Exit(mode) = &app_event {
         tracing::info!(?mode, "host received app exit event");
         return Ok(LoopAction::ClearAndExit);
+    }
+
+    if matches!(&app_event, AppEvent::OnboardingCompleted) {
+        loop_state.onboarding_completed = true;
+        return Ok(LoopAction::Continue);
     }
 
     if matches!(&app_event, AppEvent::Interrupt) {

--- a/crates/tui/src/mcp_command_tests.rs
+++ b/crates/tui/src/mcp_command_tests.rs
@@ -28,6 +28,7 @@ fn widget_with_model(model: Model) -> (ChatWidget, mpsc::UnboundedReceiver<AppEv
         available_models: Vec::new(),
         saved_models: Vec::new(),
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });

--- a/crates/tui/src/model_display_tests.rs
+++ b/crates/tui/src/model_display_tests.rs
@@ -62,6 +62,7 @@ fn widget_with_model(
         available_models,
         saved_models,
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     })
@@ -123,6 +124,7 @@ fn saved_model_metadata_overlays_catalog_display_for_picker() {
             api_key: None,
         }],
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_warnings: Vec::new(),
     };
 
@@ -229,6 +231,7 @@ fn model_picker_distinguishes_same_model_slug_by_provider_binding() {
         available_models: vec![model],
         saved_models,
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });

--- a/crates/tui/src/onboarding_viewport.rs
+++ b/crates/tui/src/onboarding_viewport.rs
@@ -44,6 +44,45 @@ pub(crate) fn render_lines_with_anchor(
     render_scrolled_paragraph(paragraph, total_rows, scroll_offset, area, buf);
 }
 
+pub(crate) fn render_lines_with_fixed_footer(
+    body_lines: Vec<Line<'static>>,
+    footer_lines: Vec<Line<'static>>,
+    anchor: Option<ViewportAnchor>,
+    area: Rect,
+    buf: &mut Buffer,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let footer_paragraph =
+        Paragraph::new(Text::from(footer_lines.clone())).wrap(Wrap { trim: false });
+    let footer_rows = footer_paragraph.line_count(area.width);
+    let footer_height = u16::try_from(footer_rows)
+        .unwrap_or(u16::MAX)
+        .min(area.height);
+    let body_height = area.height.saturating_sub(footer_height);
+
+    if body_height > 0 {
+        render_lines_with_anchor(
+            body_lines,
+            anchor,
+            Rect {
+                height: body_height,
+                ..area
+            },
+            buf,
+        );
+    }
+
+    let footer_area = Rect {
+        y: area.y.saturating_add(body_height),
+        height: footer_height,
+        ..area
+    };
+    render_footer_paragraph(footer_paragraph, footer_rows, footer_area, buf);
+}
+
 fn scroll_offset_for_anchor(
     lines: &[Line<'static>],
     anchor: ViewportAnchor,
@@ -82,6 +121,26 @@ fn wrapped_row_count(lines: &[Line<'static>], width: u16) -> usize {
     Paragraph::new(Text::from(lines.to_vec()))
         .wrap(Wrap { trim: false })
         .line_count(width)
+}
+
+fn render_footer_paragraph(
+    paragraph: Paragraph<'_>,
+    total_rows: usize,
+    area: Rect,
+    buf: &mut Buffer,
+) {
+    if area.height == 0 {
+        return;
+    }
+
+    let visible_rows = area.height as usize;
+    if total_rows <= visible_rows {
+        paragraph.render(area, buf);
+        return;
+    }
+
+    let scroll_offset = total_rows.saturating_sub(visible_rows);
+    render_scrolled_paragraph(paragraph, total_rows, scroll_offset, area, buf);
 }
 
 fn render_scrolled_paragraph(

--- a/crates/tui/src/onboarding_widget.rs
+++ b/crates/tui/src/onboarding_widget.rs
@@ -42,6 +42,7 @@ use crate::bottom_pane::scroll_state::ScrollState;
 use crate::exec_cell::spinner;
 use crate::onboarding_viewport::ViewportAnchor;
 use crate::onboarding_viewport::render_lines_with_anchor;
+use crate::onboarding_viewport::render_lines_with_fixed_footer;
 use crate::render::renderable::Renderable;
 use crate::tui::frame_requester::FrameRequester;
 
@@ -796,6 +797,7 @@ impl OnboardingWidget {
         }
         let current = state.selected_idx.unwrap_or(0);
         state.selected_idx = Some(if current == 0 { len - 1 } else { current - 1 });
+        state.ensure_visible(len, MAX_POPUP_ROWS.min(len));
     }
 
     fn model_move_down(state: &mut ScrollState, filtered_indices: &[usize]) {
@@ -805,6 +807,7 @@ impl OnboardingWidget {
         }
         let current = state.selected_idx.unwrap_or(0);
         state.selected_idx = Some((current + 1) % len);
+        state.ensure_visible(len, MAX_POPUP_ROWS.min(len));
     }
 
     fn model_apply_filter(
@@ -832,6 +835,7 @@ impl OnboardingWidget {
         } else {
             Some(0)
         };
+        state.scroll_top = 0;
     }
 
     fn custom_model_name_handle_key(&mut self, key: KeyEvent) {
@@ -2070,15 +2074,9 @@ impl OnboardingWidget {
 
         let max_visible = MAX_POPUP_ROWS.min(filtered_indices.len().max(1));
         let scroll_offset = state
-            .selected_idx
-            .map(|sel| {
-                if sel >= max_visible.saturating_sub(2) {
-                    sel.saturating_sub(max_visible.saturating_sub(3))
-                } else {
-                    0
-                }
-            })
-            .unwrap_or(0);
+            .scroll_top
+            .min(filtered_indices.len().saturating_sub(max_visible));
+        let mut anchor = None;
 
         for (vis_idx, &actual_idx) in filtered_indices
             .iter()
@@ -2088,20 +2086,25 @@ impl OnboardingWidget {
         {
             if let Some(item) = items.get(actual_idx) {
                 let is_selected = state.selected_idx == Some(vis_idx);
+                let start = lines.len();
                 let description = if item.display_name == item.slug {
                     None
                 } else {
                     Some(item.display_name.clone())
                 };
                 Self::render_option_row(&mut lines, item.slug.clone(), description, is_selected);
+                if is_selected {
+                    anchor = Some(ViewportAnchor {
+                        start,
+                        end: lines.len(),
+                    });
+                }
             }
         }
 
-        Self::render_footer(&mut lines, "Enter select", "Esc cancel");
-
-        Paragraph::new(lines)
-            .wrap(Wrap { trim: false })
-            .render(content_area, buf);
+        let mut footer_lines = Vec::new();
+        Self::render_footer(&mut footer_lines, "Enter select", "Esc cancel");
+        render_lines_with_fixed_footer(lines, footer_lines, anchor, content_area, buf);
     }
 
     fn render_custom_model_name(input: &str, cursor_pos: usize, area: Rect, buf: &mut Buffer) {
@@ -2421,10 +2424,24 @@ impl Renderable for OnboardingWidget {
     fn desired_height(&self, _width: u16) -> u16 {
         match &self.state {
             OnboardingState::ModelSelection {
-                filtered_indices, ..
+                items,
+                state,
+                filtered_indices,
+                ..
             } => {
-                let items = MAX_POPUP_ROWS.min(filtered_indices.len().max(1)) as u16;
-                items + 8
+                let max_visible = MAX_POPUP_ROWS.min(filtered_indices.len().max(1));
+                let scroll_offset = state
+                    .scroll_top
+                    .min(filtered_indices.len().saturating_sub(max_visible));
+                let option_rows = filtered_indices
+                    .iter()
+                    .skip(scroll_offset)
+                    .take(max_visible)
+                    .filter_map(|idx| items.get(*idx))
+                    .map(|item| if item.display_name == item.slug { 1 } else { 2 })
+                    .sum::<u16>()
+                    .max(1);
+                option_rows + 9
             }
             OnboardingState::CustomModelName { .. } => 8,
             OnboardingState::ProviderSelection { items, .. } => items.len() as u16 * 2 + 6,

--- a/crates/tui/src/tool_rendering_e2e_tests.rs
+++ b/crates/tui/src/tool_rendering_e2e_tests.rs
@@ -29,6 +29,7 @@ fn widget_with_model(
         available_models: Vec::new(),
         saved_models: Vec::new(),
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     });

--- a/crates/tui/src/worker_queue_compaction_tests.rs
+++ b/crates/tui/src/worker_queue_compaction_tests.rs
@@ -40,6 +40,7 @@ fn widget_with_model() -> ChatWidget {
         available_models: Vec::new(),
         saved_models: Vec::new(),
         show_model_onboarding: false,
+        exit_after_onboarding: false,
         startup_tooltip_override: None,
         initial_theme_name: None,
     })


### PR DESCRIPTION
- Make explicit `devo onboard` exit after provider/model binding is saved, then print a focused next-step prompt to run `devo`.
- Keep first-run `devo` onboarding behavior unchanged: after onboarding completes, the user remains in the TUI.
- Hide the regular bottom composer/status line while onboarding is active.
- Keep the model-selection footer visible in short onboarding viewports.
- Ensure command exec notifications are subscribed for launched command exec requests and harden related tests.
