### PR TITLE
feat(desktop): add process timeline, thought row, navigation

### DIFF
--- a/apps/desktop/docs/acp-traffic-logging.md
+++ b/apps/desktop/docs/acp-traffic-logging.md
@@ -1,0 +1,128 @@
+# ACP stdio traffic logging
+
+The desktop app talks to the local Devo server over **ACP** (Agent Client Protocol) on **stdio**: JSON-RPC messages on the child process stdin/stdout. To debug that wire protocol, the main process can append every message to a **JSONL** file.
+
+This uses the same enable switch and default output location as the CLI **Protocol Trace** (see [`docs/protocol-trace.md`](../../../docs/protocol-trace.md)).
+
+Implementation lives in:
+
+- `src/main/acp-traffic-log.ts` — logger, `DEVO_PROTOCOL_TRACE`, and path resolution
+- `src/main/acp-stdio-client.ts` — records each stdin/stdout message
+- `src/main/devo-manager.ts` — wires the logger into the stdio client at startup
+
+## Enabling
+
+Set `DEVO_PROTOCOL_TRACE=1` (or `true`) **before starting the desktop app**. The value is read once when the main process loads `devo-manager`; changing it at runtime has no effect until you restart the app.
+
+### Development (from repo)
+
+**macOS / Linux**
+
+```bash
+export DEVO_PROTOCOL_TRACE=1
+cd apps/desktop && bun run dev
+```
+
+**Windows (PowerShell)**
+
+```powershell
+$env:DEVO_PROTOCOL_TRACE = "1"
+cd apps\desktop; bun run dev
+```
+
+### Packaged app
+
+Set `DEVO_PROTOCOL_TRACE` in the environment used to launch Devo (shell profile, shortcut, CI job, etc.).
+
+## Output location
+
+Trace files are written to `DEVO_HOME/traces/` (default `~/.devo/traces/`) using the naming pattern `protocol-<pid>-<utc_timestamp>.ndjsonl`, where `<pid>` is the Electron main-process PID.
+
+To write to a specific path instead, set `DEVO_PROTOCOL_TRACE_FILE`:
+
+```bash
+DEVO_PROTOCOL_TRACE=1 DEVO_PROTOCOL_TRACE_FILE=/tmp/my-trace.ndjsonl bun run dev
+```
+
+If `DEVO_HOME` cannot be resolved, the trace falls back to `<temp_dir>/devo-traces/`.
+
+| Platform | Default traces directory |
+|----------|--------------------------|
+| macOS / Linux | `~/.devo/traces/` |
+| Windows | `%USERPROFILE%\.devo\traces\` |
+
+## View the log path in the UI
+
+When logging is enabled, open **Settings → Server**. Under **Developer options**, expand **ACP traffic log** to see the active file path.
+
+The renderer loads this via `window.devo.acpTraffic.getState()` (`acp-traffic-log:state` IPC).
+
+## Log format
+
+Each line is one JSON object (JSONL). Fields:
+
+| Field | Description |
+|-------|-------------|
+| `timestamp` | ISO-8601 time when the entry was written |
+| `direction` | `desktop-to-server`, `server-to-desktop`, or `system` |
+| `kind` | `request`, `response`, `notification`, `invalid`, or `closed` |
+| `id` | JSON-RPC id when present |
+| `method` | ACP method name when present |
+| `payload` | Full JSON-RPC message or system metadata |
+
+Example line:
+
+```json
+{"timestamp":"2026-06-27T01:02:03.004Z","direction":"desktop-to-server","kind":"request","id":1,"method":"initialize","payload":{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}}
+```
+
+The CLI protocol trace records raw wire lines (`seq`, `dir`, `bytes`, `line`). The desktop trace records parsed ACP messages with direction and kind, which is easier to filter when debugging the managed runtime.
+
+### What is recorded
+
+`StdioAcpClient` logs:
+
+- **desktop → server**: outbound requests and responses (e.g. permission replies)
+- **server → desktop**: inbound responses, notifications, and server-initiated requests
+- **system**: invalid stdout lines and transport `closed` events (with error text)
+
+### What is not recorded
+
+- **Server stderr** is not written to the traffic log. Non-empty stderr lines are emitted to the main-process console as `[main:acp-stdio-client]` warnings (`[stderr] …`).
+- **Renderer ↔ main IPC** is not included; only the stdio link to `devo server --transport stdio`.
+
+## Inspect the log
+
+**Tail live**
+
+```bash
+tail -f ~/.devo/traces/protocol-*.ndjsonl
+```
+
+**Pretty-print with jq**
+
+```bash
+jq -c '{ts: .timestamp, dir: .direction, kind, method, id}' ~/.devo/traces/protocol-*.ndjsonl
+```
+
+**Filter by method**
+
+```bash
+jq 'select(.method == "session/prompt")' ~/.devo/traces/protocol-*.ndjsonl
+```
+
+## Security
+
+The log can contain sensitive data: prompts, file paths, tool arguments, model/provider details, and credentials in params. Use a private path, disable logging when not debugging, and do not commit or share log files. The feature is disabled by default.
+
+## Legacy environment variables
+
+These are **ignored**:
+
+- `TRAFFIC_LOG_PATH`
+- `DEVO_DESKTOP_ACP_TRAFFIC_LOG`
+- `DEVO_DESKTOP_ACP_TRAFFIC_LOG_PATH`
+
+## Related debugging
+
+For general main-process diagnostics (spawn errors, slow IPC handlers, transport close), watch the terminal where Electron runs. Log lines are tagged `[main:<module>]`, e.g. `[main:acp-stdio-client]` and `[main:devo-manager]`.

--- a/apps/desktop/packages/devo-ai-sdk/package.json
+++ b/apps/desktop/packages/devo-ai-sdk/package.json
@@ -5,7 +5,8 @@
 	"license": "MIT",
 	"type": "module",
 	"exports": {
-		"./v2/client": "./src/v2/client.ts"
+		"./v2/client": "./src/v2/client.ts",
+		"./v2/acp-client-support": "./src/v2/acp-client-support.ts"
 	},
 	"dependencies": {
 		"ajv": "^8.20.0"

--- a/apps/desktop/packages/devo-ai-sdk/src/v2/acp-client-support.ts
+++ b/apps/desktop/packages/devo-ai-sdk/src/v2/acp-client-support.ts
@@ -51,15 +51,20 @@ export function defaultCwd(): string {
 	return process.env.HOME ?? process.cwd()
 }
 
+let sharedIpcTransport: DevoAcpTransport | null = null
+
 export function createIpcTransport(): DevoAcpTransport {
+	if (sharedIpcTransport) return sharedIpcTransport
+
 	const api = globalThis.window?.devo?.acp
 	if (!api) throw new Error("window.devo.acp is not available")
-	return {
+	sharedIpcTransport = {
 		request: (method, params, directory) => api.request({ method, params, directory }),
 		respond: (id, result) => api.respond({ id, result }),
 		subscribe: (listener) => api.subscribe(listener),
 		connected: () => api.connected(),
 	}
+	return sharedIpcTransport
 }
 
 export function providerDataFromConfigOptions(configOptions: AcpConfigOption[]): {

--- a/apps/desktop/packages/devo-ai-sdk/src/v2/client.ts
+++ b/apps/desktop/packages/devo-ai-sdk/src/v2/client.ts
@@ -536,6 +536,21 @@ function sortedMessages(messages: Message[]): Message[] {
 	return [...messages].sort(compareMessages)
 }
 
+const initializePromises = new WeakMap<DevoAcpTransport, Promise<void>>()
+
+const DESKTOP_INITIALIZE_PARAMS = {
+	protocolVersion: 1,
+	clientCapabilities: {
+		fs: { readTextFile: false, writeTextFile: false },
+		terminal: false,
+	},
+	clientInfo: {
+		name: "devo-desktop",
+		title: "Devo Desktop",
+		version: "0.1.0",
+	},
+} as const
+
 function recentMessages(messages: Message[], limit: number | undefined): Message[] {
 	const sorted = sortedMessages(messages)
 	if (limit === undefined || sorted.length <= limit) return sorted
@@ -1103,18 +1118,15 @@ class AcpClient {
 	private async ensureInitialized(): Promise<void> {
 		if (this.initialized) return
 		await this.open()
-		await this.request("initialize", {
-			protocolVersion: 1,
-			clientCapabilities: {
-				fs: { readTextFile: false, writeTextFile: false },
-				terminal: false,
-			},
-			clientInfo: {
-				name: "devo-desktop",
-				title: "Devo Desktop",
-				version: "0.1.0",
-			},
-		})
+		if (!this.transport) throw new Error("Devo ACP transport is not connected")
+		if (this.initialized) return
+
+		let promise = initializePromises.get(this.transport)
+		if (!promise) {
+			promise = this.request("initialize", DESKTOP_INITIALIZE_PARAMS).then(() => {})
+			initializePromises.set(this.transport, promise)
+		}
+		await promise
 		this.initialized = true
 	}
 
@@ -1150,6 +1162,10 @@ class AcpClient {
 
 	private handleTransportEvent(event: DevoAcpTransportEvent): void {
 		if (event.type === "closed") {
+			if (this.transport) {
+				initializePromises.delete(this.transport)
+			}
+			this.initialized = false
 			this.events.close()
 			return
 		}

--- a/apps/desktop/packages/ui/src/components/ai-elements/message.tsx
+++ b/apps/desktop/packages/ui/src/components/ai-elements/message.tsx
@@ -300,8 +300,15 @@ function TranscriptMarkdownHeading({
 	)
 }
 
+type TranscriptMarkdownRuleProps = ComponentProps<"hr"> & { node?: unknown }
+
+function TranscriptMarkdownRule({ node: _node, ..._props }: TranscriptMarkdownRuleProps) {
+	return null
+}
+
 // Product requirement: transcript Markdown headings should look like bold body text,
 // not oversized section titles or headings with divider rules.
+// Horizontal rules (--- / ***) are hidden; section breaks rely on paragraph spacing.
 const transcriptMarkdownComponents: NonNullable<MessageResponseProps["components"]> = {
 	h1: TranscriptMarkdownHeading,
 	h2: TranscriptMarkdownHeading,
@@ -309,6 +316,7 @@ const transcriptMarkdownComponents: NonNullable<MessageResponseProps["components
 	h4: TranscriptMarkdownHeading,
 	h5: TranscriptMarkdownHeading,
 	h6: TranscriptMarkdownHeading,
+	hr: TranscriptMarkdownRule,
 }
 
 export const MessageResponse = memo(

--- a/apps/desktop/src/main/acp-stdio-client.test.ts
+++ b/apps/desktop/src/main/acp-stdio-client.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path"
 import { describe, expect, test } from "bun:test"
 import { StdioAcpClient, buildServerProcessEnv, routeAcpLine } from "./acp-stdio-client"
 
@@ -53,7 +54,7 @@ describe("StdioAcpClient", () => {
 		expect(env).toMatchObject({
 			CUSTOM_FLAG: "1",
 			KEEP: "base",
-			PATH: "/Users/tester/.devo/bin:/custom/bin",
+			PATH: `${path.join("/Users/tester", ".devo", "bin")}:/custom/bin`,
 		})
 	})
 
@@ -221,6 +222,128 @@ describe("StdioAcpClient", () => {
 				payload: { jsonrpc: "2.0", id: 1, result: { ok: true } },
 			},
 		])
+	})
+
+	test("reuses the first initialize result for later initialize calls", async () => {
+		const records: unknown[] = []
+		let writeCount = 0
+		const client = new StdioAcpClient({
+			trafficLogger: {
+				getState: () => ({ enabled: true, path: null }),
+				record: (entry) => records.push(entry),
+			},
+		})
+		;(client as unknown as { child: unknown }).child = {
+			killed: false,
+			pid: 123,
+			stdin: {
+				destroyed: false,
+				writable: true,
+				writableEnded: false,
+				write: (_line: string, callback: (error?: Error) => void) => {
+					writeCount += 1
+					callback()
+					return true
+				},
+			},
+		}
+
+		const first = client.request("initialize", { protocolVersion: 1 })
+		await Promise.resolve()
+		;(client as unknown as { handleLine: (line: string) => void }).handleLine(
+			JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }),
+		)
+		await expect(first).resolves.toEqual({ ok: true })
+
+		const second = client.request("initialize", { protocolVersion: 1 })
+		await expect(second).resolves.toEqual({ ok: true })
+
+		expect(writeCount).toBe(1)
+		expect(
+			records.filter(
+				(entry) =>
+					(entry as { kind?: string; method?: string }).kind === "request" &&
+					(entry as { method?: string }).method === "initialize",
+			),
+		).toHaveLength(1)
+	})
+
+	test("scopes outgoing requests with the project directory", async () => {
+		const records: unknown[] = []
+		const client = new StdioAcpClient({
+			trafficLogger: {
+				getState: () => ({ enabled: true, path: null }),
+				record: (entry) => records.push(entry),
+			},
+		})
+		;(client as unknown as { child: unknown }).child = {
+			killed: false,
+			pid: 123,
+			stdin: {
+				destroyed: false,
+				writable: true,
+				writableEnded: false,
+				write: (_line: string, callback: (error?: Error) => void) => {
+					callback()
+					return true
+				},
+			},
+		}
+
+		const response = client.request("session/list", {}, "/repo/project")
+		await Promise.resolve()
+		;(client as unknown as { handleLine: (line: string) => void }).handleLine(
+			JSON.stringify({ jsonrpc: "2.0", id: 1, result: { sessions: [] } }),
+		)
+
+		await expect(response).resolves.toEqual({ sessions: [] })
+		expect(records[0]).toMatchObject({
+			direction: "desktop-to-server",
+			kind: "request",
+			method: "session/list",
+			payload: {
+				params: { cwd: "/repo/project" },
+			},
+		})
+	})
+
+	test("does not add project directory to unscoped requests", async () => {
+		const records: unknown[] = []
+		const client = new StdioAcpClient({
+			trafficLogger: {
+				getState: () => ({ enabled: true, path: null }),
+				record: (entry) => records.push(entry),
+			},
+		})
+		;(client as unknown as { child: unknown }).child = {
+			killed: false,
+			pid: 123,
+			stdin: {
+				destroyed: false,
+				writable: true,
+				writableEnded: false,
+				write: (_line: string, callback: (error?: Error) => void) => {
+					callback()
+					return true
+				},
+			},
+		}
+
+		const response = client.request("session/prompt", { sessionId: "s1", prompt: [] }, "/repo/project")
+		await Promise.resolve()
+		;(client as unknown as { handleLine: (line: string) => void }).handleLine(
+			JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+		)
+
+		await expect(response).resolves.toEqual({ stopReason: "end_turn" })
+		expect(records[0]).toMatchObject({
+			direction: "desktop-to-server",
+			kind: "request",
+			method: "session/prompt",
+			payload: {
+				params: { sessionId: "s1", prompt: [] },
+			},
+		})
 	})
 
 	test("records server requests, notifications, invalid lines, and closed events", () => {

--- a/apps/desktop/src/main/acp-stdio-client.ts
+++ b/apps/desktop/src/main/acp-stdio-client.ts
@@ -45,7 +45,7 @@ export type AcpTransportEvent =
 export type AcpTransportListener = (event: AcpTransportEvent) => void
 
 export interface AcpTransport {
-	request(method: string, params?: unknown): Promise<unknown>
+	request(method: string, params?: unknown, directory?: string): Promise<unknown>
 	respond(id: JsonRpcId, result: unknown): Promise<void>
 	subscribe(listener: AcpTransportListener): () => void
 	connected(): boolean
@@ -165,6 +165,23 @@ export function routeAcpLine(line: string): AcpIncomingMessage {
 	return { type: "invalid", error: "JSON-RPC message has no id or method", line }
 }
 
+const DIRECTORY_SCOPED_METHODS = new Set([
+	"session/list",
+	"model/config",
+	"model/config/set",
+	"skills/list",
+	"skills/changed",
+	"reference/search/start",
+	"command/exec",
+])
+
+function scopeRequestParams(method: string, params: unknown, directory?: string): unknown {
+	if (!directory || !DIRECTORY_SCOPED_METHODS.has(method)) return params
+	if (!params || typeof params !== "object" || Array.isArray(params)) return params
+	if ("cwd" in params) return params
+	return { ...params, cwd: directory }
+}
+
 export class StdioAcpClient implements AcpTransport {
 	private child: ChildProcessWithoutNullStreams | null = null
 	private nextId = 1
@@ -172,6 +189,8 @@ export class StdioAcpClient implements AcpTransport {
 	private pendingMethods = new Map<JsonRpcId, string>()
 	private events = new EventEmitter()
 	private stopped = false
+	private initializeResult: unknown | undefined
+	private initializeInFlight: Promise<unknown> | null = null
 
 	constructor(private readonly options: StdioAcpClientOptions = {}) {}
 
@@ -230,11 +249,39 @@ export class StdioAcpClient implements AcpTransport {
 		})
 	}
 
-	async request(method: string, params: unknown = {}): Promise<unknown> {
+	async request(method: string, params: unknown = {}, directory?: string): Promise<unknown> {
+		if (method === "initialize") {
+			return this.requestInitialize(params, directory)
+		}
+		return this.sendRequest(method, params, directory)
+	}
+
+	private async requestInitialize(params: unknown, directory?: string): Promise<unknown> {
+		if (this.initializeResult !== undefined) {
+			return this.initializeResult
+		}
+		if (this.initializeInFlight) {
+			return this.initializeInFlight
+		}
+		this.initializeInFlight = this.sendRequest("initialize", params, directory)
+			.then((result) => {
+				this.initializeResult = result
+				this.initializeInFlight = null
+				return result
+			})
+			.catch((error) => {
+				this.initializeInFlight = null
+				throw error
+			})
+		return this.initializeInFlight
+	}
+
+	private async sendRequest(method: string, params: unknown, directory?: string): Promise<unknown> {
 		this.start()
 		const id = this.nextId++
 		const child = this.requireChild()
-		const payload = { jsonrpc: "2.0", id, method, params }
+		const scopedParams = scopeRequestParams(method, params, directory)
+		const payload = { jsonrpc: "2.0", id, method, params: scopedParams }
 		const response = new Promise<unknown>((resolve, reject) => {
 			this.pending.set(id, { resolve, reject })
 		})
@@ -390,6 +437,8 @@ export class StdioAcpClient implements AcpTransport {
 
 	private close(error: Error): void {
 		this.child = null
+		this.initializeResult = undefined
+		this.initializeInFlight = null
 		this.recordTraffic({
 			direction: "system",
 			kind: "closed",

--- a/apps/desktop/src/main/acp-traffic-log.test.ts
+++ b/apps/desktop/src/main/acp-traffic-log.test.ts
@@ -3,8 +3,14 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import {
-	TRAFFIC_LOG_PATH_ENV,
+	DEVO_HOME_ENV,
+	PROTOCOL_TRACE_ENV,
+	PROTOCOL_TRACE_FILE_ENV,
 	createAcpTrafficLoggerFromEnv,
+	findDevoHome,
+	formatProtocolTraceTimestamp,
+	isProtocolTraceEnabled,
+	resolveProtocolTracePath,
 } from "./acp-traffic-log"
 
 function withTempDir<T>(run: (dir: string) => T): T {
@@ -18,12 +24,31 @@ function withTempDir<T>(run: (dir: string) => T): T {
 
 const fixedClock = () => new Date("2026-06-27T01:02:03.004Z")
 
-describe("ACP traffic log env trigger", () => {
-	test("does not create or write a log when TRAFFIC_LOG_PATH is unset or empty", () => {
+describe("protocol trace env trigger", () => {
+	test("isProtocolTraceEnabled accepts 1 and true", () => {
+		expect({
+			unset: isProtocolTraceEnabled(undefined),
+			empty: isProtocolTraceEnabled(" "),
+			one: isProtocolTraceEnabled("1"),
+			trueValue: isProtocolTraceEnabled("true"),
+			TrueValue: isProtocolTraceEnabled("TRUE"),
+			zero: isProtocolTraceEnabled("0"),
+		}).toEqual({
+			unset: false,
+			empty: false,
+			one: true,
+			trueValue: true,
+			TrueValue: true,
+			zero: false,
+		})
+	})
+
+	test("does not create or write a log when DEVO_PROTOCOL_TRACE is unset or empty", () => {
 		withTempDir((dir) => {
 			const logger = createAcpTrafficLoggerFromEnv({
-				env: {},
+				env: { [DEVO_HOME_ENV]: dir },
 				clock: fixedClock,
+				pid: 42,
 			})
 
 			logger.record({
@@ -36,17 +61,21 @@ describe("ACP traffic log env trigger", () => {
 
 			expect({
 				state: logger.getState(),
-				logsDirExists: existsSync(path.join(dir, "logs")),
+				tracesDirExists: existsSync(path.join(dir, "traces")),
 			}).toEqual({
 				state: { enabled: false, path: null },
-				logsDirExists: false,
+				tracesDirExists: false,
 			})
 		})
 
 		withTempDir((dir) => {
 			const logger = createAcpTrafficLoggerFromEnv({
-				env: { [TRAFFIC_LOG_PATH_ENV]: " " },
+				env: {
+					[DEVO_HOME_ENV]: dir,
+					[PROTOCOL_TRACE_ENV]: " ",
+				},
 				clock: fixedClock,
+				pid: 42,
 			})
 
 			logger.record({
@@ -57,22 +86,25 @@ describe("ACP traffic log env trigger", () => {
 
 			expect({
 				state: logger.getState(),
-				logsDirExists: existsSync(path.join(dir, "logs")),
+				tracesDirExists: existsSync(path.join(dir, "traces")),
 			}).toEqual({
 				state: { enabled: false, path: null },
-				logsDirExists: false,
+				tracesDirExists: false,
 			})
 		})
 	})
 
-	test("ignores the removed DEVO_DESKTOP_ACP_TRAFFIC_LOG trigger", () => {
+	test("ignores removed desktop-specific triggers", () => {
 		withTempDir((dir) => {
 			const logger = createAcpTrafficLoggerFromEnv({
 				env: {
+					[DEVO_HOME_ENV]: dir,
 					DEVO_DESKTOP_ACP_TRAFFIC_LOG: "1",
 					DEVO_DESKTOP_ACP_TRAFFIC_LOG_PATH: path.join(dir, "old", "traffic.jsonl"),
+					TRAFFIC_LOG_PATH: path.join(dir, "old", "traffic.jsonl"),
 				},
 				clock: fixedClock,
+				pid: 42,
 			})
 
 			logger.record({
@@ -85,22 +117,59 @@ describe("ACP traffic log env trigger", () => {
 
 			expect({
 				state: logger.getState(),
-				logsDirExists: existsSync(path.join(dir, "old")),
+				oldDirExists: existsSync(path.join(dir, "old")),
 			}).toEqual({
 				state: { enabled: false, path: null },
-				logsDirExists: false,
+				oldDirExists: false,
 			})
 		})
 	})
 
-	test("writes JSONL when TRAFFIC_LOG_PATH is provided", () => {
+	test("writes JSONL to DEVO_HOME/traces when DEVO_PROTOCOL_TRACE is enabled", () => {
 		withTempDir((dir) => {
-			const logPath = path.join(dir, "custom", "traffic.jsonl")
+			const expectedPath = path.join(dir, "traces", "protocol-42-20260627T010203Z.ndjsonl")
 			const logger = createAcpTrafficLoggerFromEnv({
 				env: {
-					[TRAFFIC_LOG_PATH_ENV]: ` ${logPath} `,
+					[DEVO_HOME_ENV]: dir,
+					[PROTOCOL_TRACE_ENV]: "1",
 				},
 				clock: fixedClock,
+				pid: 42,
+			})
+
+			logger.record({
+				direction: "system",
+				kind: "closed",
+				payload: { error: "transport closed" },
+			})
+
+			const lines = readFileSync(expectedPath, "utf-8").trim().split("\n")
+			expect({
+				state: logger.getState(),
+				entry: JSON.parse(lines[0]),
+			}).toEqual({
+				state: { enabled: true, path: expectedPath },
+				entry: {
+					timestamp: "2026-06-27T01:02:03.004Z",
+					direction: "system",
+					kind: "closed",
+					payload: { error: "transport closed" },
+				},
+			})
+		})
+	})
+
+	test("writes JSONL to DEVO_PROTOCOL_TRACE_FILE when provided", () => {
+		withTempDir((dir) => {
+			const logPath = path.join(dir, "custom", "trace.ndjsonl")
+			const logger = createAcpTrafficLoggerFromEnv({
+				env: {
+					[DEVO_HOME_ENV]: dir,
+					[PROTOCOL_TRACE_ENV]: "true",
+					[PROTOCOL_TRACE_FILE_ENV]: ` ${logPath} `,
+				},
+				clock: fixedClock,
+				pid: 42,
 			})
 
 			logger.record({
@@ -123,5 +192,28 @@ describe("ACP traffic log env trigger", () => {
 				},
 			})
 		})
+	})
+
+	test("falls back to temp devo-traces when DEVO_HOME is invalid", () => {
+		const logPath = resolveProtocolTracePath({
+			env: {
+				[DEVO_HOME_ENV]: path.join(tmpdir(), "missing-devo-home-for-trace"),
+				[PROTOCOL_TRACE_ENV]: "1",
+			},
+			clock: fixedClock,
+			pid: 99,
+		})
+
+		expect(logPath).toMatch(/devo-traces[\\/]protocol-99-20260627T010203Z\.ndjsonl$/)
+	})
+
+	test("findDevoHome honors DEVO_HOME and defaults to ~/.devo", () => {
+		withTempDir((dir) => {
+			expect(findDevoHome({ [DEVO_HOME_ENV]: dir })).toBe(path.resolve(dir))
+		})
+	})
+
+	test("formatProtocolTraceTimestamp matches server naming", () => {
+		expect(formatProtocolTraceTimestamp(fixedClock())).toBe("20260627T010203Z")
 	})
 })

--- a/apps/desktop/src/main/acp-traffic-log.ts
+++ b/apps/desktop/src/main/acp-traffic-log.ts
@@ -1,7 +1,10 @@
-import { appendFileSync, mkdirSync } from "node:fs"
+import { appendFileSync, mkdirSync, statSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
 import path from "node:path"
 
-export const TRAFFIC_LOG_PATH_ENV = "TRAFFIC_LOG_PATH"
+export const PROTOCOL_TRACE_ENV = "DEVO_PROTOCOL_TRACE"
+export const PROTOCOL_TRACE_FILE_ENV = "DEVO_PROTOCOL_TRACE_FILE"
+export const DEVO_HOME_ENV = "DEVO_HOME"
 
 export type AcpTrafficDirection = "desktop-to-server" | "server-to-desktop" | "system"
 export type AcpTrafficKind = "request" | "response" | "notification" | "invalid" | "closed"
@@ -28,14 +31,69 @@ export interface AcpTrafficLogger {
 interface CreateAcpTrafficLoggerOptions {
 	env?: Record<string, string | undefined>
 	clock?: () => Date
+	pid?: number
+}
+
+export function isProtocolTraceEnabled(value: string | undefined): boolean {
+	if (!value?.trim()) return false
+	const normalized = value.trim()
+	return normalized === "1" || normalized.toLowerCase() === "true"
+}
+
+export function findDevoHome(env: Record<string, string | undefined> = process.env): string {
+	const explicit = env[DEVO_HOME_ENV]?.trim()
+	if (explicit) {
+		const resolved = path.resolve(explicit)
+		const stat = statSync(resolved, { throwIfNoEntry: false })
+		if (!stat?.isDirectory()) {
+			throw new Error(`DEVO_HOME points to ${explicit}, but that path is not a directory`)
+		}
+		return resolved
+	}
+	return path.join(homedir(), ".devo")
+}
+
+export function formatProtocolTraceTimestamp(date: Date): string {
+	return date.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z")
+}
+
+export function resolveProtocolTracePath({
+	env = process.env,
+	clock = () => new Date(),
+	pid = process.pid,
+}: {
+	env?: Record<string, string | undefined>
+	clock?: () => Date
+	pid?: number
+} = {}): string | null {
+	if (!isProtocolTraceEnabled(env[PROTOCOL_TRACE_ENV])) return null
+
+	const explicit = env[PROTOCOL_TRACE_FILE_ENV]?.trim()
+	if (explicit) {
+		const resolved = path.resolve(explicit)
+		mkdirSync(path.dirname(resolved), { recursive: true })
+		return resolved
+	}
+
+	const fileName = `protocol-${pid}-${formatProtocolTraceTimestamp(clock())}.ndjsonl`
+
+	try {
+		const base = path.join(findDevoHome(env), "traces")
+		mkdirSync(base, { recursive: true })
+		return path.join(base, fileName)
+	} catch {
+		const base = path.join(tmpdir(), "devo-traces")
+		mkdirSync(base, { recursive: true })
+		return path.join(base, fileName)
+	}
 }
 
 export function createAcpTrafficLoggerFromEnv({
 	env = process.env,
 	clock = () => new Date(),
-}: CreateAcpTrafficLoggerOptions): AcpTrafficLogger {
-	const logPath = env[TRAFFIC_LOG_PATH_ENV]?.trim() || null
-
+	pid = process.pid,
+}: CreateAcpTrafficLoggerOptions = {}): AcpTrafficLogger {
+	const logPath = resolveProtocolTracePath({ env, clock, pid })
 	return new AcpTrafficFileLogger({ enabled: logPath !== null, path: logPath }, clock)
 }
 
@@ -43,7 +101,12 @@ class AcpTrafficFileLogger implements AcpTrafficLogger {
 	constructor(
 		private readonly state: AcpTrafficLogState,
 		private readonly clock: () => Date,
-	) {}
+	) {
+		if (this.state.enabled && this.state.path) {
+			mkdirSync(path.dirname(this.state.path), { recursive: true })
+			writeFileSync(this.state.path, "", "utf-8")
+		}
+	}
 
 	getState(): AcpTrafficLogState {
 		return { ...this.state }
@@ -52,7 +115,6 @@ class AcpTrafficFileLogger implements AcpTrafficLogger {
 	record(entry: AcpTrafficLogRecord): void {
 		if (!this.state.enabled || !this.state.path) return
 
-		mkdirSync(path.dirname(this.state.path), { recursive: true })
 		appendFileSync(
 			this.state.path,
 			`${JSON.stringify({ timestamp: this.clock().toISOString(), ...entry })}\n`,

--- a/apps/desktop/src/main/devo-manager.ts
+++ b/apps/desktop/src/main/devo-manager.ts
@@ -1,7 +1,9 @@
 import type { AcpTransport, AcpTransportEvent, AcpTransportListener, JsonRpcId } from "./acp-stdio-client"
 import { app } from "electron"
 import {
-	TRAFFIC_LOG_PATH_ENV,
+	DEVO_HOME_ENV,
+	PROTOCOL_TRACE_ENV,
+	PROTOCOL_TRACE_FILE_ENV,
 	createAcpTrafficLoggerFromEnv,
 	type AcpTrafficLogger,
 	type AcpTrafficLogState,
@@ -17,7 +19,9 @@ const log = createLogger("devo-manager")
 
 const STDIO_URL = "stdio://local"
 const acpTrafficLogStartupEnv = {
-	[TRAFFIC_LOG_PATH_ENV]: process.env[TRAFFIC_LOG_PATH_ENV],
+	[DEVO_HOME_ENV]: process.env[DEVO_HOME_ENV],
+	[PROTOCOL_TRACE_ENV]: process.env[PROTOCOL_TRACE_ENV],
+	[PROTOCOL_TRACE_FILE_ENV]: process.env[PROTOCOL_TRACE_FILE_ENV],
 }
 
 export interface DevoServer {
@@ -75,9 +79,13 @@ export async function restartServer(): Promise<DevoServer> {
 	return ensureServer()
 }
 
-export async function requestAcp(method: string, params?: unknown): Promise<unknown> {
+export async function requestAcp(
+	method: string,
+	params?: unknown,
+	directory?: string,
+): Promise<unknown> {
 	const client = await ensureClient()
-	return client.request(method, params)
+	return client.request(method, params, directory)
 }
 
 export async function respondAcp(id: JsonRpcId, result: unknown): Promise<void> {
@@ -94,15 +102,17 @@ export function isAcpConnected(): boolean {
 	return stdioClient?.connected() ?? false
 }
 
+const sharedAcpTransport: AcpTransport = {
+	request: requestAcp,
+	respond: respondAcp,
+	subscribe: subscribeAcp,
+	connected: isAcpConnected,
+	pid: () => stdioClient?.pid() ?? null,
+	stop: stopServer,
+}
+
 export function getAcpTransport(): AcpTransport {
-	return {
-		request: requestAcp,
-		respond: respondAcp,
-		subscribe: subscribeAcp,
-		connected: isAcpConnected,
-		pid: () => stdioClient?.pid() ?? null,
-		stop: stopServer,
-	}
+	return sharedAcpTransport
 }
 
 export function getAcpTrafficLogState(): AcpTrafficLogState {

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -205,10 +205,8 @@ export function registerIpcHandlers(): void {
 		"acp:request",
 		withLogging(
 			"acp:request",
-			async (_, request: { method: string; params?: unknown; directory?: string }) => {
-				void request.directory
-				return await requestAcp(request.method, request.params)
-			},
+			async (_, request: { method: string; params?: unknown; directory?: string }) =>
+				await requestAcp(request.method, request.params, request.directory),
 		),
 	)
 

--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -31,6 +31,7 @@ function expectedSettings() {
 			colorScheme: "dark",
 			themeId: "default",
 			displayMode: "default",
+			hideThinkingWhileWorking: true,
 			rendererPreferencesMigrated: false,
 		},
 		openIn: {
@@ -106,6 +107,7 @@ describe("settings-store", () => {
 				colorScheme: "system",
 				themeId: "default",
 				displayMode: "default",
+				hideThinkingWhileWorking: true,
 				rendererPreferencesMigrated: false,
 			},
 			openIn: {
@@ -162,6 +164,7 @@ describe("settings-store", () => {
 				colorScheme: "system",
 				themeId: "cortex",
 				displayMode: "verbose",
+				hideThinkingWhileWorking: true,
 				rendererPreferencesMigrated: false,
 			},
 		})

--- a/apps/desktop/src/preload/api.d.ts
+++ b/apps/desktop/src/preload/api.d.ts
@@ -179,6 +179,8 @@ export interface AppearanceSettings {
 	colorScheme: ColorScheme
 	themeId: string
 	displayMode: DisplayMode
+	/** Hide model reasoning/thinking blocks while the agent is still working. */
+	hideThinkingWhileWorking: boolean
 	rendererPreferencesMigrated: boolean
 }
 

--- a/apps/desktop/src/renderer/atoms/preferences.ts
+++ b/apps/desktop/src/renderer/atoms/preferences.ts
@@ -65,6 +65,11 @@ export const displayModeAtom = atomWithStorage<DisplayMode>(
 	DEFAULT_APPEARANCE_SETTINGS.displayMode,
 )
 
+export const hideThinkingWhileWorkingAtom = atomWithStorage<boolean>(
+	"devo:hideThinkingWhileWorking",
+	DEFAULT_APPEARANCE_SETTINGS.hideThinkingWhileWorking,
+)
+
 export const themeAtom = atomWithStorage<string>("devo:theme", DEFAULT_APPEARANCE_SETTINGS.themeId)
 
 export const colorSchemeAtom = atomWithStorage<ColorScheme>(

--- a/apps/desktop/src/renderer/atoms/ui.ts
+++ b/apps/desktop/src/renderer/atoms/ui.ts
@@ -11,6 +11,26 @@ export const commandPaletteOpenAtom = atom(false)
  */
 export const viewedSessionIdAtom = atom<string | null>(null)
 
+/**
+ * Last non-settings route visited before opening Settings.
+ * Used to restore navigation when leaving Settings.
+ */
+export const lastAppRouteAtom = atom<string | null>(null)
+
+/** Session kept mounted in the background while Settings is open. */
+export interface SettingsBackgroundSession {
+	sessionId: string
+	projectSlug: string
+}
+
+export const settingsBackgroundSessionAtom = atom<SettingsBackgroundSession | null>(null)
+
+/** Whether the Settings overlay is covering the main content (set by SidebarLayout). */
+export const settingsOverlayOpenAtom = atom(false)
+
+/** Last known scrollTop for a session's chat view (used when returning from Settings). */
+export const sessionScrollTopFamily = atomFamily((_sessionId: string) => atom<number | null>(null))
+
 // ============================================================
 // Review Panel State
 // ============================================================

--- a/apps/desktop/src/renderer/components/chat/chat-tool-call.test.ts
+++ b/apps/desktop/src/renderer/components/chat/chat-tool-call.test.ts
@@ -7,30 +7,19 @@ const chatToolCallSource = readFileSync(new URL("./chat-tool-call.tsx", import.m
 const rendererCssSource = readFileSync(new URL("../../index.css", import.meta.url), "utf8")
 
 describe("shouldDefaultOpen", () => {
-	test("collapses tool output by default", () => {
-		const tools = ["bash", "read", "edit", "write", "apply_patch", "glob", "grep", "list"]
-
-		expect(Object.fromEntries(tools.map((tool) => [tool, shouldDefaultOpen(tool, "completed")]))).toEqual({
-			bash: false,
-			read: false,
-			edit: false,
-			write: false,
-			apply_patch: false,
-			glob: false,
-			grep: false,
-			list: false,
-		})
-	})
-
-	test("keeps error output expanded", () => {
+	test("keeps all tool output collapsed by default", () => {
 		expect({
-			bash: shouldDefaultOpen("bash", "error"),
-			read: shouldDefaultOpen("read", "error"),
+			bash: shouldDefaultOpen("bash", "completed"),
+			read: shouldDefaultOpen("read", "completed"),
+			bashError: shouldDefaultOpen("bash", "error"),
+			readError: shouldDefaultOpen("read", "error"),
 			unknown: shouldDefaultOpen("unknown", "error"),
 		}).toEqual({
-			bash: true,
-			read: true,
-			unknown: true,
+			bash: false,
+			read: false,
+			bashError: false,
+			readError: false,
+			unknown: false,
 		})
 	})
 })

--- a/apps/desktop/src/renderer/components/chat/chat-tool-call.tsx
+++ b/apps/desktop/src/renderer/components/chat/chat-tool-call.tsx
@@ -40,13 +40,17 @@ import {
 } from "lucide-react"
 import type { ReactNode } from "react"
 import { memo, useCallback, useMemo } from "react"
-import { useToolElapsedTime } from "../../hooks/use-elapsed-time"
 import type { BundledLanguage } from "shiki"
 import { viewFileInDiffPanelAtom } from "../../atoms/ui"
 import { detectContentLanguage, detectLanguage, prettyPrintJson } from "../../lib/language"
 import type { FilePart, ToolPart, ToolStateCompleted } from "../../lib/types"
 import { SubAgentCard } from "./sub-agent-card"
-import { getToolCategory, ToolCard } from "./tool-card"
+import type { ToolCategory } from "./tool-card"
+import {
+	TranscriptDisclosure,
+	TranscriptDisclosureContent,
+	TranscriptDisclosureTrigger,
+} from "./transcript-disclosure"
 import {
 	formatToolPathForDisplay,
 	getFirstApplyPatchPath,
@@ -445,10 +449,7 @@ function BashContent({ part }: { part: ToolPart }) {
 				<Terminal
 					output={displayOutput}
 					isStreaming={isStreaming}
-					className={cn(
-						"max-h-64 border-0 shadow-none rounded-none text-[11px]",
-						error && "border-red-500/30",
-					)}
+					className="max-h-64 border-0 shadow-none rounded-none text-[11px]"
 				>
 					<TerminalHeader className="py-1.5 px-3">
 						<TerminalTitle className="text-[11px]">Output</TerminalTitle>
@@ -761,7 +762,7 @@ function TodoContent({ part }: { part: ToolPart }) {
 /** Error content for any tool */
 function ErrorContent({ error }: { error: string }) {
 	return (
-		<div className="flex items-start gap-2 rounded bg-red-500/5 mx-3.5 my-2.5 px-2 py-1.5 text-xs text-red-400">
+		<div className="mx-3.5 my-2.5 flex items-start gap-2 rounded bg-muted/30 px-2 py-1.5 text-xs text-muted-foreground">
 			<AlertTriangleIcon className="mt-0.5 size-3 shrink-0" aria-hidden="true" />
 			<pre className="max-h-32 overflow-auto font-mono">
 				<code>{error.length > 500 ? `${error.slice(0, 500)}...` : error}</code>
@@ -818,15 +819,84 @@ function GenericContent({ part }: { part: ToolPart }) {
 }
 
 // ============================================================
+// Tool group summaries
+// ============================================================
+
+export function describeToolGroup(
+	category: ToolCategory,
+	tools: ToolPart[],
+	projectRoot?: string | null,
+): string {
+	const count = tools.length
+
+	if (count <= 3) {
+		const details = tools
+			.map((t) => getToolSubtitle(t, { projectRoot }))
+			.filter(Boolean)
+			.map((s) => {
+				const parts = s!.split("/")
+				return parts.length > 1 ? parts[parts.length - 1] : s
+			})
+
+		if (details.length > 0) {
+			switch (category) {
+				case "explore":
+					return count === 1 ? `Read ${details[0]}` : `Read ${details.join(", ")}`
+				case "edit":
+					return count === 1 ? `Edited ${details[0]}` : `Edited ${details.join(", ")}`
+				case "run":
+					return count === 1 ? `Ran ${details[0]}` : `Ran ${count} commands`
+				case "delegate":
+					return count === 1 ? `Delegated: ${details[0]}` : `Delegated ${count} tasks`
+				case "fetch":
+					return count === 1 ? `Fetched ${details[0]}` : `Fetched ${count} URLs`
+				case "ask":
+					return "Asked a question"
+				case "plan":
+					return "Updated plan"
+				default:
+					return `Ran ${details.join(", ")}`
+			}
+		}
+	}
+
+	switch (category) {
+		case "explore":
+			return `Explored ${count} files`
+		case "edit":
+			return `Edited ${count} files`
+		case "run":
+			return `Ran ${count} commands`
+		case "delegate":
+			return `Delegated ${count} tasks`
+		case "fetch":
+			return `Fetched ${count} URLs`
+		case "ask":
+			return `Asked ${count} questions`
+		case "plan":
+			return "Updated plan"
+		default:
+			return `Ran ${count} tools`
+	}
+}
+
+export function isGroupRunning(tools: ToolPart[]): boolean {
+	return tools.some((t) => t.state.status === "running" || t.state.status === "pending")
+}
+
+export function isGroupError(tools: ToolPart[]): boolean {
+	return tools.some((t) => t.state.status === "error")
+}
+
+// ============================================================
 // Smart defaults: which tools should be open by default
 // ============================================================
 
 /**
  * Returns whether a tool should default to expanded in the active turn.
  */
-export function shouldDefaultOpen(_tool: string, status: string): boolean {
-	// Errors stay expanded so failure output remains visible for recovery.
-	return status === "error"
+export function shouldDefaultOpen(_tool: string, _status: string): boolean {
+	return false
 }
 /**
  * Returns whether a tool has expandable content.
@@ -914,6 +984,9 @@ interface ChatToolCallProps {
 	onDelete?: (part: ToolPart) => void
 	/** Project root used only for display-only path labels. */
 	projectRoot?: string | null
+	open?: boolean
+	defaultOpen?: boolean
+	onOpenChange?: (open: boolean) => void
 }
 
 /**
@@ -959,6 +1032,9 @@ export const ChatToolCall = memo(
 		turnHasError = false,
 		onDelete,
 		projectRoot,
+		open,
+		defaultOpen: defaultOpenProp,
+		onOpenChange,
 	}: ChatToolCallProps) {
 		const viewFileInDiff = useSetAtom(viewFileInDiffPanelAtom)
 
@@ -988,16 +1064,12 @@ export const ChatToolCall = memo(
 			[editFilePath, viewFileInDiff],
 		)
 
-		const duration = getToolDuration(part)
-		const elapsedTime = useToolElapsedTime(part)
 		const status = part.state.status as "running" | "error" | "completed" | "pending"
 
-		// Build trailing element: diff stats + "view diff" button + duration/spinner
-		// Must be called before early returns to satisfy hooks rules.
+		// Build trailing element: diff stats + "view diff" button, or a running spinner.
 		const trailingElement = useMemo(() => {
 			const parts: ReactNode[] = []
 
-			// Diff stats for edit tools
 			if (diffStats) {
 				parts.push(
 					<span key="stats" className="flex items-center gap-1.5 text-[11px]">
@@ -1013,30 +1085,19 @@ export const ChatToolCall = memo(
 				)
 			}
 
-			// Duration, elapsed time + spinner, or just spinner
-			if (duration) {
+			if (status === "running" || status === "pending") {
 				parts.push(
-					<span key="duration" className="text-[11px]">
-						{duration}
-					</span>,
-				)
-			} else if (status === "running" || status === "pending") {
-				parts.push(
-					<span key="running" className="flex items-center gap-1.5">
-						{elapsedTime && (
-							<span className="text-[11px] tabular-nums text-muted-foreground/50">
-								{elapsedTime}
-							</span>
-						)}
-						<Loader2Icon className="size-3 animate-spin text-muted-foreground/40" />
-					</span>,
+					<Loader2Icon
+						key="running"
+						className="size-3 animate-spin text-muted-foreground/40"
+					/>,
 				)
 			}
 
 			if (parts.length === 0) return undefined
 			if (parts.length === 1) return parts[0]
 			return <span className="flex items-center gap-2.5">{parts}</span>
-		}, [diffStats, duration, elapsedTime, status])
+		}, [diffStats, status])
 
 		// Combine trailing element with "View diff" button for edit-category tools
 		const combinedTrailing = useMemo(() => {
@@ -1104,9 +1165,10 @@ export const ChatToolCall = memo(
 		// --- All other tools (including todos): ToolCard ---
 		const { icon: Icon, title } = getToolInfo(part.tool)
 		const subtitle = getToolSubtitle(part, { projectRoot })
-		const category = getToolCategory(part.tool)
 		const hasContent = hasExpandableContent(part)
-		const defaultOpen = isActiveTurn ? shouldDefaultOpen(part.tool, status) : false
+		const defaultOpen =
+			defaultOpenProp ?? (isActiveTurn ? shouldDefaultOpen(part.tool, status) : false)
+		const isRunning = status === "running" || status === "pending"
 
 		// Extract attachments
 		const attachments: FilePart[] =
@@ -1114,22 +1176,44 @@ export const ChatToolCall = memo(
 				? ((part.state as ToolStateCompleted).attachments ?? [])
 				: []
 
+		const label = subtitle ? (
+			<>
+				<span>{title}</span>
+				<span className="text-muted-foreground/60"> · {subtitle}</span>
+			</>
+		) : (
+			<span>{title}</span>
+		)
+
 		return (
 			<div className="space-y-1.5">
-				<ToolCard
-					icon={<Icon className="size-3.5" />}
-					title={title}
-					subtitle={subtitle}
-					trailing={finalTrailing}
-					category={category}
+				<TranscriptDisclosure
+					className="mb-0"
 					defaultOpen={defaultOpen}
-					forceOpen={status === "error"}
-					hasContent={hasContent}
-					status={status}
-					renderContent={hasContent ? () => getToolContent(part) : undefined}
-				/>
+					expandable={hasContent}
+					open={open}
+					onOpenChange={onOpenChange}
+				>
+					<TranscriptDisclosureTrigger
+						leading={
+							<Icon
+								className={`size-4 shrink-0 ${
+									isRunning
+										? "animate-pulse text-muted-foreground"
+										: "text-muted-foreground/50"
+								}`}
+							/>
+						}
+						label={label}
+						trailing={finalTrailing}
+					/>
+					{hasContent && (
+						<TranscriptDisclosureContent className="overflow-hidden rounded-md border border-border/50">
+							{getToolContent(part)}
+						</TranscriptDisclosureContent>
+					)}
+				</TranscriptDisclosure>
 
-				{/* Tool attachments (images, etc.) */}
 				{attachments.length > 0 && <ToolAttachments attachments={attachments} />}
 			</div>
 		)

--- a/apps/desktop/src/renderer/components/chat/chat-turn.test.ts
+++ b/apps/desktop/src/renderer/components/chat/chat-turn.test.ts
@@ -5,6 +5,18 @@ const source = readFileSync(
   new URL("./chat-turn.tsx", import.meta.url),
   "utf8",
 );
+const thoughtRowSource = readFileSync(
+  new URL("./thought-row.tsx", import.meta.url),
+  "utf8",
+);
+const transcriptDisclosureSource = readFileSync(
+  new URL("./transcript-disclosure.tsx", import.meta.url),
+  "utf8",
+);
+const processTimelineViewSource = readFileSync(
+  new URL("./process-timeline-view.tsx", import.meta.url),
+  "utf8",
+);
 const chatViewSource = readFileSync(
   new URL("./chat-view.tsx", import.meta.url),
   "utf8",
@@ -39,15 +51,7 @@ const footerMetadataSource =
   source.match(
     /\{\/\* Per-turn metadata[\s\S]*?\{\/\* Turn-level message actions/,
   )?.[0] ?? "";
-const stepToggleDurationCount =
-  source.match(/\{duration && `· \$\{duration\} `\}/g)?.length ?? 0;
-const stepsToggleIndex = source.indexOf(
-  "completedProcessExpanded && stepsToggle",
-);
-const defaultModeIndex = source.indexOf(
-  "Default mode: interleaved text + grouped tool summaries",
-);
-const verboseModeIndex = source.indexOf("Verbose mode: full tool cards");
+const processTimelineIndex = source.indexOf("<ProcessTimelineView");
 
 describe("ChatTurnComponent transcript controls", () => {
   test("keeps completed process collapsed, suppresses zero-second footer, and shows actions", () => {
@@ -55,54 +59,38 @@ describe("ChatTurnComponent transcript controls", () => {
       collapsesCompletedProcess:
         source.includes("const processSectionVisible =") &&
         source.includes("completedProcessExpanded"),
-      suppressesSubSecondDuration: source.includes(
-        'workTimeMs >= 1000 ? formatWorkDuration(workTimeMs) : ""',
-      ),
+      showsSubSecondDuration: source.includes(
+        'if (workTimeMs <= 0) return ""',
+      ) && source.includes("return formatWorkDuration(workTimeMs)"),
       usesActiveTurnDuration: source.includes(
         "computeTurnWorkTime(turn, { active: working })",
       ),
-      stepsToggleBeforeDefaultStream:
-        stepsToggleIndex !== -1 &&
-        defaultModeIndex !== -1 &&
-        stepsToggleIndex < defaultModeIndex,
-      expandedStepsRenderBeforeFinalText:
-        source.includes(
-          'const stepParts = processOrderedParts.filter((part) => part.kind !== "text")',
-        ) &&
-        source.includes(
-          'const textParts = processOrderedParts.filter((part) => part.kind === "text")',
-        ) &&
-        source.includes("{verboseOrderedParts.map((item) => {") &&
-        verboseModeIndex !== -1 &&
-        source.indexOf("{verboseOrderedParts.map((item) => {") >
-          verboseModeIndex,
-      stepsShareOneToggle:
-        source.match(/const stepsToggle =/g)?.length === 1 &&
-        !source.includes("Toggle to verbose view") &&
-        !source.includes("Collapse back to default view"),
+      usesInterleavedTimeline: source.includes("buildProcessTimeline"),
+      omitsStepsToggle: !source.includes("const stepsToggle ="),
       footerConditionOmitsDuration: footerMetadataSource.includes(
         "turn.assistantMessages.length > 0 && (turnModel || turnCostStr)",
       ),
       footerDoesNotRenderDuration: !footerMetadataSource.includes(
         "{duration && <span>{duration}</span>}",
       ),
-      stepsKeepDuration: stepToggleDurationCount === 1,
       usesAlwaysVisibleActions: responseActionsProps.trim() === "",
       usesHoverHiddenActions:
         responseActionsProps.includes("opacity-0") ||
         responseActionsProps.includes("group-hover/turn:opacity-100"),
+      rendersTimelineDirectlyUnderWorkedFor:
+        processTimelineIndex !== -1 &&
+        source.indexOf("<CompletedTurnProcessDisclosure") < processTimelineIndex,
     }).toEqual({
       collapsesCompletedProcess: true,
-      suppressesSubSecondDuration: true,
+      showsSubSecondDuration: true,
       usesActiveTurnDuration: true,
-      stepsToggleBeforeDefaultStream: true,
-      expandedStepsRenderBeforeFinalText: true,
-      stepsShareOneToggle: true,
+      usesInterleavedTimeline: true,
+      omitsStepsToggle: true,
       footerConditionOmitsDuration: true,
       footerDoesNotRenderDuration: true,
-      stepsKeepDuration: true,
       usesAlwaysVisibleActions: true,
       usesHoverHiddenActions: false,
+      rendersTimelineDirectlyUnderWorkedFor: true,
     });
   });
 
@@ -144,8 +132,8 @@ describe("ChatTurnComponent transcript controls", () => {
   test("renders the active turn working timer between user message and assistant content", () => {
     const userMessageIndex = source.indexOf("{/* User message */}");
     const workingStripIndex = source.indexOf("<WorkingTurnStatusStrip");
-    const assistantContentIndex = source.indexOf(
-      "{/* Tool calls + reasoning section */}",
+    const processTimelineSectionIndex = source.indexOf(
+      "Interleaved thought/tool process timeline",
     );
     const responseTextIndex = source.indexOf("{/* Streaming response");
 
@@ -159,11 +147,11 @@ describe("ChatTurnComponent transcript controls", () => {
         userMessageIndex !== -1 &&
         workingStripIndex !== -1 &&
         userMessageIndex < workingStripIndex,
-      placesStripBeforeAssistantContent:
+      placesStripBeforeProcessTimeline:
         workingStripIndex !== -1 &&
-        assistantContentIndex !== -1 &&
+        processTimelineSectionIndex !== -1 &&
         responseTextIndex !== -1 &&
-        workingStripIndex < assistantContentIndex &&
+        workingStripIndex < processTimelineSectionIndex &&
         workingStripIndex < responseTextIndex,
       removesOldWorkingShimmer: !source.includes("Working shimmer"),
       keepsCompletedDurationAffordance: source.includes('Worked for "'),
@@ -172,7 +160,7 @@ describe("ChatTurnComponent transcript controls", () => {
       usesWorkingForCopy: true,
       reusesTurnDuration: true,
       placesStripAfterUserMessage: true,
-      placesStripBeforeAssistantContent: true,
+      placesStripBeforeProcessTimeline: true,
       removesOldWorkingShimmer: true,
       keepsCompletedDurationAffordance: true,
     });
@@ -181,7 +169,7 @@ describe("ChatTurnComponent transcript controls", () => {
   test("folds completed process details under Worked for while keeping final answer visible", () => {
     const disclosureIndex = source.indexOf("<CompletedTurnProcessDisclosure");
     const processSectionIndex = source.indexOf(
-      "{/* Tool calls + reasoning section */}",
+      "Interleaved thought/tool process timeline",
     );
     const completedFinalResponseIndex = source.indexOf(
       "{/* Completed final response */}",
@@ -201,90 +189,87 @@ describe("ChatTurnComponent transcript controls", () => {
       processSectionCanBeCollapsed:
         source.includes("const processSectionVisible =") &&
         source.includes("completedProcessExpanded"),
-      stepsToggleHiddenWhenProcessCollapsed: source.includes(
-        "completedProcessExpanded && stepsToggle",
-      ),
       disclosureReplacesCompletedDurationRow:
         disclosureIndex !== -1 && !source.includes("<CompletedTurnDurationRow"),
       finalResponseOutsideProcess:
         processSectionIndex !== -1 &&
         completedFinalResponseIndex !== -1 &&
         processSectionIndex < completedFinalResponseIndex,
-      opensReasoningContentAfterExpandingWorkedFor: source.includes(
-        "<TranscriptReasoningBlock",
+      rendersThoughtRowsInTimeline: processTimelineViewSource.includes(
+        "<ThoughtRow",
       ),
     }).toEqual({
       definesProcessDisclosure: true,
       tracksCompletedProcessState: true,
       splitsFinalResponseFromProcess: true,
       processSectionCanBeCollapsed: true,
-      stepsToggleHiddenWhenProcessCollapsed: true,
       disclosureReplacesCompletedDurationRow: true,
       finalResponseOutsideProcess: true,
-      opensReasoningContentAfterExpandingWorkedFor: true,
+      rendersThoughtRowsInTimeline: true,
     });
   });
 
   test("keeps completed process disclosure reachable when duration is unavailable", () => {
     expect({
-      disclosureAllowsMissingDuration: source.includes(
+      disclosureAlwaysRendersWhenMounted: !source.includes(
         "if (!duration && !hasProcessDetails) return null",
       ),
       disclosureUsesWorkedFallback: source.includes(
         '{duration ? "Worked for " : "Worked"}',
       ),
-      renderConditionIncludesProcessDetails: source.includes(
-        "{!working && (duration || hasCompletedProcessDetails) && (",
+      renderConditionUsesWorkedForSummary: source.includes(
+        "!working && showWorkedForSummary",
+      ),
+      showsWorkedForOnAnyCompletedTurn: source.includes(
+        "return turn.assistantMessages.length > 0",
       ),
     }).toEqual({
-      disclosureAllowsMissingDuration: true,
+      disclosureAlwaysRendersWhenMounted: true,
       disclosureUsesWorkedFallback: true,
-      renderConditionIncludesProcessDetails: true,
+      renderConditionUsesWorkedForSummary: true,
+      showsWorkedForOnAnyCompletedTurn: true,
     });
   });
 
-  test("uses a subtle transcript-local reasoning indicator instead of the default Thought row", () => {
-    const chatTurnComponentSource =
-      source.match(
-        /export const ChatTurnComponent = memo\([\s\S]*?\n\)/,
-      )?.[0] ?? "";
-
+  test("uses transcript disclosure rows for thoughts and tools", () => {
     expect({
-      definesTranscriptReasoningBlock: source.includes(
-        "function TranscriptReasoningBlock",
+      definesThoughtRow: thoughtRowSource.includes("export const ThoughtRow"),
+      usesTranscriptDisclosureTrigger: transcriptDisclosureSource.includes(
+        "export const TranscriptDisclosureTrigger",
       ),
-      definesTranscriptReasoningLiveCue: source.includes(
-        "function TranscriptReasoningLiveCue",
-      ),
-      usesLeftRailReasoningStyle:
-        source.includes("border-l") &&
-        source.includes('aria-label="Reasoning details"'),
-      removesBareReasoningTrigger: !chatTurnComponentSource.includes(
-        "<ReasoningTrigger />",
-      ),
+      usesCollapsedThoughtChevron:
+        transcriptDisclosureSource.includes("ChevronRightIcon") &&
+        transcriptDisclosureSource.includes("ChevronDownIcon"),
+      removesBareReasoningTrigger: !source.includes("<ReasoningTrigger />"),
       keepsSharedReasoningTriggerUnchanged:
         sharedReasoningSource.includes("export const ReasoningTrigger") &&
         sharedReasoningSource.includes("Thought for a few seconds"),
       dropsVisibleThoughtCopyDependency: !source.includes(
         "Thought for a few seconds",
       ),
-      keepsActiveThinkingCue: source.includes("Thinking..."),
-      completedReasoningRendersDirectly: source.includes(
-        "<TranscriptReasoningBlock key={processItem.part.id} text={text} animated={isStreaming && i === item.items.length - 1} />",
+      keepsActiveThinkingCue: thoughtRowSource.includes("Thinking..."),
+      switchesToThoughtWhenComplete: thoughtRowSource.includes(
+        "<span>Thought</span>",
       ),
-      verboseReasoningRendersDirectly: source.includes(
-        "<TranscriptReasoningBlock text={reasoningText} animated={isReasoningStreaming} />",
+      toolsUseTranscriptDisclosure: chatToolCallSource.includes(
+        "<TranscriptDisclosure",
+      ),
+      toolsOmitDurationTrailing: !chatToolCallSource.includes("getToolDuration(part)"),
+      timelineRendersSeparateThoughtRows: processTimelineViewSource.includes(
+        'item.kind === "thought"',
       ),
     }).toEqual({
-      definesTranscriptReasoningBlock: true,
-      definesTranscriptReasoningLiveCue: true,
-      usesLeftRailReasoningStyle: true,
+      definesThoughtRow: true,
+      usesTranscriptDisclosureTrigger: true,
+      usesCollapsedThoughtChevron: true,
       removesBareReasoningTrigger: true,
       keepsSharedReasoningTriggerUnchanged: true,
       dropsVisibleThoughtCopyDependency: true,
       keepsActiveThinkingCue: true,
-      completedReasoningRendersDirectly: true,
-      verboseReasoningRendersDirectly: true,
+      switchesToThoughtWhenComplete: true,
+      toolsUseTranscriptDisclosure: true,
+      toolsOmitDurationTrailing: true,
+      timelineRendersSeparateThoughtRows: true,
     });
   });
 
@@ -329,6 +314,28 @@ describe("ChatTurnComponent transcript controls", () => {
       keepsIconStyleConsistent: true,
       handlesCompactionEvents: true,
       bridgesRuntimeCompactionEvents: true,
+    });
+  });
+
+  test("interleaves thoughts and tools inside the process timeline", () => {
+    expect({
+      noMergedTurnThinkingSection: !source.includes("function TurnThinkingSection"),
+      noReasoningProcessGroups: !source.includes('"reasoning-process"'),
+      usesPerRowExpansion: source.includes("expandedRowIds"),
+      endsThinkingWhenAssistantTextStarts: processTimelineViewSource.includes(
+        "isReasoningPartActivelyStreaming",
+      ),
+      keepsWorkedForOnReasoningOnlyTurns: source.includes("showWorkedForSummary"),
+      verboseUsesDisplayModeOnly: source.includes(
+        'const showVerboseTools = displayMode === "verbose"',
+      ),
+    }).toEqual({
+      noMergedTurnThinkingSection: true,
+      noReasoningProcessGroups: true,
+      usesPerRowExpansion: true,
+      endsThinkingWhenAssistantTextStarts: true,
+      keepsWorkedForOnReasoningOnlyTurns: true,
+      verboseUsesDisplayModeOnly: true,
     });
   });
 });

--- a/apps/desktop/src/renderer/components/chat/chat-turn.tsx
+++ b/apps/desktop/src/renderer/components/chat/chat-turn.tsx
@@ -5,12 +5,6 @@ import {
 	MessageContent,
 	MessageResponse,
 } from "@devo/ui/components/ai-elements/message"
-import {
-	Reasoning,
-	ReasoningContent,
-	ReasoningText,
-	useReasoning,
-} from "@devo/ui/components/ai-elements/reasoning"
 import { Shimmer } from "@devo/ui/components/ai-elements/shimmer"
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@devo/ui/components/dialog"
 
@@ -26,7 +20,7 @@ import {
 	Undo2Icon,
 	XIcon,
 } from "lucide-react"
-import { memo, type ReactNode, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react"
+import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react"
 import { useDisplayMode } from "../../hooks/use-agents"
 import type { SessionCompactionStatus } from "../../atoms/compaction"
 import type { ChatMessageEntry, ChatTurn as ChatTurnType } from "../../hooks/use-session-chat"
@@ -46,13 +40,13 @@ import type {
 	TextPart,
 	ToolPart,
 } from "../../lib/types"
-import { ChatToolCall, getToolInfo, getToolSubtitle } from "./chat-tool-call"
+import { buildProcessTimeline } from "./process-timeline"
+import { ProcessTimelineView } from "./process-timeline-view"
 import {
 	CompactionStatusDivider,
 	isCompactionStatusText,
 } from "./compaction-status-divider"
 import { PermissionItem } from "./chat-permission"
-import { getToolCategory, type ToolCategory } from "./tool-card"
 
 // ============================================================
 // Utility functions
@@ -398,40 +392,6 @@ function getError(assistantMessages: ChatMessageEntry[]): string | undefined {
 	return undefined
 }
 
-function LazyReasoningContent({
-	children,
-	animated,
-}: {
-	children: ReactNode
-	animated?: boolean
-}) {
-	const { isOpen, isStreaming } = useReasoning()
-	if (!isOpen && !isStreaming) return null
-	return <ReasoningContent animated={animated}>{children}</ReasoningContent>
-}
-
-function TranscriptReasoningLiveCue() {
-	return (
-		<div
-			aria-label="Reasoning details"
-			className="border-l border-border/70 pl-3 text-sm text-muted-foreground/70"
-		>
-			<Shimmer duration={1}>Thinking...</Shimmer>
-		</div>
-	)
-}
-
-function TranscriptReasoningBlock({ text, animated }: { text: string; animated?: boolean }) {
-	return (
-		<div
-			aria-label="Reasoning details"
-			className="border-l border-border/70 pl-3 text-sm text-muted-foreground/80"
-		>
-			<ReasoningText animated={animated}>{text}</ReasoningText>
-		</div>
-	)
-}
-
 // ============================================================
 // Turn comparison for memo
 // ============================================================
@@ -489,212 +449,6 @@ function areTurnsEqual(a: ChatTurnType, b: ChatTurnType): boolean {
 }
 
 // ============================================================
-// Default mode helpers — tool grouping
-// ============================================================
-
-/**
- * Groups consecutive tool parts of the same category into summary items.
- * Interleaves text and reasoning between groups to preserve natural order.
- *
- * Example output:
- *   text: "Let me look at the code..."
- *   tool-group: { category: "explore", tools: [read, grep, glob] }
- *   text: "I found the issue, let me fix it..."
- *   tool-group: { category: "edit", tools: [edit, write] }
- *   tool-group: { category: "run", tools: [bash] }
- */
-type StreamItem =
-	| { kind: "text"; id: string; text: string; metadata?: Record<string, unknown> }
-	| { kind: "reasoning-process"; items: (RenderablePart & { kind: "reasoning" | "tool" })[] }
-	| { kind: "tool-group"; category: ToolCategory; tools: ToolPart[] }
-
-function groupPartsForStream(ordered: RenderablePart[]): StreamItem[] {
-	const items: StreamItem[] = []
-	let currentGroup: { category: ToolCategory; tools: ToolPart[] } | null = null
-	let currentProcessGroup: (RenderablePart & { kind: "reasoning" | "tool" })[] = []
-
-	const hasReasoning = ordered.some((p) => p.kind === "reasoning")
-
-	const flushGroup = () => {
-		if (currentGroup) {
-			items.push({ kind: "tool-group", ...currentGroup })
-			currentGroup = null
-		}
-	}
-
-	const flushProcessGroup = () => {
-		if (currentProcessGroup.length > 0) {
-			items.push({ kind: "reasoning-process", items: currentProcessGroup })
-			currentProcessGroup = []
-		}
-	}
-
-	for (const part of ordered) {
-		if (hasReasoning && (part.kind === "reasoning" || part.kind === "tool")) {
-			currentProcessGroup.push(part)
-		} else if (!hasReasoning && part.kind === "tool") {
-			const category = getToolCategory(part.part.tool)
-			if (currentGroup && currentGroup.category === category) {
-				currentGroup.tools.push(part.part)
-			} else {
-				flushGroup()
-				currentGroup = { category, tools: [part.part] }
-			}
-		} else {
-			flushGroup()
-			flushProcessGroup()
-			if (part.kind === "text") {
-				items.push({ kind: "text", id: part.id, text: part.text, metadata: part.metadata })
-			}
-		}
-	}
-	flushGroup()
-	flushProcessGroup()
-	return items
-}
-
-/**
- * Generates a human-readable summary for a group of tools in the same category.
- * Returns text like "Read 3 files", "Edited foo.tsx, bar.tsx", "Ran 2 commands".
- */
-function describeToolGroup(
-	category: ToolCategory,
-	tools: ToolPart[],
-	projectRoot?: string | null,
-): string {
-	const count = tools.length
-
-	// For small groups, list specific targets
-	if (count <= 3) {
-		const details = tools
-			.map((t) => getToolSubtitle(t, { projectRoot }))
-			.filter(Boolean)
-			.map((s) => {
-				// Shorten file paths to just the filename
-				const parts = s!.split("/")
-				return parts.length > 1 ? parts[parts.length - 1] : s
-			})
-
-		if (details.length > 0) {
-			switch (category) {
-				case "explore":
-					return count === 1 ? `Read ${details[0]}` : `Read ${details.join(", ")}`
-				case "edit":
-					return count === 1 ? `Edited ${details[0]}` : `Edited ${details.join(", ")}`
-				case "run":
-					return count === 1
-						? `Ran ${details[0]}`
-						: `Ran ${count} commands`
-				case "delegate":
-					return count === 1 ? `Delegated: ${details[0]}` : `Delegated ${count} tasks`
-				case "fetch":
-					return count === 1 ? `Fetched ${details[0]}` : `Fetched ${count} URLs`
-				case "ask":
-					return "Asked a question"
-				case "plan":
-					return "Updated plan"
-				default:
-					return `Ran ${details.join(", ")}`
-			}
-		}
-	}
-
-	// For larger groups, use count-based summaries
-	switch (category) {
-		case "explore":
-			return `Explored ${count} files`
-		case "edit":
-			return `Edited ${count} files`
-		case "run":
-			return `Ran ${count} commands`
-		case "delegate":
-			return `Delegated ${count} tasks`
-		case "fetch":
-			return `Fetched ${count} URLs`
-		case "ask":
-			return `Asked ${count} questions`
-		case "plan":
-			return "Updated plan"
-		default:
-			return `Ran ${count} tools`
-	}
-}
-
-/**
- * Returns true if any tool in the group is still running/pending.
- */
-function isGroupRunning(tools: ToolPart[]): boolean {
-	return tools.some((t) => t.state.status === "running" || t.state.status === "pending")
-}
-
-/**
- * Returns true if any tool in the group has an error.
- */
-function isGroupError(tools: ToolPart[]): boolean {
-	return tools.some((t) => t.state.status === "error")
-}
-
-/** Renders a single tool group summary as a collapsible disclosure row */
-const ToolGroupSummary = memo(function ToolGroupSummary({
-	category,
-	tools,
-	isActiveTurn,
-	projectRoot,
-}: {
-	category: ToolCategory
-	tools: ToolPart[]
-	isActiveTurn: boolean
-	projectRoot?: string | null
-}) {
-	const [expanded, setExpanded] = useState(false)
-	const description = describeToolGroup(category, tools, projectRoot)
-	const running = isGroupRunning(tools)
-	const hasError = isGroupError(tools)
-	const { icon: GroupIcon } = getToolInfo(tools[0].tool)
-
-	return (
-		<div className="space-y-2">
-			<button
-				type="button"
-				onClick={() => setExpanded((v) => !v)}
-				className="flex w-full items-center gap-2 rounded-md bg-muted/20 px-3 py-1.5 text-[12px] transition-colors hover:bg-muted/40"
-			>
-				<GroupIcon
-					className={`size-3.5 shrink-0 ${
-						hasError
-							? "text-red-400"
-							: running
-								? "animate-pulse text-muted-foreground"
-								: "text-muted-foreground/50"
-					}`}
-				/>
-				<span className={`flex-1 text-left ${hasError ? "text-red-400" : "text-muted-foreground/70"}`}>
-					{description}
-				</span>
-				{running && !expanded && (
-					<Loader2Icon className="size-3 animate-spin text-muted-foreground/30" />
-				)}
-				<ChevronDownIcon
-					className={`size-3 shrink-0 text-muted-foreground/30 transition-transform ${expanded ? "" : "-rotate-90"}`}
-				/>
-			</button>
-			{expanded && (
-				<div className="space-y-2 pl-3">
-					{tools.map((tool) => (
-						<ChatToolCall
-							key={tool.id}
-							part={tool}
-							isActiveTurn={isActiveTurn}
-							projectRoot={projectRoot}
-						/>
-					))}
-				</div>
-			)}
-		</div>
-	)
-})
-
-// ============================================================
 // ChatTurnComponent
 // ============================================================
 
@@ -728,9 +482,6 @@ interface ChatTurnProps {
 	onForkFromTurn?: () => Promise<void>
 	/** Delete a specific part from a message (for error recovery) */
 	onDeletePart?: (sessionId: string, messageId: string, partId: string) => Promise<void>
-	/** Controlled verbose step expansion state, used by virtualized transcripts. */
-	stepsExpanded?: boolean
-	onStepsExpandedChange?: (turnId: string, expanded: boolean) => void
 }
 
 function pendingPermissionFingerprint(permission: PendingPermission | undefined): string {
@@ -780,8 +531,6 @@ function CompletedTurnProcessDisclosure({
 	hasProcessDetails: boolean
 	onToggle: () => void
 }) {
-	if (!duration && !hasProcessDetails) return null
-
 	const content = (
 		<>
 			<span>
@@ -799,7 +548,7 @@ function CompletedTurnProcessDisclosure({
 
 	if (!hasProcessDetails) {
 		return (
-			<div className="flex w-full items-center gap-1.5 border-b border-border/70 pb-2 text-sm tabular-nums text-muted-foreground/70">
+			<div className="flex w-fit max-w-full items-center gap-1.5 border-b border-border/70 pb-1 text-sm tabular-nums text-muted-foreground/70">
 				{content}
 			</div>
 		)
@@ -810,7 +559,7 @@ function CompletedTurnProcessDisclosure({
 			type="button"
 			onClick={onToggle}
 			aria-expanded={expanded}
-			className="flex w-full items-center gap-1.5 border-b border-border/70 pb-2 text-left text-sm tabular-nums text-muted-foreground/70 transition-colors hover:text-foreground"
+			className="flex w-fit max-w-full items-center gap-1.5 border-b border-border/70 pb-1 text-left text-sm tabular-nums text-muted-foreground/70 transition-colors hover:text-foreground"
 		>
 			{content}
 		</button>
@@ -827,10 +576,8 @@ function CompletedTurnProcessDisclosure({
  *   individual tools. Response text is always visible.
  *
  * Display mode preference (default/verbose) modifies behavior:
- * - default: interleaved text + grouped tool summaries as inline chips.
- *   Tool groups batch consecutive same-category calls (e.g., "Explored 3 files",
- *   "Edited foo.tsx, bar.tsx"). A "Show N steps" toggle reveals full tool cards.
- * - verbose: all turns show all tools expanded with full content (tool cards)
+ * - default: interleaved text + grouped tool summaries as collapsible rows.
+ * - verbose: all turns show all tools expanded with full content.
  */
 export const ChatTurnComponent = memo(
 	function ChatTurnComponent({
@@ -846,30 +593,17 @@ export const ChatTurnComponent = memo(
 		onRevertToMessage,
 		onForkFromTurn,
 		onDeletePart,
-		stepsExpanded: controlledStepsExpanded,
-		onStepsExpandedChange,
 	}: ChatTurnProps) {
-		const [uncontrolledStepsExpanded, setUncontrolledStepsExpanded] = useState(false)
 		const [completedProcessExpanded, setCompletedProcessExpanded] = useState(false)
+		const [expandedRowIds, setExpandedRowIds] = useState<Set<string>>(() => new Set())
 		const [copied, setCopied] = useState(false)
 		const displayMode = useDisplayMode()
 		const toolPathRoot = agent?.worktreePath ?? agent?.directory ?? agent?.projectDirectory
 		const turnRef = useRef<HTMLDivElement>(null)
-		const stepsExpanded = controlledStepsExpanded ?? uncontrolledStepsExpanded
 		useEffect(() => {
 			setCompletedProcessExpanded(false)
+			setExpandedRowIds(new Set())
 		}, [turn.id])
-
-		const setStepsExpanded = useCallback(
-			(expanded: boolean) => {
-				if (onStepsExpandedChange) {
-					onStepsExpandedChange(turn.id, expanded)
-				} else {
-					setUncontrolledStepsExpanded(expanded)
-				}
-			},
-			[onStepsExpandedChange, turn.id],
-		)
 
 		const isSynthetic = useMemo(() => isSyntheticMessage(turn.userMessage), [turn.userMessage])
 		const userText = useMemo(() => getUserText(turn.userMessage), [turn.userMessage])
@@ -916,21 +650,37 @@ export const ChatTurnComponent = memo(
 		}, [turn.assistantMessages])
 
 		const working = isLast && isWorking
+
 		// User requirement: queue state belongs in the composer status stack;
 		// this transcript must not infer queued state from an empty assistant response.
 		const processOrderedParts = working ? orderedParts : completedProcessParts
+		const processTimelineItems = useMemo(
+			() => buildProcessTimeline(processOrderedParts),
+			[processOrderedParts],
+		)
 		const processToolParts = useMemo(
 			() => processOrderedParts.flatMap((part) => (part.kind === "tool" ? [part.part] : [])),
 			[processOrderedParts],
 		)
 		const hasSteps = processToolParts.length > 0
-		const hasCompletedProcessDetails = !working && completedProcessParts.length > 0
-		const processSectionVisible = working || (hasCompletedProcessDetails && completedProcessExpanded)
+		const hasWorkToDisclose = !working && processTimelineItems.length > 0
+		const hasCompletedProcessDetails = hasWorkToDisclose
+		const workTimeMs = useMemo(
+			() => computeTurnWorkTime(turn, { active: working }),
+			[turn, working],
+		)
+		const showWorkedForSummary = useMemo(() => {
+			if (working) return false
+			return turn.assistantMessages.length > 0
+		}, [turn.assistantMessages.length, working])
+		const processSectionVisible =
+			(working && processTimelineItems.length > 0) ||
+			(!working && hasCompletedProcessDetails && completedProcessExpanded)
 
 		const duration = useMemo(() => {
-			const workTimeMs = computeTurnWorkTime(turn, { active: working })
-			return workTimeMs >= 1000 ? formatWorkDuration(workTimeMs) : ""
-		}, [turn, working])
+			if (workTimeMs <= 0) return ""
+			return formatWorkDuration(workTimeMs)
+		}, [workTimeMs])
 		const turnCostStr = useMemo(() => {
 			const cost = computeTurnCost(turn)
 			return cost > 0 ? formatCost(cost) : ""
@@ -947,32 +697,19 @@ export const ChatTurnComponent = memo(
 
 		// Determine if tools should be shown individually (active turn behavior)
 		const isActiveTurn = working
-		const isVerbose = displayMode === "verbose"
+		const showVerboseTools = displayMode === "verbose"
 
-		// In default mode, we render a "stream" of grouped tool summaries + text.
-		// In verbose mode, we render full tool cards.
-		// stepsExpanded forces verbose rendering on a per-turn basis.
-		const showVerboseTools = isVerbose || stepsExpanded
-
-		const verboseOrderedParts = useMemo(() => {
-			if (!stepsExpanded || isVerbose || working) return processOrderedParts
-			const stepParts = processOrderedParts.filter((part) => part.kind !== "text")
-			const textParts = processOrderedParts.filter((part) => part.kind === "text")
-			return [...stepParts, ...textParts]
-		}, [isVerbose, processOrderedParts, stepsExpanded, working])
-
-		// Grouped stream items for the default (non-verbose) rendering path
-		const defaultOrderedParts = processOrderedParts
-
-		const streamItems = useMemo(
-			() => (showVerboseTools ? [] : groupPartsForStream(defaultOrderedParts)),
-			[showVerboseTools, defaultOrderedParts],
-		)
-
-		// In default mode, process text is rendered inline within the stream.
-		// In verbose mode, process text is inline within the expanded ordered parts.
 		const textAlreadyInline =
 			processSectionVisible && processOrderedParts.some((p) => p.kind === "text")
+
+		const handleToggleTimelineRow = useCallback((rowId: string, open: boolean) => {
+			setExpandedRowIds((previous) => {
+				const next = new Set(previous)
+				if (open) next.add(rowId)
+				else next.delete(rowId)
+				return next
+			})
+		}, [])
 
 		const handleCopyResponse = useCallback(async () => {
 			if (!responseText) return
@@ -1021,26 +758,6 @@ export const ChatTurnComponent = memo(
 			[onDeletePart],
 		)
 
-		const stepsToggle =
-			!isVerbose && !isActiveTurn && hasSteps ? (
-				<button
-					type="button"
-					onClick={() => setStepsExpanded(!stepsExpanded)}
-					className="flex items-center gap-1.5 text-[11px] text-muted-foreground/40 transition-colors hover:text-foreground"
-				>
-					<ChevronDownIcon className={showVerboseTools ? "size-3" : "size-3 -rotate-90"} />
-					<span>
-						{showVerboseTools ? "Hide" : "Show"} {processToolParts.length}{" "}
-						{processToolParts.length === 1 ? "step" : "steps"}
-					</span>
-					<span>
-						{turnModel && `· ${turnModel} `}
-						{duration && `· ${duration} `}
-						{turnCostStr && `· ${turnCostStr}`}
-					</span>
-				</button>
-			) : null
-
 		return (
 			<div ref={turnRef} className="group/turn space-y-4">
 				{/* User message */}
@@ -1064,7 +781,8 @@ export const ChatTurnComponent = memo(
 				)}
 
 				{working && <WorkingTurnStatusStrip turn={turn} />}
-				{!working && (duration || hasCompletedProcessDetails) && (
+
+				{!working && showWorkedForSummary && (
 					<CompletedTurnProcessDisclosure
 						duration={duration}
 						expanded={completedProcessExpanded}
@@ -1073,145 +791,31 @@ export const ChatTurnComponent = memo(
 					/>
 				)}
 
-				{/* Tool calls + reasoning section */}
+				{/* Interleaved thought/tool process timeline */}
 				{processSectionVisible && (
 					<div className="space-y-2">
-						{!working && completedProcessExpanded && stepsToggle}
+						<ProcessTimelineView
+							defaultExpandAll={showVerboseTools}
+							expandedRowIds={showVerboseTools ? undefined : expandedRowIds}
+							isActiveTurn={isActiveTurn}
+							items={processTimelineItems}
+							onDeleteToolPart={onDeletePart ? handleDeleteToolPart : undefined}
+							onToggleRow={showVerboseTools ? undefined : handleToggleTimelineRow}
+							orderedParts={processOrderedParts}
+							projectRoot={toolPathRoot}
+							renderText={(item) => (
+								<div className="py-0.5">
+									<ResearchArtifactBlock item={item} />
+								</div>
+							)}
+							turnHasError={!!errorText}
+							working={working}
+						/>
 
-						{/* ── Default mode: interleaved text + grouped tool summaries ── */}
-						{!showVerboseTools && (
-							<div className="space-y-3">
-								{streamItems.map((item, idx) => {
-									if (item.kind === "text") {
-										return (
-											<div key={item.id} className="py-0.5">
-												<ResearchArtifactBlock item={item} />
-											</div>
-										)
-									}
-									if (item.kind === "reasoning-process") {
-										const firstReasoning = item.items.find((p) => p.kind === "reasoning") as { kind: "reasoning", part: ReasoningPart } | undefined
-										const lastItem = item.items[item.items.length - 1]
-
-										const durationSec = firstReasoning?.part.time.end
-											? Math.ceil((firstReasoning.part.time.end - firstReasoning.part.time.start) / 1000)
-											: undefined
-										const isStreaming = working && (!lastItem || (lastItem.kind === "reasoning" && !lastItem.part.time.end))
-
-										return (
-											<Reasoning
-												key={`process-${idx}`}
-												isStreaming={isStreaming}
-												duration={durationSec}
-												defaultOpen={isStreaming ? undefined : completedProcessExpanded}
-											>
-												{isStreaming && <TranscriptReasoningLiveCue />}
-												<LazyReasoningContent animated={isStreaming}>
-													<div className="flex flex-col gap-4">
-														{item.items.map((processItem, i) => {
-															if (processItem.kind === "reasoning") {
-																const text = processItem.part.text.replace("[REDACTED]", "").trim()
-																if (!text) return null
-																return (
-																	<TranscriptReasoningBlock key={processItem.part.id} text={text} animated={isStreaming && i === item.items.length - 1} />
-																)
-															}
-															if (processItem.kind === "tool") {
-																return (
-																	<div key={processItem.part.id} className="pl-3">
-																		<ChatToolCall
-																			part={processItem.part}
-																			isActiveTurn={isActiveTurn}
-																			projectRoot={toolPathRoot}
-																		/>
-																	</div>
-																)
-															}
-															return null
-														})}
-													</div>
-												</LazyReasoningContent>
-											</Reasoning>
-										)
-									}
-									if (item.kind === "tool-group") {
-										if (item.tools.length === 1) {
-											return (
-												<ChatToolCall
-													key={item.tools[0].id}
-													part={item.tools[0]}
-													isActiveTurn={isActiveTurn}
-													projectRoot={toolPathRoot}
-												/>
-											)
-										}
-										return (
-											<ToolGroupSummary
-												key={`group-${idx}-${item.tools[0].id}`}
-												category={item.category}
-												tools={item.tools}
-												isActiveTurn={isActiveTurn}
-												projectRoot={toolPathRoot}
-											/>
-										)
-									}
-									return null
-								})}
-								{/* Live status while the agent is still working */}
-								{working && hasSteps && (
-									<div className="flex items-center gap-2 px-1 text-xs text-muted-foreground">
-										<Loader2Icon className="size-3 animate-spin text-muted-foreground/30" />
-										<Shimmer className="text-[11px]">{statusText}</Shimmer>
-									</div>
-								)}
-							</div>
-						)}
-
-
-						{/* ── Verbose mode: full tool cards ──────────────────────── */}
-
-						{showVerboseTools && (
-							<div className="space-y-3.5">
-								{verboseOrderedParts.map((item) => {
-									if (item.kind === "tool") {
-										return (
-											<ChatToolCall
-												key={item.part.id}
-												part={item.part}
-												isActiveTurn={isActiveTurn}
-												turnHasError={!!errorText}
-												onDelete={onDeletePart ? handleDeleteToolPart : undefined}
-												projectRoot={toolPathRoot}
-											/>
-										)
-									}
-									if (item.kind === "reasoning") {
-										const reasoningText = item.part.text.replace("[REDACTED]", "").trim()
-										if (!reasoningText) return null
-										const durationSec = item.part.time.end
-											? Math.ceil((item.part.time.end - item.part.time.start) / 1000)
-											: undefined
-										const isReasoningStreaming = !item.part.time.end && working
-										return (
-											<Reasoning
-												key={item.part.id}
-												isStreaming={isReasoningStreaming}
-												duration={durationSec}
-												defaultOpen={isReasoningStreaming ? undefined : completedProcessExpanded}
-											>
-												{isReasoningStreaming && <TranscriptReasoningLiveCue />}
-												<LazyReasoningContent animated={isReasoningStreaming}>
-													<TranscriptReasoningBlock text={reasoningText} animated={isReasoningStreaming} />
-												</LazyReasoningContent>
-											</Reasoning>
-										)
-									}
-									return (
-										<div key={item.id} className="py-0.5">
-											<ResearchArtifactBlock item={item} />
-										</div>
-									)
-								})}
+						{working && hasSteps && (
+							<div className="flex items-center gap-2 px-1 text-xs text-muted-foreground">
+								<Loader2Icon className="size-3 animate-spin text-muted-foreground/30" />
+								<Shimmer className="text-[11px]">{statusText}</Shimmer>
 							</div>
 						)}
 					</div>
@@ -1313,7 +917,6 @@ export const ChatTurnComponent = memo(
 		if (prev.agent?.worktreePath !== next.agent?.worktreePath) return false
 		if (prev.isConnected !== next.isConnected) return false
 		if (prev.compactionStatus !== next.compactionStatus) return false
-		if (prev.stepsExpanded !== next.stepsExpanded) return false
 		if (
 			pendingPermissionFingerprint(prev.pendingPermission) !==
 			pendingPermissionFingerprint(next.pendingPermission)

--- a/apps/desktop/src/renderer/components/chat/chat-view.tsx
+++ b/apps/desktop/src/renderer/components/chat/chat-view.tsx
@@ -21,7 +21,6 @@ import { useVirtualizer } from "@tanstack/react-virtual"
 import { useAtomValue, useSetAtom } from "jotai"
 import {
 	ArrowUpToLineIcon,
-	ChevronUpIcon,
 	GitForkIcon,
 	GoalIcon,
 	ListTodoIcon,
@@ -35,6 +34,7 @@ import {
 import {
 	type CSSProperties,
 	type ReactNode,
+	type RefObject,
 	useCallback,
 	useEffect,
 	useImperativeHandle,
@@ -53,7 +53,17 @@ import {
 	effectiveQuestionFamily,
 } from "../../atoms/derived/session-requests"
 import { appStore } from "../../atoms/store"
+import { sessionScrollTopFamily, settingsOverlayOpenAtom } from "../../atoms/ui"
 import { useDraftActions, useDraftSnapshot } from "../../hooks/use-draft"
+import {
+	freezeSessionScroll,
+	getFrozenSessionScroll,
+	getPendingRestoreScrollTop,
+	getRestoredScrollTop,
+	markScrollRestored,
+	setPendingRestoreScrollTop,
+	trackSettingsOverlayOpen,
+} from "../../lib/settings-scroll-freeze"
 import type {
 	ConfigData,
 	ModelRef,
@@ -91,7 +101,6 @@ import {
 	ComposerStatusStack,
 	type ComposerGoal,
 	type ComposerGoalStatus,
-	type ComposerQueueItem,
 } from "./composer-status-stack"
 import { ContextItems } from "./context-items"
 import type { MentionOption } from "./mention-popover"
@@ -111,9 +120,6 @@ import { SlashCommandPopover, type SlashCommandPopoverHandle } from "./slash-com
 
 type ComposerTrigger = "goal" | "plan"
 type ComposerGoalAction = "edit" | "pause" | "resume" | "clear"
-type ComposerPromptPart =
-	| { type: "text"; text: string }
-	| { type: "file"; mime: string; filename?: string; url: string }
 
 function objectRecord(value: unknown): Record<string, unknown> | null {
 	return value && typeof value === "object" ? (value as Record<string, unknown>) : null
@@ -137,32 +143,6 @@ function normalizeComposerGoal(value: unknown): ComposerGoal | null {
 		timeUsedSeconds: (record.timeUsedSeconds ?? record.time_used_seconds) as ComposerGoal["timeUsedSeconds"],
 		observedAtMs: Date.now(),
 	}
-}
-
-function promptPartsFromTextAndFiles(text: string, files?: FileAttachment[]): ComposerPromptPart[] {
-	const parts: ComposerPromptPart[] = [{ type: "text", text }]
-	for (const file of files ?? []) {
-		parts.push({
-			type: "file",
-			mime: file.mediaType ?? "application/octet-stream",
-			filename: file.filename,
-			url: file.url,
-		})
-	}
-	return parts
-}
-
-function chatTurnUserText(turn: ChatTurn): string {
-	return turn.userMessage.parts
-		.filter((part) => part.type === "text")
-		.map((part) => part.text)
-		.join("\n")
-		.trim()
-}
-
-function chatTurnUserCreatedAt(turn: ChatTurn): number {
-	const created = turn.userMessage.info.time?.created
-	return typeof created === "number" && Number.isFinite(created) ? created : 0
 }
 
 /**
@@ -242,6 +222,7 @@ function ComposerTriggerChip({
  */
 function ScrollOnLoad({ loading, sessionId }: { loading: boolean; sessionId: string }) {
 	const { scrollToBottom } = useStickToBottomContext()
+	const settingsOverlayOpen = useAtomValue(settingsOverlayOpenAtom)
 	const prevLoadingRef = useRef(loading)
 	const prevSessionRef = useRef(sessionId)
 
@@ -251,12 +232,84 @@ function ScrollOnLoad({ loading, sessionId }: { loading: boolean; sessionId: str
 		prevLoadingRef.current = loading
 		prevSessionRef.current = sessionId
 
+		if (settingsOverlayOpen || getPendingRestoreScrollTop() != null) return
+
 		// Instant scroll when: loading just finished, or session changed while not loading
 		// (e.g. messages were already cached in the Jotai store)
 		if ((wasLoading && !loading) || (sessionChanged && !loading)) {
 			scrollToBottom("instant")
 		}
-	}, [loading, sessionId, scrollToBottom])
+	}, [loading, sessionId, scrollToBottom, settingsOverlayOpen])
+
+	return null
+}
+
+/**
+ * Tracks scroll position while the session is visible so it can be restored
+ * after returning from Settings (StickToBottom may reset on layout changes).
+ */
+function ScrollPositionTracker({ sessionId }: { sessionId: string }) {
+	const { scrollRef } = useStickToBottomContext()
+	const setScrollTop = useSetAtom(sessionScrollTopFamily(sessionId))
+	const settingsOverlayOpen = useAtomValue(settingsOverlayOpenAtom)
+
+	useEffect(() => {
+		const element = scrollRef.current
+		if (!element) return
+
+		const onScroll = () => {
+			if (settingsOverlayOpen) return
+			setScrollTop(element.scrollTop)
+		}
+
+		element.addEventListener("scroll", onScroll, { passive: true })
+		return () => element.removeEventListener("scroll", onScroll)
+	}, [scrollRef, sessionId, setScrollTop, settingsOverlayOpen])
+
+	return null
+}
+
+/**
+ * Handles scroll freeze/restore around the Settings overlay with StickToBottom context.
+ */
+function SettingsScrollGuard({ sessionId }: { sessionId: string }) {
+	const { scrollRef, stopScroll } = useStickToBottomContext()
+	const settingsOverlayOpen = useAtomValue(settingsOverlayOpenAtom)
+
+	useLayoutEffect(() => {
+		const wasOverlayOpen = trackSettingsOverlayOpen(settingsOverlayOpen)
+
+		if (!wasOverlayOpen && settingsOverlayOpen) {
+			const top = scrollRef.current?.scrollTop ?? getFrozenSessionScroll(sessionId) ?? null
+			if (top != null) {
+				freezeSessionScroll(sessionId, top)
+			}
+			stopScroll()
+			return
+		}
+
+		if (!wasOverlayOpen || settingsOverlayOpen) return
+
+		const frozen = getFrozenSessionScroll(sessionId)
+		if (frozen == null) return
+
+		setPendingRestoreScrollTop(frozen)
+		markScrollRestored(frozen)
+
+		const applyRestore = () => {
+			if (!scrollRef.current) return
+			scrollRef.current.scrollTop = frozen
+			stopScroll()
+		}
+		applyRestore()
+		requestAnimationFrame(() => {
+			applyRestore()
+			requestAnimationFrame(() => {
+				applyRestore()
+				setPendingRestoreScrollTop(null)
+			})
+		})
+	}, [sessionId, settingsOverlayOpen, scrollRef, stopScroll])
 
 	return null
 }
@@ -265,8 +318,10 @@ interface ScrollHandle {
 	scrollToBottom: (behavior?: "instant" | "smooth") => void
 	/** Returns the current scrollHeight of the scroll container */
 	getScrollHeight: () => number
-	/** Smoothly scrolls the container to a specific scrollTop value */
-	scrollToPosition: (top: number) => void
+	/** Returns the current scrollTop of the scroll container */
+	getScrollTop: () => number
+	/** Scrolls the container to a specific scrollTop value */
+	scrollToPosition: (top: number, behavior?: ScrollBehavior) => void
 }
 
 /**
@@ -286,14 +341,87 @@ function ScrollBridge({ scrollRef }: { scrollRef: React.RefObject<ScrollHandle |
 			getScrollHeight: () => {
 				return ctx.scrollRef.current?.scrollHeight ?? 0
 			},
-			scrollToPosition: (top: number) => {
-				ctx.scrollRef.current?.scrollTo({ top, behavior: "smooth" })
+			getScrollTop: () => {
+				return ctx.scrollRef.current?.scrollTop ?? 0
+			},
+			scrollToPosition: (top: number, behavior: ScrollBehavior = "smooth") => {
+				ctx.scrollRef.current?.scrollTo({ top, behavior })
 			},
 		}),
 		[ctx],
 	)
 	return null
 }
+
+/** Prefetch older messages when the user scrolls toward the top of the thread. */
+function LoadEarlierOnScroll({
+	hasEarlierMessages,
+	loadingEarlier,
+	onLoadEarlier,
+	scrollRef,
+}: {
+	hasEarlierMessages: boolean
+	loadingEarlier: boolean
+	onLoadEarlier?: () => Promise<void>
+	scrollRef: RefObject<ScrollHandle | null>
+}) {
+	const { scrollRef: containerRef, stopScroll } = useStickToBottomContext()
+	const sentinelRef = useRef<HTMLDivElement>(null)
+	const loadingRef = useRef(loadingEarlier)
+	loadingRef.current = loadingEarlier
+	const hasEarlierRef = useRef(hasEarlierMessages)
+	hasEarlierRef.current = hasEarlierMessages
+
+	const loadWithScrollPreserve = useCallback(async () => {
+		if (!onLoadEarlier || loadingRef.current || !hasEarlierRef.current) return
+		stopScroll()
+		const beforeHeight = scrollRef.current?.getScrollHeight() ?? 0
+		const beforeTop = scrollRef.current?.getScrollTop() ?? 0
+		await onLoadEarlier()
+		requestAnimationFrame(() => {
+			stopScroll()
+			const afterHeight = scrollRef.current?.getScrollHeight() ?? 0
+			scrollRef.current?.scrollToPosition(afterHeight - beforeHeight + beforeTop, "auto")
+			requestAnimationFrame(() => stopScroll())
+		})
+	}, [onLoadEarlier, scrollRef, stopScroll])
+
+	useEffect(() => {
+		const root = containerRef.current
+		const target = sentinelRef.current
+		if (!root || !target || !hasEarlierMessages || !onLoadEarlier) return
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (!entries[0]?.isIntersecting) return
+				void loadWithScrollPreserve()
+			},
+			{ root, rootMargin: "160px 0px 0px 0px", threshold: 0 },
+		)
+		observer.observe(target)
+		return () => observer.disconnect()
+	}, [containerRef, hasEarlierMessages, loadWithScrollPreserve, onLoadEarlier])
+
+	if (!hasEarlierMessages && !loadingEarlier) return null
+
+	return (
+		<div
+			ref={sentinelRef}
+			className="flex min-h-8 justify-center py-2"
+			aria-busy={loadingEarlier}
+			aria-live="polite"
+		>
+			{loadingEarlier ? (
+				<Loader2Icon className="size-4 animate-spin text-muted-foreground/70" />
+			) : (
+				<span className="sr-only">Scroll up to load earlier messages</span>
+			)}
+		</div>
+	)
+}
+
+const TURN_ESTIMATE_MIN = 120
+const TURN_ESTIMATE_MAX = 12_000
 
 function estimateTurnSize(turn: ChatTurn): number {
 	let partCount = turn.userMessage.parts.length
@@ -308,7 +436,38 @@ function estimateTurnSize(turn: ChatTurn): number {
 			}, 0)
 		)
 	}, 0)
-	return Math.min(960, 180 + turn.assistantMessages.length * 72 + partCount * 36 + assistantTextLength / 12)
+	const toolCount = turn.assistantMessages.reduce((total, message) => {
+		return total + message.parts.filter((part) => part.type === "tool").length
+	}, 0)
+	const reasoningCount = turn.assistantMessages.reduce((total, message) => {
+		return total + message.parts.filter((part) => part.type === "reasoning").length
+	}, 0)
+	const estimated =
+		180 +
+		turn.assistantMessages.length * 72 +
+		partCount * 36 +
+		toolCount * 96 +
+		reasoningCount * 48 +
+		assistantTextLength / 10
+	return Math.max(TURN_ESTIMATE_MIN, Math.min(TURN_ESTIMATE_MAX, estimated))
+}
+
+function turnListRevision(turns: ChatTurn[]): string {
+	return turns
+		.map((turn) => {
+			let partCount = turn.userMessage.parts.length
+			let textLength = 0
+			for (const message of turn.assistantMessages) {
+				partCount += message.parts.length
+				for (const part of message.parts) {
+					if (part.type === "text" || part.type === "reasoning") {
+						textLength += part.text.length
+					}
+				}
+			}
+			return `${turn.id}:${partCount}:${textLength}`
+		})
+		.join("|")
 }
 
 interface VirtualizedTurnListProps {
@@ -318,13 +477,18 @@ interface VirtualizedTurnListProps {
 
 function VirtualizedTurnList({ turns, renderTurn }: VirtualizedTurnListProps) {
 	const { scrollRef } = useStickToBottomContext()
+	const turnsRevision = useMemo(() => turnListRevision(turns), [turns])
 	const virtualizer = useVirtualizer({
 		count: turns.length,
 		getScrollElement: () => scrollRef.current,
 		getItemKey: (index) => turns[index]?.id ?? index,
 		estimateSize: (index) => estimateTurnSize(turns[index]),
-		overscan: 5,
+		overscan: 8,
 	})
+
+	useLayoutEffect(() => {
+		virtualizer.measure()
+	}, [turnsRevision, virtualizer])
 
 	return (
 		<div
@@ -648,13 +812,28 @@ export function ChatView({
 	reviewPanelOpen,
 }: ChatViewProps) {
 	const isWorking = agent.status === "running"
+	const settingsOverlayOpen = useAtomValue(settingsOverlayOpenAtom)
+
+	const conversationTargetScrollTop = useCallback(
+		(defaultTarget: number) => {
+			const restored = getRestoredScrollTop()
+			if (restored != null) return restored
+			const pendingRestore = getPendingRestoreScrollTop()
+			if (pendingRestore != null) return pendingRestore
+			if (settingsOverlayOpen) {
+				const frozen = getFrozenSessionScroll(agent.sessionId)
+				if (frozen != null) return frozen
+			}
+			return defaultTarget
+		},
+		[agent.sessionId, settingsOverlayOpen],
+	)
 
 	// Ref to imperatively scroll the conversation to bottom from outside the
 	// <Conversation> tree (e.g. after sending a message or answering a question).
 	const scrollRef = useRef<ScrollHandle | null>(null)
 	const composerRef = useRef<HTMLDivElement | null>(null)
 	const [composerInset, setComposerInset] = useState(0)
-	const [expandedStepTurnIds, setExpandedStepTurnIds] = useState<Set<string>>(() => new Set())
 
 	// Session-level error and setup phase from the session atom
 	const sessionEntry = useAtomValue(sessionFamily(agent.sessionId))
@@ -707,9 +886,6 @@ export function ChatView({
 	const effectivePermission = useAtomValue(effectivePermissionFamily(agent.sessionId))
 	const removePermission = useSetAtom(removePermissionAtom)
 
-	useEffect(() => {
-		setExpandedStepTurnIds(new Set())
-	}, [agent.sessionId])
 	// Format the session-level error for display. Only shown when the last
 	// turn doesn't already carry an assistant-level error (the server emits
 	// both session.error and message.updated for the same failure, so showing
@@ -800,18 +976,6 @@ export function ChatView({
 		? "mx-auto w-full min-w-0"
 		: "mx-auto w-full min-w-0 max-w-3xl"
 
-	const handleStepsExpandedChange = useCallback((turnId: string, expanded: boolean) => {
-		setExpandedStepTurnIds((current) => {
-			const next = new Set(current)
-			if (expanded) {
-				next.add(turnId)
-			} else {
-				next.delete(turnId)
-			}
-			return next
-		})
-	}, [])
-
 	const renderTurn = useCallback(
 		(turn: ChatTurn, index: number) => (
 			<ChatTurnComponent
@@ -823,8 +987,6 @@ export function ChatView({
 				pendingPermission={index === turns.length - 1 ? effectivePermission : undefined}
 				isConnected={isConnected}
 				compactionStatus={compactionStatus}
-				stepsExpanded={expandedStepTurnIds.has(turn.id)}
-				onStepsExpandedChange={handleStepsExpandedChange}
 				onApprovePermission={handleApprovePermission}
 				onDenyPermission={handleDenyPermission}
 				onRevertToMessage={onRevertToMessage}
@@ -843,10 +1005,8 @@ export function ChatView({
 			agent,
 			effectivePermission,
 			compactionStatus,
-			expandedStepTurnIds,
 			handleApprovePermission,
 			handleDenyPermission,
-			handleStepsExpandedChange,
 			isConnected,
 			isWorking,
 			onDeletePart,
@@ -867,32 +1027,26 @@ export function ChatView({
 		>
 			{/* Chat messages -- constrained width for readability */}
 			<div className="relative min-h-0 min-w-0 flex-1">
-				<Conversation key={agent.sessionId} className="h-full">
+				<Conversation
+					key={agent.sessionId}
+					className="h-full"
+					targetScrollTop={conversationTargetScrollTop}
+				>
 					<ScrollOnLoad loading={loading} sessionId={agent.sessionId} />
+					<SettingsScrollGuard sessionId={agent.sessionId} />
+					<ScrollPositionTracker sessionId={agent.sessionId} />
 					<ScrollBridge scrollRef={scrollRef} />
 					<ConversationContent
 						scrollClassName="scrollbar-comfort"
 						className="gap-10 px-6 pt-2 pb-[calc(var(--chat-composer-inset)+1rem)] sm:px-8 sm:pt-6 sm:pb-[calc(var(--chat-composer-inset)+1.5rem)] lg:px-10"
 					>
 						<div className={cn(contentWidthClass, "space-y-10")}>
-							{/* Load earlier messages button */}
-							{hasEarlierMessages && (
-								<div className="flex justify-center pb-4">
-									<button
-										type="button"
-										onClick={onLoadEarlier}
-										disabled={loadingEarlier}
-										className="flex items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
-									>
-										{loadingEarlier ? (
-											<Loader2Icon className="size-3 animate-spin" />
-										) : (
-											<ChevronUpIcon className="size-3" />
-										)}
-										{loadingEarlier ? "Loading..." : "Load earlier messages"}
-									</button>
-								</div>
-							)}
+							<LoadEarlierOnScroll
+								hasEarlierMessages={hasEarlierMessages}
+								loadingEarlier={loadingEarlier}
+								onLoadEarlier={onLoadEarlier}
+								scrollRef={scrollRef}
+							/>
 
 							{loading ? (
 								<div className="flex items-center justify-center py-8">
@@ -1028,7 +1182,6 @@ function ChatInputSection({
 	const [activeTrigger, setActiveTrigger] = useState<ComposerTrigger | null>(null)
 	const [activeGoal, setActiveGoal] = useState<ComposerGoal | null>(null)
 	const [goalAction, setGoalAction] = useState<ComposerGoalAction | null>(null)
-	const [queueItems, setQueueItems] = useState<ComposerQueueItem[]>([])
 
 	// User requirement: the /goal footer chip is only an input trigger;
 	// the composer-adjacent status row reflects the real session goal state.
@@ -1036,21 +1189,7 @@ function ChatInputSection({
 		setActiveTrigger(null)
 		setActiveGoal(null)
 		setGoalAction(null)
-		setQueueItems([])
 	}, [agent.sessionId])
-
-	useEffect(() => {
-		setQueueItems((current) =>
-			current.filter((item) => {
-				if (item.status !== "queued") return true
-				const createdAt = item.createdAtMs ?? 0
-				return !turns.some(
-					(turn) =>
-						chatTurnUserText(turn) === item.text && chatTurnUserCreatedAt(turn) >= createdAt - 1_000,
-				)
-			}),
-		)
-	}, [turns])
 
 	const loadGoalStatus = useCallback(async (): Promise<ComposerGoal | null> => {
 		if (!agent.directory) return null
@@ -1365,108 +1504,6 @@ function ChatInputSection({
 			setGoalAction(null)
 		}
 	}, [agent.directory, agent.sessionId, goalAction])
-
-	const handleSteerQueueItem = useCallback(
-		async (item: ComposerQueueItem) => {
-			if (!agent.directory || !item.queuedInputId || !item.activeTurnId) return
-			const client = getProjectClient(agent.directory)
-			if (!client?.turn?.steerQueued) return
-			setQueueItems((current) =>
-				current.map((entry) => (entry.id === item.id ? { ...entry, status: "steering" } : entry)),
-			)
-			try {
-				await client.turn.steerQueued({
-					sessionID: agent.sessionId,
-					expectedTurnID: item.activeTurnId,
-					queuedInputID: item.queuedInputId,
-				})
-				setQueueItems((current) => current.filter((entry) => entry.id !== item.id))
-			} catch (err) {
-				log.error("turn.queue.steer failed", { sessionId: agent.sessionId }, err)
-				setQueueItems((current) =>
-					current.map((entry) =>
-						entry.id === item.id
-							? { ...entry, status: "error", error: err instanceof Error ? err.message : "Steer failed" }
-							: entry,
-					),
-				)
-			}
-		},
-		[agent.directory, agent.sessionId],
-	)
-
-	const handleRemoveQueueItem = useCallback(
-		async (item: ComposerQueueItem) => {
-			if (!agent.directory || !item.queuedInputId) {
-				setQueueItems((current) => current.filter((entry) => entry.id !== item.id))
-				return
-			}
-			const client = getProjectClient(agent.directory)
-			if (!client?.turn?.removeQueued) return
-			setQueueItems((current) =>
-				current.map((entry) => (entry.id === item.id ? { ...entry, status: "removing" } : entry)),
-			)
-			try {
-				await client.turn.removeQueued({
-					sessionID: agent.sessionId,
-					queuedInputID: item.queuedInputId,
-				})
-				setQueueItems((current) => current.filter((entry) => entry.id !== item.id))
-			} catch (err) {
-				log.error("turn.queue.remove failed", { sessionId: agent.sessionId }, err)
-				setQueueItems((current) =>
-					current.map((entry) =>
-						entry.id === item.id
-							? { ...entry, status: "error", error: err instanceof Error ? err.message : "Remove failed" }
-							: entry,
-					),
-				)
-			}
-		},
-		[agent.directory, agent.sessionId],
-	)
-
-	const handleEditQueueItem = useCallback(
-		async (item: ComposerQueueItem) => {
-			if ((item.fileCount ?? 0) > 0) return
-			if (item.queuedInputId) {
-				if (!agent.directory) return
-				const client = getProjectClient(agent.directory)
-				if (!client?.turn?.removeQueued) return
-				setQueueItems((current) =>
-					current.map((entry) =>
-						entry.id === item.id ? { ...entry, status: "removing" } : entry,
-					),
-				)
-				try {
-					await client.turn.removeQueued({
-						sessionID: agent.sessionId,
-						queuedInputID: item.queuedInputId,
-					})
-				} catch (err) {
-					log.error("turn.queue.edit remove failed", { sessionId: agent.sessionId }, err)
-					setQueueItems((current) =>
-						current.map((entry) =>
-							entry.id === item.id
-								? {
-										...entry,
-										status: "error",
-										error: err instanceof Error ? err.message : "Edit failed",
-									}
-								: entry,
-						),
-					)
-					return
-				}
-				setQueueItems((current) => current.filter((entry) => entry.id !== item.id))
-			} else {
-				setQueueItems((current) => current.filter((entry) => entry.id !== item.id))
-			}
-			slashCommandRef.current?.setText(item.text)
-			focusComposer()
-		},
-		[agent.directory, agent.sessionId, focusComposer],
-	)
 
 	const handleSlashCommand = useCallback(
 		async (text: string): Promise<boolean> => {

--- a/apps/desktop/src/renderer/components/chat/message-response-style.test.ts
+++ b/apps/desktop/src/renderer/components/chat/message-response-style.test.ts
@@ -32,19 +32,21 @@ describe("MessageResponse markdown surfaces", () => {
 				"transcript Markdown headings should look like bold body text",
 			),
 			headingComponents: messageSource.includes("const transcriptMarkdownComponents"),
-			headingClassWins: messageSource.includes(
-				"className,\n\t\t\t\t\"my-2 border-0 pb-0 text-sm font-semibold leading-6 text-foreground\"",
-			),
 			headingStyle: messageSource.includes(
 				"my-2 border-0 pb-0 text-sm font-semibold leading-6 text-foreground",
 			),
-			markdownRulesStillRender: !messageSource.includes("hr: TranscriptMarkdownRule"),
+			markdownRulesHidden: messageSource.includes("hr: TranscriptMarkdownRule"),
+			markdownRulesRequirementComment: messageSource.includes(
+				"Horizontal rules (--- / ***) are hidden",
+			),
+			markdownRuleReturnsNull: messageSource.includes("function TranscriptMarkdownRule"),
 		}).toEqual({
 			requirementComment: true,
 			headingComponents: true,
-			headingClassWins: true,
 			headingStyle: true,
-			markdownRulesStillRender: true,
+			markdownRulesHidden: true,
+			markdownRulesRequirementComment: true,
+			markdownRuleReturnsNull: true,
 		})
 	})
 

--- a/apps/desktop/src/renderer/components/chat/process-timeline-view.tsx
+++ b/apps/desktop/src/renderer/components/chat/process-timeline-view.tsx
@@ -1,0 +1,175 @@
+import { Loader2Icon } from "lucide-react"
+import { memo, useCallback, type ReactNode } from "react"
+import type { ReasoningPart, ToolPart } from "../../lib/types"
+import { ChatToolCall, describeToolGroup, getToolInfo, isGroupRunning } from "./chat-tool-call"
+import {
+	buildProcessTimeline,
+	isReasoningPartActivelyStreaming,
+	processTimelineRowId,
+	type ProcessTimelineInput,
+	type ProcessTimelineItem,
+} from "./process-timeline"
+import { ThoughtRow } from "./thought-row"
+import type { ToolCategory } from "./tool-card"
+import {
+	TranscriptDisclosure,
+	TranscriptDisclosureContent,
+	TranscriptDisclosureTrigger,
+} from "./transcript-disclosure"
+
+export { buildProcessTimeline, isReasoningPartActivelyStreaming }
+
+const TranscriptToolGroupRow = memo(function TranscriptToolGroupRow({
+	category,
+	tools,
+	isActiveTurn,
+	projectRoot,
+	defaultOpen = false,
+	open,
+	onOpenChange,
+}: {
+	category: ToolCategory
+	tools: ToolPart[]
+	isActiveTurn: boolean
+	projectRoot?: string | null
+	defaultOpen?: boolean
+	open?: boolean
+	onOpenChange?: (open: boolean) => void
+}) {
+	const description = describeToolGroup(category, tools, projectRoot)
+	const running = isGroupRunning(tools)
+	const { icon: GroupIcon } = getToolInfo(tools[0].tool)
+
+	return (
+		<TranscriptDisclosure
+			className="mb-0"
+			defaultOpen={defaultOpen}
+			open={open}
+			onOpenChange={onOpenChange}
+		>
+			<TranscriptDisclosureTrigger
+				leading={
+					<GroupIcon
+						className={`size-4 shrink-0 ${
+							running
+								? "animate-pulse text-muted-foreground"
+								: "text-muted-foreground/50"
+						}`}
+					/>
+				}
+				label={<span>{description}</span>}
+				trailing={
+					running ? (
+						<Loader2Icon className="size-3 animate-spin text-muted-foreground/30" />
+					) : undefined
+				}
+			/>
+			<TranscriptDisclosureContent className="space-y-2">
+				{tools.map((tool) => (
+					<ChatToolCall
+						key={tool.id}
+						isActiveTurn={isActiveTurn}
+						part={tool}
+						projectRoot={projectRoot}
+					/>
+				))}
+			</TranscriptDisclosureContent>
+		</TranscriptDisclosure>
+	)
+})
+
+export interface ProcessTimelineViewProps {
+	items: ProcessTimelineItem[]
+	orderedParts: ProcessTimelineInput[]
+	working: boolean
+	isActiveTurn: boolean
+	projectRoot?: string | null
+	defaultExpandAll?: boolean
+	expandedRowIds?: Set<string>
+	onToggleRow?: (rowId: string, open: boolean) => void
+	renderText: (item: Extract<ProcessTimelineItem, { kind: "text" }>) => ReactNode
+	turnHasError?: boolean
+	onDeleteToolPart?: (part: ToolPart) => Promise<void>
+}
+
+export const ProcessTimelineView = memo(function ProcessTimelineView({
+	items,
+	orderedParts,
+	working,
+	isActiveTurn,
+	projectRoot,
+	defaultExpandAll = false,
+	expandedRowIds,
+	onToggleRow,
+	renderText,
+	turnHasError,
+	onDeleteToolPart,
+}: ProcessTimelineViewProps) {
+	const resolveOpen = useCallback(
+		(rowId: string, fallbackDefault: boolean) => {
+			if (defaultExpandAll) return true
+			if (expandedRowIds?.has(rowId)) return true
+			return fallbackDefault
+		},
+		[defaultExpandAll, expandedRowIds],
+	)
+
+	return (
+		<div className="space-y-1">
+			{items.map((item, index) => {
+				const rowId = processTimelineRowId(item, index)
+
+				if (item.kind === "text") {
+					return <div key={rowId}>{renderText(item)}</div>
+				}
+
+				if (item.kind === "thought") {
+					const isStreaming = working && isReasoningPartActivelyStreaming(orderedParts, item.part)
+					return (
+						<ThoughtRow
+							key={rowId}
+							defaultOpen={defaultExpandAll}
+							isStreaming={isStreaming}
+							onOpenChange={
+								onToggleRow ? (open) => onToggleRow(rowId, open) : undefined
+							}
+							open={expandedRowIds ? expandedRowIds.has(rowId) : undefined}
+							part={item.part}
+						/>
+					)
+				}
+
+				if (item.kind === "tool") {
+					return (
+						<ChatToolCall
+							key={rowId}
+							defaultOpen={defaultExpandAll}
+							isActiveTurn={isActiveTurn}
+							onDelete={onDeleteToolPart}
+							open={expandedRowIds ? expandedRowIds.has(rowId) : undefined}
+							onOpenChange={
+								onToggleRow ? (open) => onToggleRow(rowId, open) : undefined
+							}
+							part={item.part}
+							projectRoot={projectRoot}
+							turnHasError={turnHasError}
+						/>
+					)
+				}
+
+				return (
+					<TranscriptToolGroupRow
+						key={rowId}
+						category={item.category}
+						defaultOpen={resolveOpen(rowId, defaultExpandAll)}
+						isActiveTurn={isActiveTurn}
+						onOpenChange={onToggleRow ? (open) => onToggleRow(rowId, open) : undefined}
+						open={expandedRowIds ? expandedRowIds.has(rowId) : undefined}
+						projectRoot={projectRoot}
+						tools={item.tools}
+					/>
+				)
+			})}
+		</div>
+	)
+})

--- a/apps/desktop/src/renderer/components/chat/process-timeline.test.ts
+++ b/apps/desktop/src/renderer/components/chat/process-timeline.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import type { ReasoningPart, ToolPart } from "../../lib/types"
+import { buildProcessTimeline, isReasoningPartActivelyStreaming } from "./process-timeline"
+
+function reasoning(id: string): { kind: "reasoning"; part: ReasoningPart } {
+	return {
+		kind: "reasoning",
+		part: {
+			id,
+			type: "reasoning",
+			text: `thought-${id}`,
+			time: { start: 1, end: 2 },
+		} as ReasoningPart,
+	}
+}
+
+function tool(id: string, toolName = "read"): { kind: "tool"; part: ToolPart } {
+	return {
+		kind: "tool",
+		part: {
+			id,
+			tool: toolName,
+			type: "tool",
+			state: { status: "completed", time: { start: 1, end: 2 }, output: "" },
+		} as ToolPart,
+	}
+}
+
+describe("buildProcessTimeline", () => {
+	test("emits separate thought rows for each reasoning part", () => {
+		expect(buildProcessTimeline([reasoning("r1"), tool("t1"), reasoning("r2"), tool("t2")])).toEqual([
+			{ kind: "thought", part: reasoning("r1").part },
+			{ kind: "tool", part: tool("t1").part },
+			{ kind: "thought", part: reasoning("r2").part },
+			{ kind: "tool", part: tool("t2").part },
+		])
+	})
+
+	test("groups consecutive same-category tools without reasoning between them", () => {
+		expect(buildProcessTimeline([reasoning("r1"), tool("t1"), tool("t2")])).toEqual([
+			{ kind: "thought", part: reasoning("r1").part },
+			{
+				category: "explore",
+				kind: "tool-group",
+				tools: [tool("t1").part, tool("t2").part],
+			},
+		])
+	})
+})
+
+function reasoningWithoutEnd(id: string): { kind: "reasoning"; part: ReasoningPart } {
+	return {
+		kind: "reasoning",
+		part: {
+			id,
+			type: "reasoning",
+			text: `thought-${id}`,
+			time: { start: 1 },
+		} as ReasoningPart,
+	}
+}
+
+describe("isReasoningPartActivelyStreaming", () => {
+	test("stops streaming once a tool follows the reasoning block", () => {
+		const parts = [reasoningWithoutEnd("r1"), tool("t1"), reasoningWithoutEnd("r2")]
+
+		expect({
+			first: isReasoningPartActivelyStreaming(parts, reasoningWithoutEnd("r1").part),
+			second: isReasoningPartActivelyStreaming(parts, reasoningWithoutEnd("r2").part),
+		}).toEqual({
+			first: false,
+			second: true,
+		})
+	})
+
+	test("stops streaming once assistant text follows the reasoning block", () => {
+		const parts = [
+			reasoningWithoutEnd("r1"),
+			{ id: "txt", kind: "text" as const, text: "Here is the answer." },
+		]
+
+		expect(isReasoningPartActivelyStreaming(parts, reasoningWithoutEnd("r1").part)).toBe(false)
+	})
+})

--- a/apps/desktop/src/renderer/components/chat/process-timeline.ts
+++ b/apps/desktop/src/renderer/components/chat/process-timeline.ts
@@ -1,0 +1,100 @@
+import type { ReasoningPart, ToolPart } from "../../lib/types"
+import { getToolCategory, type ToolCategory } from "./tool-card"
+
+export type ProcessTimelineInput =
+	| { kind: "tool"; part: ToolPart }
+	| { kind: "text"; id: string; text: string; metadata?: Record<string, unknown> }
+	| { kind: "reasoning"; part: ReasoningPart }
+
+export type ProcessTimelineItem =
+	| { kind: "text"; id: string; text: string; metadata?: Record<string, unknown> }
+	| { kind: "thought"; part: ReasoningPart }
+	| { kind: "tool"; part: ToolPart }
+	| { kind: "tool-group"; category: ToolCategory; tools: ToolPart[] }
+
+/**
+ * Builds an interleaved process timeline from ordered assistant parts.
+ * Each reasoning part becomes its own thought row; tools are grouped only when
+ * consecutive and share the same category.
+ */
+export function buildProcessTimeline(ordered: ProcessTimelineInput[]): ProcessTimelineItem[] {
+	const items: ProcessTimelineItem[] = []
+	let currentGroup: { category: ToolCategory; tools: ToolPart[] } | null = null
+
+	const flushGroup = () => {
+		if (!currentGroup) return
+		if (currentGroup.tools.length === 1) {
+			items.push({ kind: "tool", part: currentGroup.tools[0] })
+		} else {
+			items.push({
+				category: currentGroup.category,
+				kind: "tool-group",
+				tools: currentGroup.tools,
+			})
+		}
+		currentGroup = null
+	}
+
+	for (const part of ordered) {
+		if (part.kind === "reasoning") {
+			flushGroup()
+			items.push({ kind: "thought", part: part.part })
+		} else if (part.kind === "tool") {
+			const category = getToolCategory(part.part.tool)
+			if (currentGroup && currentGroup.category === category) {
+				currentGroup.tools.push(part.part)
+			} else {
+				flushGroup()
+				currentGroup = { category, tools: [part.part] }
+			}
+		} else if (part.kind === "text") {
+			flushGroup()
+			items.push({
+				id: part.id,
+				kind: "text",
+				metadata: part.metadata,
+				text: part.text,
+			})
+		}
+	}
+
+	flushGroup()
+	return items
+}
+
+export function isReasoningPartActivelyStreaming(
+	orderedParts: ProcessTimelineInput[],
+	reasoningPart: ReasoningPart,
+): boolean {
+	if (reasoningPart.time.end) return false
+
+	const partIndex = orderedParts.findIndex(
+		(part) => part.kind === "reasoning" && part.part.id === reasoningPart.id,
+	)
+	if (partIndex === -1) return false
+
+	for (let i = partIndex + 1; i < orderedParts.length; i++) {
+		const part = orderedParts[i]
+		if (part.kind === "text" && part.text.replace("[REDACTED]", "").trim()) {
+			return false
+		}
+		if (part.kind === "tool" || part.kind === "reasoning") {
+			return false
+		}
+	}
+
+	return true
+}
+
+export function processTimelineRowId(item: ProcessTimelineItem, index: number): string {
+	switch (item.kind) {
+		case "text":
+			return item.id
+		case "thought":
+			return item.part.id
+		case "tool":
+			return item.part.id
+		case "tool-group":
+			return `group-${index}-${item.tools[0]?.id ?? index}`
+	}
+}

--- a/apps/desktop/src/renderer/components/chat/sub-agent-card.tsx
+++ b/apps/desktop/src/renderer/components/chat/sub-agent-card.tsx
@@ -293,44 +293,30 @@ export const SubAgentCard = memo(function SubAgentCard({ part: propPart }: SubAg
 	const showSummary = collapseState === "summary" || collapseState === "expanded"
 	const showExpanded = collapseState === "expanded"
 
+	const ChevronIcon = collapseState !== "closed" ? ChevronDownIcon : ChevronRightIcon
+
 	return (
-		<div
-			className={cn(
-				"overflow-hidden rounded-lg border",
-				isRunning
-					? "border-violet-500/30 bg-violet-500/[0.02]"
-					: isError
-						? "border-red-500/30 bg-red-500/[0.02]"
-						: "border-border bg-card/50",
-			)}
-		>
-			{/* Header — always visible */}
-			<div className="flex items-center gap-2.5 px-3.5 py-2.5">
-				{/* Clickable area toggles collapse */}
+		<div className="not-prose space-y-0">
+			<div className="flex w-fit max-w-full items-center gap-2">
 				<button
 					type="button"
 					onClick={handleHeaderToggle}
-					className="flex min-w-0 flex-1 items-center gap-2.5 text-left transition-colors hover:opacity-80"
+					className="flex w-fit max-w-full items-center gap-1.5 text-left text-sm text-muted-foreground/70 transition-colors hover:text-foreground"
 				>
-					<ChevronRightIcon
-						className={cn(
-							"size-3 shrink-0 text-muted-foreground/50 transition-transform",
-							collapseState !== "closed" && "rotate-90",
-						)}
-					/>
 					<ZapIcon
 						className={cn(
-							"size-3.5 shrink-0",
-							isRunning ? "text-violet-400 animate-pulse" : "text-muted-foreground",
+							"size-4 shrink-0",
+							isRunning ? "animate-pulse text-violet-400" : "text-muted-foreground/50",
 						)}
 					/>
-					<span className="text-xs font-medium text-foreground/80">Agent</span>
-					<span className="shrink-0 text-xs text-muted-foreground/60">({agentType})</span>
-					{/* Truncated task title in header */}
-					<span className="min-w-0 truncate text-xs text-muted-foreground/50">{taskTitle}</span>
+					<span className="min-w-0 truncate">
+						<span className={isError ? "text-red-400" : undefined}>Agent</span>
+						<span className="text-muted-foreground/60"> ({agentType})</span>
+						<span className="text-muted-foreground/60"> · {taskTitle}</span>
+					</span>
+					<ChevronIcon aria-hidden="true" className="size-4 shrink-0 transition-transform" />
 				</button>
-				{/* Right side: status / duration / open button — outside trigger */}
-				<div className="flex shrink-0 items-center gap-2.5">
+				<div className="flex shrink-0 items-center gap-2 pb-1">
 				{/* Waiting indicator: shown when sub-agent has a pending permission or question */}
 				{childIsWaiting && childHasPendingPermission && (
 					<span className="flex items-center gap-1 text-[11px] font-medium text-amber-400">
@@ -370,28 +356,28 @@ export const SubAgentCard = memo(function SubAgentCard({ part: propPart }: SubAg
 				</div>
 			</div>
 
-			{/* ── Summary state: single-line teaser ────────────────── */}
-			{showSummary && !showExpanded && firstLine && (
-				<div className="flex items-baseline gap-2 border-t border-border/30 px-3.5 py-2">
-					<p className="min-w-0 flex-1 truncate text-[11px] leading-relaxed text-muted-foreground/70 italic">
-						{firstLine}
-					</p>
-					{hasMore && (
-						<button
-							type="button"
-							onClick={handleShowMore}
-							className="inline-flex shrink-0 items-center gap-0.5 text-[10px] font-medium text-primary/70 transition-colors hover:text-primary"
-						>
-							Show more
-							<ChevronDownIcon className="size-3" />
-						</button>
+			{showSummary && (
+				<div className="mt-1.5 mb-4 overflow-hidden rounded-md border border-border/50">
+					{!showExpanded && firstLine && (
+						<div className="flex items-baseline gap-2 px-3.5 py-2">
+							<p className="min-w-0 flex-1 truncate text-[11px] leading-relaxed text-muted-foreground/70 italic">
+								{firstLine}
+							</p>
+							{hasMore && (
+								<button
+									type="button"
+									onClick={handleShowMore}
+									className="inline-flex shrink-0 items-center gap-0.5 text-[10px] font-medium text-primary/70 transition-colors hover:text-primary"
+								>
+									Show more
+									<ChevronDownIcon className="size-3" />
+								</button>
+							)}
+						</div>
 					)}
-				</div>
-			)}
 
-			{/* ── Expanded state: full content ────────────────────── */}
-			{showExpanded && (
-				<>
+					{showExpanded && (
+						<>
 					{/* Live activity: latest tool calls */}
 					{latestToolParts.length > 0 && (
 						<div className="border-t border-border/30 px-3.5 py-2">
@@ -476,15 +462,16 @@ export const SubAgentCard = memo(function SubAgentCard({ part: propPart }: SubAg
 							</span>
 						</div>
 					)}
-				</>
-			)}
+						</>
+					)}
 
-			{/* Error shown in summary state too (not just expanded) */}
-			{showSummary && !showExpanded && isError && (
-				<div className="border-t border-red-500/20 bg-red-500/5 px-3.5 py-2">
-					<span className="text-[11px] text-red-400">
-						{part.state.status === "error" ? part.state.error : "Sub-agent failed"}
-					</span>
+					{!showExpanded && isError && (
+						<div className="border-t border-red-500/20 bg-red-500/5 px-3.5 py-2">
+							<span className="text-[11px] text-red-400">
+								{part.state.status === "error" ? part.state.error : "Sub-agent failed"}
+							</span>
+						</div>
+					)}
 				</div>
 			)}
 		</div>

--- a/apps/desktop/src/renderer/components/chat/thought-row.tsx
+++ b/apps/desktop/src/renderer/components/chat/thought-row.tsx
@@ -1,0 +1,51 @@
+import { ReasoningText } from "@devo/ui/components/ai-elements/reasoning"
+import { Shimmer } from "@devo/ui/components/ai-elements/shimmer"
+import { memo } from "react"
+import type { ReasoningPart } from "../../lib/types"
+import {
+	TranscriptDisclosure,
+	TranscriptDisclosureContent,
+	TranscriptDisclosureTrigger,
+} from "./transcript-disclosure"
+
+export const ThoughtRow = memo(function ThoughtRow({
+	part,
+	isStreaming,
+	open,
+	defaultOpen = false,
+	onOpenChange,
+}: {
+	part: ReasoningPart
+	isStreaming: boolean
+	open?: boolean
+	defaultOpen?: boolean
+	onOpenChange?: (open: boolean) => void
+}) {
+	const text = part.text.replace("[REDACTED]", "").trim()
+	if (!text) return null
+
+	return (
+		<TranscriptDisclosure
+			className="mb-0"
+			defaultOpen={defaultOpen}
+			open={open}
+			onOpenChange={onOpenChange}
+		>
+			<TranscriptDisclosureTrigger
+				aria-label="Reasoning details"
+				label={
+					isStreaming ? (
+						<Shimmer duration={1}>Thinking...</Shimmer>
+					) : (
+						<span>Thought</span>
+					)
+				}
+			/>
+			<TranscriptDisclosureContent>
+				<div aria-label="Reasoning details" className="text-sm text-muted-foreground/80">
+					<ReasoningText animated={isStreaming}>{text}</ReasoningText>
+				</div>
+			</TranscriptDisclosureContent>
+		</TranscriptDisclosure>
+	)
+})

--- a/apps/desktop/src/renderer/components/chat/transcript-disclosure.tsx
+++ b/apps/desktop/src/renderer/components/chat/transcript-disclosure.tsx
@@ -1,0 +1,152 @@
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@devo/ui/components/collapsible"
+import { cn } from "@devo/ui/lib/utils"
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react"
+import {
+	createContext,
+	memo,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+	type ReactNode,
+} from "react"
+
+interface TranscriptDisclosureContextValue {
+	isOpen: boolean
+	expandable: boolean
+}
+
+const TranscriptDisclosureContext = createContext<TranscriptDisclosureContextValue | null>(null)
+
+function useTranscriptDisclosure() {
+	const context = useContext(TranscriptDisclosureContext)
+	if (!context) {
+		throw new Error("Transcript disclosure components must be used within TranscriptDisclosure")
+	}
+	return context
+}
+
+export interface TranscriptDisclosureProps {
+	open?: boolean
+	defaultOpen?: boolean
+	onOpenChange?: (open: boolean) => void
+	expandable?: boolean
+	forceOpen?: boolean
+	className?: string
+	children: ReactNode
+}
+
+export const TranscriptDisclosure = memo(function TranscriptDisclosure({
+	open: openProp,
+	defaultOpen = false,
+	onOpenChange,
+	expandable = true,
+	forceOpen = false,
+	className,
+	children,
+}: TranscriptDisclosureProps) {
+	const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen)
+	const isControlled = openProp !== undefined
+	const isOpen = forceOpen || (isControlled ? openProp : uncontrolledOpen)
+
+	const handleOpenChange = useCallback(
+		(nextOpen: boolean) => {
+			if (forceOpen) return
+			if (!isControlled) setUncontrolledOpen(nextOpen)
+			onOpenChange?.(nextOpen)
+		},
+		[forceOpen, isControlled, onOpenChange],
+	)
+
+	const contextValue = useMemo(
+		() => ({ expandable: expandable && !forceOpen, isOpen }),
+		[expandable, forceOpen, isOpen],
+	)
+
+	if (!expandable) {
+		return (
+			<TranscriptDisclosureContext.Provider value={contextValue}>
+				<div className={cn("not-prose", className)}>{children}</div>
+			</TranscriptDisclosureContext.Provider>
+		)
+	}
+
+	return (
+		<TranscriptDisclosureContext.Provider value={contextValue}>
+			<Collapsible
+				className={cn("not-prose", className)}
+				open={isOpen}
+				onOpenChange={handleOpenChange}
+			>
+				{children}
+			</Collapsible>
+		</TranscriptDisclosureContext.Provider>
+	)
+})
+
+const triggerClassName =
+	"flex w-fit max-w-full items-center gap-1.5 border-0 bg-transparent p-0 m-0 text-sm text-muted-foreground/70 transition-colors hover:text-foreground"
+
+export interface TranscriptDisclosureTriggerProps {
+	label: ReactNode
+	leading?: ReactNode
+	trailing?: ReactNode
+	className?: string
+	"aria-label"?: string
+}
+
+export const TranscriptDisclosureTrigger = memo(function TranscriptDisclosureTrigger({
+	label,
+	leading,
+	trailing,
+	className,
+	"aria-label": ariaLabel,
+}: TranscriptDisclosureTriggerProps) {
+	const { isOpen, expandable } = useTranscriptDisclosure()
+	const ChevronIcon = isOpen ? ChevronDownIcon : ChevronRightIcon
+
+	if (!expandable) {
+		return (
+			<div className={cn(triggerClassName, className)} aria-label={ariaLabel}>
+				{leading}
+				<span className="min-w-0 truncate">{label}</span>
+				{trailing}
+			</div>
+		)
+	}
+
+	return (
+		<CollapsibleTrigger className={cn(triggerClassName, className)} aria-label={ariaLabel}>
+			{leading}
+			<span className="min-w-0 truncate">{label}</span>
+			<ChevronIcon aria-hidden="true" className="size-4 shrink-0 transition-transform" />
+			{trailing}
+		</CollapsibleTrigger>
+	)
+})
+
+export interface TranscriptDisclosureContentProps {
+	children: ReactNode
+	className?: string
+}
+
+export const TranscriptDisclosureContent = memo(function TranscriptDisclosureContent({
+	children,
+	className,
+}: TranscriptDisclosureContentProps) {
+	return (
+		<CollapsibleContent
+			className={cn(
+				"outline-none data-closed:mt-0 data-closed:mb-0 data-closed:h-0 data-closed:overflow-hidden data-open:mt-1.5",
+				className,
+			)}
+			keepMounted={false}
+		>
+			{children}
+		</CollapsibleContent>
+	)
+})

--- a/apps/desktop/src/renderer/components/session-route.tsx
+++ b/apps/desktop/src/renderer/components/session-route.tsx
@@ -1,26 +1,10 @@
 /**
  * Route component for /project/$projectSlug/session/$sessionId.
  *
- * Thin wrapper that extracts the sessionId from route params and delegates
- * to SessionView, which contains all the session orchestration logic.
+ * Session rendering is handled by SidebarLayout so the view can stay mounted
+ * while Settings is open. This route exists for URL matching and params only.
  */
 
-import { useParams } from "@tanstack/react-router"
-import { SessionView } from "./session-view"
-
 export function SessionRoute() {
-	const { sessionId } = useParams({ strict: false }) as {
-		sessionId?: string
-		projectSlug?: string
-	}
-
-	if (!sessionId) {
-		return (
-			<div className="flex h-full items-center justify-center">
-				<p className="text-sm text-muted-foreground">No session selected</p>
-			</div>
-		)
-	}
-
-	return <SessionView sessionId={sessionId} />
+	return null
 }

--- a/apps/desktop/src/renderer/components/settings/general-settings.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/general-settings.test.tsx
@@ -52,12 +52,16 @@ describe("GeneralSettings", () => {
 			hasDarkMode: markup.includes(">Dark</button>") || markup.includes(">Dark</"),
 			hasDisplayMode: markup.includes(">Display mode</label>"),
 			hasVerboseMode: markup.includes(">Verbose</div>") || markup.includes(">Verbose<"),
+			hasConversation: markup.includes(">Conversation</h3>"),
+			hasHideThinking: markup.includes(">Hide thinking while working</label>"),
 		}).toEqual({
 			hasAppearance: true,
 			hasTheme: true,
 			hasDarkMode: true,
 			hasDisplayMode: true,
 			hasVerboseMode: true,
+			hasConversation: true,
+			hasHideThinking: true,
 		})
 	})
 })

--- a/apps/desktop/src/renderer/components/settings/general-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/general-settings.tsx
@@ -10,7 +10,7 @@ import { useAtomValue, useSetAtom } from "jotai"
 import { MonitorIcon, MoonIcon, SunIcon } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { opaqueWindowsAtom } from "../../atoms/preferences"
-import { useDisplayMode, useSetDisplayMode } from "../../hooks/use-agents"
+import { useDisplayMode, useHideThinkingWhileWorking, useSetDisplayMode, useSetHideThinkingWhileWorking } from "../../hooks/use-agents"
 import { useColorScheme, useSetColorScheme } from "../../hooks/use-theme"
 import type { ColorScheme } from "../../lib/themes"
 import { fetchOpenInTargets, setOpenInPreferred } from "../../services/backend"
@@ -34,6 +34,10 @@ export function GeneralSettings() {
 				<ThemeRow />
 				<OpaqueWindowsRow />
 				<DisplayModeRow />
+			</SettingsSection>
+
+			<SettingsSection title="Conversation">
+				<HideThinkingWhileWorkingRow />
 			</SettingsSection>
 		</div>
 	)
@@ -171,6 +175,23 @@ function DisplayModeRow() {
 					<SelectItem value="verbose">Verbose</SelectItem>
 				</SelectContent>
 			</Select>
+		</SettingsRow>
+	)
+}
+
+function HideThinkingWhileWorkingRow() {
+	const hideThinkingWhileWorking = useHideThinkingWhileWorking()
+	const setHideThinkingWhileWorking = useSetHideThinkingWhileWorking()
+
+	return (
+		<SettingsRow
+			label="Hide thinking while working"
+			description="Hide model reasoning blocks until the turn completes"
+		>
+			<Switch
+				checked={hideThinkingWhileWorking}
+				onCheckedChange={setHideThinkingWhileWorking}
+			/>
 		</SettingsRow>
 	)
 }

--- a/apps/desktop/src/renderer/components/settings/server-settings.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/server-settings.test.tsx
@@ -40,7 +40,7 @@ describe("ServerSettings", () => {
 		})
 
 	test("shows a collapsed developer trigger without the log path when enabled", () => {
-		const logPath = "/Users/tester/Library/Application Support/Devo/logs/acp-traffic/traffic.jsonl"
+		const logPath = "/Users/tester/.devo/traces/protocol-12345-20260703T153000Z.ndjsonl"
 		const markup = renderToStaticMarkup(
 			<AcpTrafficLogStatus
 				state={{
@@ -53,7 +53,7 @@ describe("ServerSettings", () => {
 		expect({
 			hasDeveloperOptions: markup.includes("Developer options"),
 			hasTrigger: markup.includes("ACP traffic log"),
-			hasDescription: markup.includes("View the current JSONL log location"),
+			hasDescription: markup.includes("Protocol trace enabled via DEVO_PROTOCOL_TRACE"),
 			hasCollapsedState: markup.includes('aria-expanded="false"'),
 			hasPath: markup.includes(logPath),
 			hasSensitiveHint: markup.includes("prompts, paths, tool arguments, and provider details"),
@@ -70,7 +70,7 @@ describe("ServerSettings", () => {
 	})
 
 	test("shows log location details when the developer trigger is expanded", () => {
-		const logPath = "/Users/tester/Library/Application Support/Devo/logs/acp-traffic/traffic.jsonl"
+		const logPath = "/Users/tester/.devo/traces/protocol-12345-20260703T153000Z.ndjsonl"
 		const markup = renderToStaticMarkup(
 			<AcpTrafficLogStatus
 				initialExpanded

--- a/apps/desktop/src/renderer/components/settings/server-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/server-settings.tsx
@@ -213,7 +213,7 @@ export function AcpTrafficLogStatus({
 		>
 			<SettingsRow
 				label="ACP traffic log"
-				description="View the current JSONL log location"
+				description="Protocol trace enabled via DEVO_PROTOCOL_TRACE"
 			>
 				<Button
 					type="button"
@@ -237,7 +237,8 @@ export function AcpTrafficLogStatus({
 						<p className="text-sm text-muted-foreground">No log file path is available.</p>
 					)}
 					<p className="text-xs text-muted-foreground">
-						The log may include prompts, paths, tool arguments, and provider details.
+						Traces are written under DEVO_HOME/traces/ (default ~/.devo/traces/). The log may
+						include prompts, paths, tool arguments, and provider details.
 					</p>
 				</div>
 			)}

--- a/apps/desktop/src/renderer/components/settings/settings-page.tsx
+++ b/apps/desktop/src/renderer/components/settings/settings-page.tsx
@@ -5,6 +5,7 @@ import {
 	SidebarMenuItem,
 } from "@devo/ui/components/sidebar"
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router"
+import { useAtomValue } from "jotai"
 import {
 	ArrowLeftIcon,
 	BellIcon,
@@ -16,6 +17,8 @@ import {
 	WrenchIcon,
 } from "lucide-react"
 import { useEffect } from "react"
+import { lastAppRouteAtom } from "../../atoms/ui"
+import { resolveSettingsBackTarget } from "../../lib/app-navigation"
 import { useSetSidebarSlot } from "../sidebar-slot-context"
 
 // ============================================================
@@ -73,6 +76,7 @@ export function SettingsPage() {
 function SettingsSidebarContent() {
 	const navigate = useNavigate()
 	const pathname = useRouterState({ select: (s) => s.location.pathname })
+	const lastAppRoute = useAtomValue(lastAppRouteAtom)
 
 	// Derive active tab from the last path segment (e.g. "/settings/general" -> "general")
 	const activeTab = pathname.split("/").pop() || "general"
@@ -82,7 +86,7 @@ function SettingsSidebarContent() {
 			<div className="flex shrink-0 flex-col gap-1 px-3 pb-7">
 				<button
 					type="button"
-					onClick={() => navigate({ to: "/" })}
+					onClick={() => navigate(resolveSettingsBackTarget(lastAppRoute))}
 					className="flex h-8 w-full items-center gap-2.5 rounded-lg px-1.5 text-left text-sm font-normal text-muted-foreground transition-colors hover:bg-black/[0.04] hover:text-sidebar-foreground dark:hover:bg-white/[0.06]"
 				>
 					<span className="flex size-[18px] shrink-0 items-center justify-center text-sidebar-foreground/90">

--- a/apps/desktop/src/renderer/components/sidebar-layout.tsx
+++ b/apps/desktop/src/renderer/components/sidebar-layout.tsx
@@ -11,6 +11,7 @@ import {
 	useSidebar,
 } from "@devo/ui/components/sidebar"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@devo/ui/components/tooltip"
+import { cn } from "@devo/ui/lib/utils"
 import { Outlet, useNavigate, useParams, useRouterState } from "@tanstack/react-router"
 import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { type MouseEvent, useCallback, useEffect, useRef, useState } from "react"
@@ -21,6 +22,8 @@ import {
 	desktopFoldersAtom,
 } from "../atoms/desktop-folders"
 import { terminalPanelOpenAtom } from "../atoms/terminal"
+import { settingsBackgroundSessionAtom, settingsOverlayOpenAtom } from "../atoms/ui"
+import { useAppRoutePersistence } from "../hooks/use-app-route-persistence"
 import { useAgents, useProjectList, useSetCommandPaletteOpen } from "../hooks/use-agents"
 import { useAgentActions } from "../hooks/use-server"
 import {
@@ -31,6 +34,7 @@ import {
 	upsertDesktopFolder,
 } from "../lib/desktop-folders"
 import { formatShortcut } from "../lib/shortcut-display"
+import { isSettingsRoute } from "../lib/app-navigation"
 import type { Agent, SidebarProject } from "../lib/types"
 import { createDesktopFolder, pickDirectory, statDesktopFolders } from "../services/backend"
 import { loadProjectSessions } from "../services/connection-manager"
@@ -45,6 +49,7 @@ import {
 } from "./sidebar/sidebar-session-delete"
 import { CreateFolderDialog } from "./sidebar/sidebar-folder-dialogs"
 import { useSidebarSlot } from "./sidebar-slot-context"
+import { SessionView } from "./session-view"
 import { UpdateBanner } from "./update-banner"
 
 // ============================================================
@@ -199,6 +204,14 @@ export function SidebarLayout() {
 	const pathname = useRouterState({ select: (state) => state.location.pathname })
 	const { content: slotContent, footer: slotFooter } = useSidebarSlot()
 	const [terminalPanelOpen, setTerminalPanelOpen] = useAtom(terminalPanelOpenAtom)
+	const backgroundSession = useAtomValue(settingsBackgroundSessionAtom)
+	const [settingsOverlayOpen, setSettingsOverlayOpen] = useAtom(settingsOverlayOpenAtom)
+	useAppRoutePersistence()
+
+	const isSettingsOpen = isSettingsRoute(pathname)
+	if (settingsOverlayOpen !== isSettingsOpen) {
+		setSettingsOverlayOpen(isSettingsOpen)
+	}
 
 	// ---- Sidebar-specific data ----
 	const agents = useAgents()
@@ -223,8 +236,12 @@ export function SidebarLayout() {
 	const visibleAgents = agents
 	const activeAgent = sessionId ? visibleAgents.find((agent) => agent.id === sessionId) : null
 	const terminalDirectory = activeAgent?.worktreePath ?? activeAgent?.directory ?? null
+	const sessionToKeepAlive =
+		sessionId ?? (isSettingsOpen ? backgroundSession?.sessionId : null)
 	const isTranscriptRoute =
-		pathname.includes("/session/") || /^\/automations\/[^/]+\/runs\/[^/]+$/.test(pathname)
+		pathname.includes("/session/") ||
+		(isSettingsOpen && backgroundSession != null) ||
+		/^\/automations\/[^/]+\/runs\/[^/]+$/.test(pathname)
 	const transcriptFillsTitlebar = isMac && isTranscriptRoute
 	const transcriptTitlebarFillAttr = transcriptFillsTitlebar ? "true" : undefined
 
@@ -543,7 +560,24 @@ export function SidebarLayout() {
 							data-transcript-titlebar-fill={transcriptTitlebarFillAttr}
 							className="relative min-h-0 min-w-0 flex-1 overflow-hidden"
 						>
-							<Outlet />
+							<div
+								className={cn(
+									"absolute inset-0 h-full",
+									isSettingsOpen && "pointer-events-none invisible",
+								)}
+								aria-hidden={isSettingsOpen}
+							>
+								{sessionToKeepAlive ? (
+									<SessionView sessionId={sessionToKeepAlive} />
+								) : (
+									!isSettingsOpen && <Outlet />
+								)}
+							</div>
+							{isSettingsOpen && (
+								<div className="absolute inset-0 z-10 h-full overflow-hidden bg-background">
+									<Outlet />
+								</div>
+							)}
 						</div>
 						<DesktopTerminalPanel
 							open={terminalPanelOpen}

--- a/apps/desktop/src/renderer/components/sidebar/app-sidebar-content.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/app-sidebar-content.tsx
@@ -15,7 +15,10 @@ import { activeServerConfigAtom } from "../../atoms/connection"
 import { sandboxMappingsAtom } from "../../atoms/derived/agents"
 import { automationsEnabledAtom } from "../../atoms/feature-flags"
 import { projectPaginationFamily } from "../../atoms/sessions"
+import { appStore } from "../../atoms/store"
+import { sessionScrollTopFamily } from "../../atoms/ui"
 import type { Agent, SidebarProject } from "../../lib/types"
+import { freezeSessionScroll } from "../../lib/settings-scroll-freeze"
 import { openInTarget } from "../../services/backend"
 import { loadMoreProjectSessions, loadProjectSessions } from "../../services/connection-manager"
 import {
@@ -465,7 +468,15 @@ export function AppSidebarContent({
 			<SidebarFooter className="gap-1 px-3 pt-0 pb-3">
 				<button
 					type="button"
-					onClick={() => navigate({ to: "/settings" })}
+					onClick={() => {
+						if (selectedSessionId) {
+							const scrollTop = appStore.get(sessionScrollTopFamily(selectedSessionId))
+							if (scrollTop != null) {
+								freezeSessionScroll(selectedSessionId, scrollTop)
+							}
+						}
+						navigate({ to: "/settings" })
+					}}
 					className={cn(
 						"flex h-8 w-full items-center gap-2.5 rounded-lg px-1.5 text-left text-sm font-normal text-muted-foreground transition-colors hover:bg-black/[0.04] hover:text-sidebar-foreground dark:hover:bg-white/[0.06]",
 					)}

--- a/apps/desktop/src/renderer/hooks/use-agents.ts
+++ b/apps/desktop/src/renderer/hooks/use-agents.ts
@@ -8,7 +8,7 @@ import {
 	projectListAtom,
 	sessionNameFamily,
 } from "../atoms/derived/agents"
-import { type DisplayMode, displayModeAtom } from "../atoms/preferences"
+import { type DisplayMode, displayModeAtom, hideThinkingWhileWorkingAtom } from "../atoms/preferences"
 import { commandPaletteOpenAtom } from "../atoms/ui"
 import { persistAppearanceSettings } from "../lib/settings-sync"
 import type { Agent, SidebarProject } from "../lib/types"
@@ -60,5 +60,19 @@ export const useSetDisplayMode = () => {
 			void persistAppearanceSettings({ displayMode })
 		},
 		[setDisplayMode],
+	)
+}
+
+export const useHideThinkingWhileWorking = (): boolean =>
+	useAtomValue(hideThinkingWhileWorkingAtom)
+
+export const useSetHideThinkingWhileWorking = () => {
+	const setHideThinkingWhileWorking = useSetAtom(hideThinkingWhileWorkingAtom)
+	return useCallback(
+		(hideThinkingWhileWorking: boolean) => {
+			setHideThinkingWhileWorking(hideThinkingWhileWorking)
+			void persistAppearanceSettings({ hideThinkingWhileWorking })
+		},
+		[setHideThinkingWhileWorking],
 	)
 }

--- a/apps/desktop/src/renderer/hooks/use-app-route-persistence.ts
+++ b/apps/desktop/src/renderer/hooks/use-app-route-persistence.ts
@@ -1,0 +1,37 @@
+import { useParams, useRouterState } from "@tanstack/react-router"
+import { useSetAtom } from "jotai"
+import { useEffect } from "react"
+import {
+	lastAppRouteAtom,
+	settingsBackgroundSessionAtom,
+} from "../atoms/ui"
+import { shouldClearBackgroundSession, shouldTrackAppRoute } from "../lib/app-navigation"
+
+/**
+ * Tracks the last non-settings route and the session to keep alive while Settings is open.
+ */
+export function useAppRoutePersistence() {
+	const pathname = useRouterState({ select: (state) => state.location.pathname })
+	const { projectSlug, sessionId } = useParams({ strict: false }) as {
+		projectSlug?: string
+		sessionId?: string
+	}
+	const setLastAppRoute = useSetAtom(lastAppRouteAtom)
+	const setBackgroundSession = useSetAtom(settingsBackgroundSessionAtom)
+
+	useEffect(() => {
+		if (shouldTrackAppRoute(pathname)) {
+			setLastAppRoute(pathname)
+		}
+	}, [pathname, setLastAppRoute])
+
+	useEffect(() => {
+		if (sessionId && projectSlug) {
+			setBackgroundSession({ sessionId, projectSlug })
+			return
+		}
+		if (shouldClearBackgroundSession(pathname, sessionId)) {
+			setBackgroundSession(null)
+		}
+	}, [pathname, projectSlug, sessionId, setBackgroundSession])
+}

--- a/apps/desktop/src/renderer/hooks/use-desktop-settings-sync.ts
+++ b/apps/desktop/src/renderer/hooks/use-desktop-settings-sync.ts
@@ -2,7 +2,7 @@ import { useSetAtom } from "jotai"
 import { useCallback, useEffect } from "react"
 import type { AppSettings } from "../../preload/api"
 import { desktopFoldersAtom } from "../atoms/desktop-folders"
-import { colorSchemeAtom, displayModeAtom, opaqueWindowsAtom, themeAtom } from "../atoms/preferences"
+import { colorSchemeAtom, displayModeAtom, hideThinkingWhileWorkingAtom, opaqueWindowsAtom, themeAtom } from "../atoms/preferences"
 import { buildRendererPreferencesMigrationPatch } from "../lib/settings-sync"
 
 function isElectron(): boolean {
@@ -13,6 +13,7 @@ export function useDesktopSettingsSync() {
 	const setColorScheme = useSetAtom(colorSchemeAtom)
 	const setTheme = useSetAtom(themeAtom)
 	const setDisplayMode = useSetAtom(displayModeAtom)
+	const setHideThinkingWhileWorking = useSetAtom(hideThinkingWhileWorkingAtom)
 	const setOpaqueWindows = useSetAtom(opaqueWindowsAtom)
 	const setDesktopFolders = useSetAtom(desktopFoldersAtom)
 
@@ -21,10 +22,11 @@ export function useDesktopSettingsSync() {
 			setColorScheme(settings.appearance.colorScheme)
 			setTheme(settings.appearance.themeId)
 			setDisplayMode(settings.appearance.displayMode)
+			setHideThinkingWhileWorking(settings.appearance.hideThinkingWhileWorking)
 			setOpaqueWindows(settings.opaqueWindows)
 			setDesktopFolders(settings.desktopFolders.folders)
 		},
-		[setColorScheme, setDesktopFolders, setDisplayMode, setOpaqueWindows, setTheme],
+		[setColorScheme, setDesktopFolders, setDisplayMode, setHideThinkingWhileWorking, setOpaqueWindows, setTheme],
 	)
 
 	useEffect(() => {

--- a/apps/desktop/src/renderer/hooks/use-session-chat.ts
+++ b/apps/desktop/src/renderer/hooks/use-session-chat.ts
@@ -22,8 +22,19 @@ export type { ChatMessageEntry, ChatTurn }
 /** Sentinel empty array — stable reference */
 const EMPTY_ENTRIES: ChatMessageEntry[] = []
 
-/** How many messages to fetch on initial load. */
-const INITIAL_LIMIT = 30
+/**
+ * History is paginated by message count (aligned to user-message boundaries).
+ * Agent turns with many tool calls can span dozens of messages, so budget
+ * generously when targeting a turn count.
+ */
+const MESSAGES_PER_TURN_ESTIMATE = 20
+/** Turns shown when opening a historical session. */
+const INITIAL_TURN_COUNT = 8
+/** Additional turns fetched each time the user scrolls toward the top. */
+const PAGE_TURN_COUNT = 5
+
+const INITIAL_LIMIT = INITIAL_TURN_COUNT * MESSAGES_PER_TURN_ESTIMATE
+const PAGE_SIZE = PAGE_TURN_COUNT * MESSAGES_PER_TURN_ESTIMATE
 
 /**
  * Hook to load chat data for a session.
@@ -43,10 +54,11 @@ export function useSessionChat(
 	const isMockMode = useAtomValue(isMockModeAtom)
 	const [loading, setLoading] = useState(false)
 	const [loadingEarlier, setLoadingEarlier] = useState(false)
+	const [hasEarlierMessages, setHasEarlierMessages] = useState(false)
 	const [error, setError] = useState<string | null>(null)
 	const syncedRef = useRef<string | null>(null)
 	const turnsRef = useRef<ChatTurn[]>([])
-	const hasEarlierRef = useRef(false)
+	const loadedLimitsRef = useRef(new Map<string, number>())
 
 	// Read from Jotai atoms
 	const storeMessages = useAtomValue(messagesFamily(sessionId ?? ""))
@@ -90,12 +102,14 @@ export function useSessionChat(
 					return
 				}
 
+				const limit = loadedLimitsRef.current.get(sid) ?? INITIAL_LIMIT
 				const result = await client.session.messages({
 					sessionID: sid,
-					limit: INITIAL_LIMIT,
+					limit,
 				})
 				const raw = (result.data ?? []) as Array<{ info: Message; parts: Part[] }>
-				hasEarlierRef.current = raw.length >= INITIAL_LIMIT
+				loadedLimitsRef.current.set(sid, limit)
+				setHasEarlierMessages(raw.length >= limit)
 
 				// Hydrate the Jotai store
 				const messages = raw.map((m) => m.info)
@@ -118,19 +132,24 @@ export function useSessionChat(
 		[directory],
 	)
 
-	// Load all messages (for "load earlier" button)
+	// Load the next page of older messages when the user scrolls toward the top.
 	const loadEarlier = useCallback(async () => {
-		if (!sessionId || !directory || loadingEarlier) return
+		if (!sessionId || !directory || loadingEarlier || !hasEarlierMessages) return
 		const client = getProjectClient(directory)
 		if (!client) return
+
+		const currentLimit = loadedLimitsRef.current.get(sessionId) ?? INITIAL_LIMIT
+		const nextLimit = currentLimit + PAGE_SIZE
 
 		setLoadingEarlier(true)
 		try {
 			const result = await client.session.messages({
 				sessionID: sessionId,
+				limit: nextLimit,
 			})
 			const raw = (result.data ?? []) as Array<{ info: Message; parts: Part[] }>
-			hasEarlierRef.current = false
+			loadedLimitsRef.current.set(sessionId, nextLimit)
+			setHasEarlierMessages(raw.length >= nextLimit)
 
 			const messages = raw.map((m) => m.info)
 			const parts: Record<string, Part[]> = {}
@@ -145,7 +164,7 @@ export function useSessionChat(
 		} finally {
 			setLoadingEarlier(false)
 		}
-	}, [sessionId, directory, loadingEarlier])
+	}, [sessionId, directory, loadingEarlier, hasEarlierMessages])
 
 	// Trigger initial fetch when session changes (skip in mock mode -- data is pre-hydrated)
 	useEffect(() => {
@@ -160,16 +179,15 @@ export function useSessionChat(
 	//
 	// - turnsRef: structural-sharing cache — must be cleared so stale turn objects
 	//   from the previous session aren't mixed into the new session's render.
-	// - hasEarlierRef: tracks whether the server has older messages to load.
-	//   MUST be cleared so the "Load earlier messages" button from a previous
-	//   session (that had 30+ messages) doesn't appear on a freshly-switched
-	//   session whose atom is still empty.
+	// - hasEarlierMessages: tracks whether the server has older messages to load.
+	//   MUST be cleared so the load-earlier affordance from a previous session
+	//   doesn't appear on a freshly-switched session whose atom is still empty.
 	// - loading: if the new session has no cached data yet, pre-set the loading
 	//   flag so the UI shows a spinner instead of "No messages yet" during the
 	//   one render that happens before the fetch effect fires.
 	useEffect(() => {
 		turnsRef.current = []
-		hasEarlierRef.current = false
+		setHasEarlierMessages(false)
 		if (!isMockMode && sessionId) {
 			const hasCachedData = (appStore.get(messagesFamily(sessionId)) ?? []).length > 0
 			if (!hasCachedData) {
@@ -184,7 +202,7 @@ export function useSessionChat(
 		loading,
 		loadingEarlier,
 		error,
-		hasEarlierMessages: hasEarlierRef.current,
+		hasEarlierMessages,
 		loadEarlier,
 		reload: fetchAndHydrate,
 	}

--- a/apps/desktop/src/renderer/lib/app-navigation.test.ts
+++ b/apps/desktop/src/renderer/lib/app-navigation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+import {
+	isOverlayRoute,
+	isSettingsRoute,
+	resolveSettingsBackTarget,
+	shouldClearBackgroundSession,
+	shouldTrackAppRoute,
+} from "./app-navigation"
+
+describe("app navigation", () => {
+	test("shouldTrackAppRoute ignores overlay routes", () => {
+		expect(shouldTrackAppRoute("/")).toBe(true)
+		expect(shouldTrackAppRoute("/project/foo/session/bar")).toBe(true)
+		expect(shouldTrackAppRoute("/settings")).toBe(false)
+		expect(shouldTrackAppRoute("/settings/general")).toBe(false)
+		expect(shouldTrackAppRoute("/automations")).toBe(false)
+		expect(shouldTrackAppRoute("/automations/foo/runs/bar")).toBe(false)
+	})
+
+	test("isSettingsRoute matches settings paths only", () => {
+		expect(isSettingsRoute("/settings")).toBe(true)
+		expect(isSettingsRoute("/settings/servers")).toBe(true)
+		expect(isSettingsRoute("/automations")).toBe(false)
+		expect(isSettingsRoute("/project/foo/session/bar")).toBe(false)
+	})
+
+	test("isOverlayRoute matches settings and automations", () => {
+		expect(isOverlayRoute("/settings/general")).toBe(true)
+		expect(isOverlayRoute("/automations/foo")).toBe(true)
+		expect(isOverlayRoute("/project/foo/session/bar")).toBe(false)
+	})
+
+	test("resolveSettingsBackTarget restores last route or home", () => {
+		expect(resolveSettingsBackTarget("/project/foo/session/bar")).toEqual({
+			to: "/project/foo/session/bar",
+		})
+		expect(resolveSettingsBackTarget(null)).toEqual({ to: "/" })
+	})
+
+	test("shouldClearBackgroundSession clears on non-session app routes", () => {
+		expect(shouldClearBackgroundSession("/", undefined)).toBe(true)
+		expect(shouldClearBackgroundSession("/project/foo", undefined)).toBe(true)
+		expect(shouldClearBackgroundSession("/project/foo/", undefined)).toBe(true)
+		expect(shouldClearBackgroundSession("/settings/general", undefined)).toBe(false)
+		expect(shouldClearBackgroundSession("/project/foo/session/bar", "bar")).toBe(false)
+	})
+})

--- a/apps/desktop/src/renderer/lib/app-navigation.ts
+++ b/apps/desktop/src/renderer/lib/app-navigation.ts
@@ -1,0 +1,28 @@
+const OVERLAY_ROUTE_PREFIXES = ["/settings", "/automations"] as const
+
+export function isOverlayRoute(pathname: string): boolean {
+	return OVERLAY_ROUTE_PREFIXES.some(
+		(prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+	)
+}
+
+export function isSettingsRoute(pathname: string): boolean {
+	return pathname === "/settings" || pathname.startsWith("/settings/")
+}
+
+export function shouldTrackAppRoute(pathname: string): boolean {
+	return !isOverlayRoute(pathname)
+}
+
+export function resolveSettingsBackTarget(lastRoute: string | null): { to: string } {
+	return { to: lastRoute ?? "/" }
+}
+
+export function shouldClearBackgroundSession(
+	pathname: string,
+	sessionId: string | undefined,
+): boolean {
+	if (isOverlayRoute(pathname)) return false
+	if (sessionId) return false
+	return pathname === "/" || /^\/project\/[^/]+\/?$/.test(pathname)
+}

--- a/apps/desktop/src/renderer/lib/session-metrics.test.ts
+++ b/apps/desktop/src/renderer/lib/session-metrics.test.ts
@@ -66,6 +66,23 @@ describe("turn duration metrics", () => {
 		expect(computeTurnWorkTime(turn, { now: () => 99_000 })).toBe(8_000)
 	})
 
+	test("uses the latest persisted part end when assistant completion is recorded early", () => {
+		const turn = turnWith([
+			{
+				info: { id: "a1", role: "assistant", time: { created: 1_100, completed: 1_200 } },
+				parts: [
+					{
+						id: "tool-1",
+						type: "tool",
+						state: { status: "completed", time: { start: 2_000, end: 31_000 } },
+					},
+				],
+			},
+		] as ChatTurn["assistantMessages"])
+
+		expect(computeTurnWorkTime(turn)).toBe(30_000)
+	})
+
 	test("uses Date.now only for active turns", () => {
 		const turn = turnWith([
 			{
@@ -159,7 +176,7 @@ describe("top bar turn timer metrics", () => {
 
 		expect({ split, label: formatTimerSplit(split, now) }).toEqual({
 			split: { completedMs: 0, activeStartMs: start },
-			label: "0s",
+			label: "1s",
 		})
 	})
 

--- a/apps/desktop/src/renderer/lib/session-metrics.ts
+++ b/apps/desktop/src/renderer/lib/session-metrics.ts
@@ -167,6 +167,26 @@ function terminalPartTimestamp(part: Part): number | undefined {
 	return typeof end === "number" ? end : undefined
 }
 
+function completedTurnWorkEnd(turn: ChatTurn): number | undefined {
+	let end: number | undefined
+
+	for (const entry of turn.assistantMessages) {
+		const completed = entry.info.time.completed
+		if (typeof completed === "number") {
+			end = end === undefined ? completed : Math.max(end, completed)
+		}
+		for (const part of entry.parts) {
+			const timestamp = terminalPartTimestamp(part)
+			if (timestamp !== undefined) {
+				end = end === undefined ? timestamp : Math.max(end, timestamp)
+			}
+		}
+	}
+
+	if (end !== undefined) return end
+	return completedTurnEnd(turn)
+}
+
 function completedTurnStopTime(turn: ChatTurn): number | undefined {
 	for (let i = turn.assistantMessages.length - 1; i >= 0; i--) {
 		const completed = turn.assistantMessages[i].info.time.completed
@@ -196,7 +216,7 @@ export function computeTurnWorkTime(
 	options: { active?: boolean; now?: () => number } = {},
 ): number {
 	const start = turn.userMessage.info.time.created
-	const end = options.active ? (options.now?.() ?? Date.now()) : completedTurnEnd(turn)
+	const end = options.active ? (options.now?.() ?? Date.now()) : completedTurnWorkEnd(turn)
 	if (typeof start !== "number" || typeof end !== "number") return 0
 	const elapsed = Math.max(0, end - start)
 	if (!options.active && elapsed > MAX_COMPLETED_TURN_WORK_TIME_MS) return 0
@@ -734,10 +754,10 @@ export function estimateContextBreakdown(
 // Formatters
 // ============================================================
 
-/** Format milliseconds as a compact duration string: "12s", "1m 34s", "2h 5m". */
+/** Format milliseconds as a compact duration string: "1s", "12s", "1m 34s", "2h 5m". */
 export function formatWorkDuration(ms: number): string {
-	const seconds = Math.floor(ms / 1000)
-	if (seconds < 1) return "0s"
+	if (ms <= 0) return "0s"
+	const seconds = Math.ceil(ms / 1000)
 	if (seconds < 60) return `${seconds}s`
 	const minutes = Math.floor(seconds / 60)
 	const remainingSeconds = seconds % 60

--- a/apps/desktop/src/renderer/lib/settings-scroll-freeze.ts
+++ b/apps/desktop/src/renderer/lib/settings-scroll-freeze.ts
@@ -1,0 +1,47 @@
+const frozenScrollBySessionId = new Map<string, number>()
+let pendingRestoreScrollTop: number | null = null
+let settingsOverlayWasOpen = false
+let restoredScrollTop: number | null = null
+let restoredUntilMs = 0
+
+const RESTORE_GUARD_MS = 2_000
+
+export function freezeSessionScroll(sessionId: string, scrollTop: number): void {
+	frozenScrollBySessionId.set(sessionId, scrollTop)
+}
+
+export function getFrozenSessionScroll(sessionId: string): number | null {
+	return frozenScrollBySessionId.get(sessionId) ?? null
+}
+
+export function clearFrozenSessionScroll(sessionId: string): void {
+	frozenScrollBySessionId.delete(sessionId)
+}
+
+export function setPendingRestoreScrollTop(scrollTop: number | null): void {
+	pendingRestoreScrollTop = scrollTop
+}
+
+export function getPendingRestoreScrollTop(): number | null {
+	return pendingRestoreScrollTop
+}
+
+export function markScrollRestored(scrollTop: number): void {
+	restoredScrollTop = scrollTop
+	restoredUntilMs = Date.now() + RESTORE_GUARD_MS
+}
+
+export function getRestoredScrollTop(): number | null {
+	if (restoredScrollTop == null || Date.now() > restoredUntilMs) {
+		restoredScrollTop = null
+		return null
+	}
+	return restoredScrollTop
+}
+
+/** Module-level overlay tracking that survives component remounts. */
+export function trackSettingsOverlayOpen(open: boolean): boolean {
+	const wasOpen = settingsOverlayWasOpen
+	settingsOverlayWasOpen = open
+	return wasOpen
+}

--- a/apps/desktop/src/renderer/lib/settings-sync.test.ts
+++ b/apps/desktop/src/renderer/lib/settings-sync.test.ts
@@ -46,6 +46,7 @@ const defaultSettings: AppSettings = {
 		colorScheme: "dark",
 		themeId: "default",
 		displayMode: "default",
+		hideThinkingWhileWorking: true,
 		rendererPreferencesMigrated: false,
 	},
 	openIn: {

--- a/apps/desktop/src/renderer/lib/settings-sync.ts
+++ b/apps/desktop/src/renderer/lib/settings-sync.ts
@@ -19,6 +19,7 @@ function readRendererAppearanceSnapshot(storage: Storage): AppearancePatch {
 	const colorScheme = readJsonStorageValue(storage, "devo:colorScheme")
 	const themeId = readJsonStorageValue(storage, "devo:theme")
 	const displayMode = readJsonStorageValue(storage, "devo:displayMode")
+	const hideThinkingWhileWorking = readJsonStorageValue(storage, "devo:hideThinkingWhileWorking")
 
 	const snapshot: AppearancePatch = {}
 	if (typeof colorScheme === "string" && COLOR_SCHEMES.has(colorScheme)) {
@@ -29,6 +30,9 @@ function readRendererAppearanceSnapshot(storage: Storage): AppearancePatch {
 	}
 	if (typeof displayMode === "string" && DISPLAY_MODES.has(displayMode)) {
 		snapshot.displayMode = displayMode as AppearanceSettings["displayMode"]
+	}
+	if (typeof hideThinkingWhileWorking === "boolean") {
+		snapshot.hideThinkingWhileWorking = hideThinkingWhileWorking
 	}
 	return snapshot
 }

--- a/apps/desktop/src/renderer/services/connection-manager.test.ts
+++ b/apps/desktop/src/renderer/services/connection-manager.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import type { DevoClient } from "@devo-ai/sdk/v2/client"
 import type { Event, Session } from "../lib/types"
+import { partsFamily, partStorageKey } from "../atoms/parts"
 import { sessionFamily, upsertSessionAtom } from "../atoms/sessions"
 import { appStore } from "../atoms/store"
 
@@ -64,12 +65,13 @@ mock.module("./devo", () => ({
 	getSession: async () => null,
 	getSessionStatuses: async () => getSessionStatusesImpl(),
 	listProjects: async () => [],
+	projectsFromSessions: (sessions: Session[]) => sessions,
 	listSessions: async (client: DevoClient, options?: unknown) => listSessionsImpl(client, options),
 	subscribeToGlobalEvents: async (client: DevoClient) =>
 		streamFor(((client as unknown as { directory?: string }).directory) ?? "__base__"),
 }))
 
-describe("connection manager project status bridge", () => {
+describe("connection manager project event bridge", () => {
 	beforeEach(() => {
 		streams.clear()
 		listSessionsImpl = async () => []
@@ -117,6 +119,46 @@ describe("connection manager project status bridge", () => {
 		await new Promise((resolve) => setTimeout(resolve, 5))
 
 		expect(appStore.get(sessionFamily(session.id))?.status).toEqual({ type: "busy" })
+	})
+
+	test("forwards project-scoped message part events into renderer state", async () => {
+		const directory = "/repo/project-message-bridge"
+		const session: Session = {
+			id: "message-bridge-session",
+			directory,
+			title: "Message bridge",
+			time: { created: 1, updated: 1 },
+		}
+		appStore.set(upsertSessionAtom, { session, directory })
+
+		const manager = await import(`./connection-manager?case=${Date.now()}`)
+		activeManager = manager
+		await manager.connectToDevo("devo://stdio")
+		expect(manager.getProjectClient(directory)).not.toBeNull()
+
+		streamFor(directory).push({
+			type: "message.part.updated",
+			properties: {
+				part: {
+					id: "assistant-message-text",
+					sessionID: session.id,
+					messageID: "assistant-message",
+					type: "text",
+					text: "hello from project stream",
+				},
+			},
+		})
+		await new Promise((resolve) => setTimeout(resolve, 5))
+
+		expect(appStore.get(partsFamily(partStorageKey(session.id, "assistant-message")))).toEqual([
+			{
+				id: "assistant-message-text",
+				sessionID: session.id,
+				messageID: "assistant-message",
+				type: "text",
+				text: "hello from project stream",
+			},
+		])
 	})
 
 	test("loads project statuses after session list hydration", async () => {

--- a/apps/desktop/src/renderer/services/connection-manager.ts
+++ b/apps/desktop/src/renderer/services/connection-manager.ts
@@ -18,14 +18,14 @@ import {
 	updateStreamingPart,
 } from "../atoms/streaming"
 import { createLogger } from "../lib/logger"
-import type { Event } from "../lib/types"
+import type { Event, Session } from "../lib/types"
 import {
 	connectToServer,
 	disposeAllInstances,
 	getSession,
 	getSessionStatuses,
-	listProjects,
 	listSessions,
+	projectsFromSessions,
 	subscribeToGlobalEvents,
 } from "./devo"
 
@@ -63,8 +63,11 @@ let connection: {
 /** Per-project SDK clients, keyed by directory path */
 const projectClients = new Map<string, DevoClient>()
 
-/** Project clients whose local session.status stream is bridged into the UI store. */
-const projectStatusBridgeDirs = new Set<string>()
+/** Unscoped `session/list` snapshot from the latest discovery pass. */
+let discoveredSessions: Session[] | null = null
+
+/** Project clients whose local event stream is bridged into the UI store. */
+const projectEventBridgeDirs = new Set<string>()
 
 /**
  * Monotonically increasing ID for event loop instances.
@@ -92,7 +95,65 @@ function setGlobalAbort(controller: AbortController | null) {
 
 function clearProjectClients(): void {
 	projectClients.clear()
-	projectStatusBridgeDirs.clear()
+	projectEventBridgeDirs.clear()
+}
+
+function clearDiscoverySessionCache(): void {
+	discoveredSessions = null
+}
+
+function normalizeDirectoryPath(value: string): string {
+	return value.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase()
+}
+
+function filterDiscoveredSessions(
+	sessions: Session[],
+	directory: string,
+	options?: { limit?: number; roots?: boolean; search?: string },
+): Session[] {
+	const target = normalizeDirectoryPath(directory)
+	let filtered = sessions.filter((session) => {
+		if (!session.directory) return false
+		return normalizeDirectoryPath(session.directory) === target
+	})
+	if (options?.roots) {
+		filtered = filtered.filter((session) => !session.parentID)
+	}
+	if (options?.search) {
+		const query = options.search.toLowerCase()
+		filtered = filtered.filter((session) =>
+			(session.title ?? session.id).toLowerCase().includes(query),
+		)
+	}
+	if (options?.limit !== undefined) {
+		filtered = filtered.slice(0, options.limit)
+	}
+	return filtered
+}
+
+async function hydrateProjectSessionsFromCache(
+	directory: string,
+	sandboxDirs: Set<string> | undefined,
+	options: { limit?: number; roots?: boolean; search?: string } | undefined,
+): Promise<boolean> {
+	if (!discoveredSessions) return false
+
+	const baseClient = getBaseClient()
+	if (!baseClient) return false
+
+	const sessions = filterDiscoveredSessions(discoveredSessions, directory, options)
+	const statuses = await getSessionStatuses(baseClient)
+	appStore.set(setSessionsAtom, { sessions, statuses, directory, sandboxDirs })
+
+	if (options?.limit !== undefined) {
+		appStore.set(updateProjectPaginationAtom, {
+			directory,
+			fetchedCount: sessions.length,
+			limit: options.limit,
+		})
+	}
+
+	return true
 }
 
 // ============================================================
@@ -112,6 +173,7 @@ export async function connectToDevo(url: string, authHeader?: string | null): Pr
 		log.info("Disconnecting previous connection", { url: connection.url })
 		connection.abortController.abort()
 		clearProjectClients()
+		clearDiscoverySessionCache()
 	}
 
 	// Also abort any stale ACP event loop from a previous HMR module that we can't
@@ -165,7 +227,9 @@ export async function loadAllProjects() {
 		return []
 	}
 	try {
-		const projects = await listProjects(client)
+		const sessions = await listSessions(client)
+		discoveredSessions = sessions
+		const projects = projectsFromSessions(sessions)
 		log.info("Loaded projects from API", { count: projects.length })
 		return projects
 	} catch (err) {
@@ -188,13 +252,21 @@ export async function loadProjectSessions(
 	sandboxDirs?: Set<string>,
 	options?: { limit?: number; roots?: boolean; search?: string },
 ): Promise<void> {
-	const client = getProjectClient(directory)
-	if (!client) return
-
-	// Set loading state so the sidebar shows a spinner
 	if (options?.limit) {
 		appStore.set(setProjectPaginationLoadingAtom, directory)
 	}
+
+	if (await hydrateProjectSessionsFromCache(directory, sandboxDirs, options)) {
+		log.info("Loaded sessions for project from discovery cache", {
+			directory,
+			limit: options?.limit,
+			roots: options?.roots,
+		})
+		return
+	}
+
+	const client = getProjectClient(directory)
+	if (!client) return
 
 	try {
 		const sessions = await listSessions(client, options)
@@ -242,6 +314,19 @@ export async function loadMoreProjectSessions(
 	const nextLimit = currentLimit + SESSIONS_PAGE_SIZE
 	log.info("Loading more sessions", { directory, currentLimit, nextLimit })
 	appStore.set(setProjectPaginationLoadingAtom, directory)
+
+	if (
+		await hydrateProjectSessionsFromCache(directory, undefined, {
+			limit: nextLimit,
+			roots: true,
+		})
+	) {
+		log.info("Loaded more sessions for project from discovery cache", {
+			directory,
+			limit: nextLimit,
+		})
+		return
+	}
 
 	const client = getProjectClient(directory)
 	if (!client) {
@@ -314,7 +399,7 @@ export function getProjectClient(directory: string): DevoClient | null {
 			authHeader: connection.authHeader ?? undefined,
 		})
 		projectClients.set(directory, client)
-		startProjectStatusBridge(client, directory, connection.abortController.signal)
+		startProjectEventBridge(client, directory, connection.abortController.signal)
 	}
 	return client
 }
@@ -647,9 +732,9 @@ async function startEventLoop(
 	log.info("ACP event loop exited", { generation, stale: generation !== eventLoopGeneration })
 }
 
-function startProjectStatusBridge(client: DevoClient, directory: string, signal: AbortSignal): void {
-	if (projectStatusBridgeDirs.has(directory)) return
-	projectStatusBridgeDirs.add(directory)
+function startProjectEventBridge(client: DevoClient, directory: string, signal: AbortSignal): void {
+	if (projectEventBridgeDirs.has(directory)) return
+	projectEventBridgeDirs.add(directory)
 
 	void (async () => {
 		const batcher = createEventBatcher()
@@ -658,17 +743,17 @@ function startProjectStatusBridge(client: DevoClient, directory: string, signal:
 			for await (const globalEvent of stream) {
 				if (signal.aborted) break
 				const event = globalEvent.payload
-				if (event?.type === "session.status") {
+				if (event) {
 					batcher.enqueue(event)
 				}
 			}
 		} catch (err) {
 			if (!signal.aborted) {
-				log.warn("Project status bridge stopped", { directory }, err)
+				log.warn("Project event bridge stopped", { directory }, err)
 			}
 		} finally {
 			batcher.dispose(signal.aborted)
-			projectStatusBridgeDirs.delete(directory)
+			projectEventBridgeDirs.delete(directory)
 		}
 	})()
 }

--- a/apps/desktop/src/renderer/services/devo.ts
+++ b/apps/desktop/src/renderer/services/devo.ts
@@ -5,6 +5,7 @@ import type {
 	WorkspaceDiffDetail,
 } from "@devo-ai/sdk/v2/client"
 import { createDevoClient } from "@devo-ai/sdk/v2/client"
+import { stableId } from "@devo-ai/sdk/v2/acp-client-support"
 import type { Event, DevoProject, QuestionAnswer, Session, SessionStatus } from "../lib/types"
 import { createLogger } from "../lib/logger"
 import { workspacePatchFilesFromView } from "../lib/workspace-diff"
@@ -44,8 +45,51 @@ export function connectToServer(url: string, options?: ConnectOptions): DevoClie
  * Fetch all projects known to the server.
  */
 export async function listProjects(client: DevoClient): Promise<DevoProject[]> {
-	const result = await client.project.list()
-	return (result.data as DevoProject[]) ?? []
+	const sessions = await listSessions(client)
+	return projectsFromSessions(sessions, clientDirectory(client))
+}
+
+/**
+ * Derive project entries from a session list returned by `session/list`.
+ */
+export function projectsFromSessions(
+	sessions: Session[],
+	fallbackDirectory?: string,
+): DevoProject[] {
+	const byDirectory = new Map<string, DevoProject>()
+	for (const session of sessions) {
+		const directory = session.directory
+		if (!directory) continue
+		const previous = byDirectory.get(directory)
+		const updated = session.time.lastActivity ?? session.time.updated ?? session.time.created
+		if (previous) {
+			previous.time.updated = Math.max(previous.time.updated ?? 0, updated)
+			continue
+		}
+		byDirectory.set(directory, {
+			id: stableId(directory),
+			name: directory.split(/[\\/]/).filter(Boolean).at(-1) ?? directory,
+			worktree: directory,
+			path: { root: directory },
+			time: { created: session.time.created, updated },
+			sandboxes: [],
+		})
+	}
+	if (byDirectory.size === 0 && fallbackDirectory) {
+		byDirectory.set(fallbackDirectory, {
+			id: stableId(fallbackDirectory),
+			name: fallbackDirectory.split(/[\\/]/).filter(Boolean).at(-1) ?? fallbackDirectory,
+			worktree: fallbackDirectory,
+			path: { root: fallbackDirectory },
+			time: { created: Date.now(), updated: Date.now() },
+			sandboxes: [],
+		})
+	}
+	return [...byDirectory.values()]
+}
+
+function clientDirectory(client: DevoClient): string | undefined {
+	return (client as { directory?: string }).directory
 }
 
 /**

--- a/apps/desktop/src/shared/app-settings.ts
+++ b/apps/desktop/src/shared/app-settings.ts
@@ -26,6 +26,7 @@ export const DEFAULT_APPEARANCE_SETTINGS: AppearanceSettings = {
 	colorScheme: "dark",
 	themeId: "default",
 	displayMode: "default",
+	hideThinkingWhileWorking: true,
 	rendererPreferencesMigrated: false,
 }
 


### PR DESCRIPTION
  persistence

  - Refactor chat-turn into composable structure
  - Add ProcessTimeline view for turn visualization
  - Add ThoughtRow and TranscriptDisclosure components
  - Add app-navigation with route persistence
  - Add settings-scroll-freeze and connection-manager tests
  - Make IPC transport a singleton to prevent duplicate subscriptions
  - Add session metrics with token usage display