### PR TITLE
fix: avoid auto git diff for write tool results

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,7 +1,7 @@
 //! Client-side transport API for talking to a Devo server.
 //!
 //! Protocol logic (JSON-RPC routing, pending response maps, ACP client handlers)
-//! lives in [`client_core`]. [`stdio::StdioServerClient`] and
+//! lives in `client_core`. [`stdio::StdioServerClient`] and
 //! [`websocket::WebSocketServerClient`] are thin transport adapters.
 
 mod acp_fs;

--- a/crates/tui/src/chatwidget/worker_events.rs
+++ b/crates/tui/src/chatwidget/worker_events.rs
@@ -9,7 +9,6 @@ use devo_protocol::parse_command::ParsedCommand;
 use devo_protocol::protocol::ExecCommandSource;
 use ratatui::text::Line;
 
-use crate::app_event::AppEvent;
 use crate::bottom_pane::ApprovalOverlay;
 use crate::bottom_pane::ApprovalOverlayRequest;
 use crate::bottom_pane::InputMode;
@@ -18,7 +17,6 @@ use crate::events::WorkerEvent;
 use crate::exec_cell::CommandOutput;
 use crate::exec_cell::ExecCell;
 use crate::exec_cell::new_active_exec_command;
-use crate::get_git_diff::get_git_diff;
 use crate::history_cell;
 use crate::tool_io_cell::FileChangeToolIoCell;
 use crate::tool_io_cell::ToolIoCell;
@@ -587,13 +585,6 @@ impl ChatWidget {
                 } else {
                     "Tool completed"
                 });
-                if self.should_auto_show_git_diff_for_turn(&resolved_title, is_error) {
-                    let tx = self.app_event_tx.clone();
-                    tokio::spawn(async move {
-                        let text = Self::format_git_diff_result(get_git_diff().await);
-                        tx.send(AppEvent::DiffResult(text));
-                    });
-                }
             }
             WorkerEvent::ToolResult {
                 tool_use_id,
@@ -703,13 +694,6 @@ impl ChatWidget {
                 } else {
                     "Tool completed"
                 });
-                if self.should_auto_show_git_diff_for_turn(&resolved_title, is_error) {
-                    let tx = self.app_event_tx.clone();
-                    tokio::spawn(async move {
-                        let text = Self::format_git_diff_result(get_git_diff().await);
-                        tx.send(AppEvent::DiffResult(text));
-                    });
-                }
             }
             WorkerEvent::ShellCommandFinished { exit_code } => {
                 let interrupted = exit_code.is_none();

--- a/crates/tui/src/chatwidget_tests.rs
+++ b/crates/tui/src/chatwidget_tests.rs
@@ -8229,45 +8229,6 @@ fn auto_git_diff_trigger_matches_editing_tools_only() {
 }
 
 #[tokio::test]
-async fn successful_write_tool_result_triggers_diff_event() {
-    let model = Model {
-        slug: "test-model".to_string(),
-        display_name: "Test Model".to_string(),
-        ..Model::default()
-    };
-    let (mut widget, mut app_event_rx) = widget_with_model(model, PathBuf::from("."));
-
-    widget.handle_worker_event(crate::events::WorkerEvent::ToolCall {
-        tool_use_id: "tool-1".to_string(),
-        summary: "write src/main.rs".to_string(),
-        preparing: false,
-        parsed_commands: None,
-    });
-    widget.handle_worker_event(crate::events::WorkerEvent::ToolResult {
-        tool_use_id: "tool-1".to_string(),
-        title: "write src/main.rs".to_string(),
-        preview: "updated".to_string(),
-        is_error: false,
-        truncated: false,
-    });
-
-    let diff_event = tokio::time::timeout(std::time::Duration::from_secs(1), async {
-        loop {
-            if let Some(AppEvent::DiffResult(text)) = app_event_rx.recv().await {
-                break text;
-            }
-        }
-    })
-    .await
-    .expect("diff event should arrive");
-
-    assert!(
-        !diff_event.is_empty(),
-        "auto diff should send some result text"
-    );
-}
-
-#[tokio::test]
 async fn research_turn_does_not_auto_show_git_diff() {
     let model = Model {
         slug: "test-model".to_string(),


### PR DESCRIPTION
Stop write-tool completion from spawning a real git diff in the TUI and remove the flaky assertion that depended on CI checkout state.