### PR TITLE
fix: enable image input for MiniMax-M3

### DIFF
--- a/crates/core/models.json
+++ b/crates/core/models.json
@@ -42,7 +42,8 @@
             "limit": 10000
         },
         "input_modalities": [
-            "text"
+            "text",
+            "image"
         ],
         "reasoning_implementation": {
             "model_variant": {

--- a/crates/core/src/model_catalog.rs
+++ b/crates/core/src/model_catalog.rs
@@ -154,6 +154,17 @@ mod tests {
     }
 
     #[test]
+    fn builtin_minimax_m3_supports_image_input() {
+        let model = load_builtin_models()
+            .expect("load builtin models")
+            .into_iter()
+            .find(|model| model.slug == "MiniMax-M3")
+            .expect("MiniMax-M3 model");
+
+        assert!(model.input_modalities.contains(&InputModality::Image));
+    }
+
+    #[test]
     fn load_from_config_applies_partial_builtin_override_without_replacing_metadata() {
         let builtin = load_builtin_models()
             .expect("load builtins")


### PR DESCRIPTION
Reason: MiniMax-M3 is cataloged as text-only in the built-in model catalog although the model supports image input and Devo already supports image attachments end to end.

Changes:
- Add `image` to the `input_modalities` of the `MiniMax-M3` built-in model entry in `crates/core/models.json`.
- Add a catalog regression test (`builtin_minimax_m3_supports_image_input`) asserting MiniMax-M3 advertises image input.

Checks:
- `cargo fmt --all -- --check`
- `cargo test -p devo-core model_catalog`
