### PR TITLE
fix(tui): remove extra spacing between message area and composer

### DIFF
--- a/crates/tui/src/chatwidget/render.rs
+++ b/crates/tui/src/chatwidget/render.rs
@@ -119,7 +119,6 @@ impl Renderable for ChatWidget {
         history_height
             .saturating_add(self.subagent_live_list_desired_height())
             .saturating_add(self.bottom_pane.desired_height(width))
-            .saturating_add(2)
     }
 
     fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
@@ -139,12 +138,17 @@ impl ChatWidget {
         let bottom_height = self
             .bottom_pane
             .desired_height(area.width)
-            .min(area.height.saturating_sub(1).max(3));
+            .min(area.height);
         let subagent_height = self
             .subagent_live_list_desired_height()
-            .min(area.height.saturating_sub(bottom_height).saturating_sub(1));
+            .min(area.height.saturating_sub(bottom_height));
+        let history_height = u16::try_from(
+            self.active_viewport_lines(area.width.max(1)).len(),
+        )
+        .unwrap_or(u16::MAX)
+        .min(area.height.saturating_sub(bottom_height).saturating_sub(subagent_height));
         let [history_area, subagent_area, bottom_area] = Layout::vertical([
-            Constraint::Min(1),
+            Constraint::Length(history_height),
             Constraint::Length(subagent_height),
             Constraint::Length(bottom_height),
         ])

--- a/crates/tui/src/chatwidget/render.rs
+++ b/crates/tui/src/chatwidget/render.rs
@@ -135,18 +135,17 @@ impl Renderable for ChatWidget {
 
 impl ChatWidget {
     fn chat_layout_areas(&self, area: Rect) -> (Rect, Rect, Rect) {
-        let bottom_height = self
-            .bottom_pane
-            .desired_height(area.width)
-            .min(area.height);
+        let bottom_height = self.bottom_pane.desired_height(area.width).min(area.height);
         let subagent_height = self
             .subagent_live_list_desired_height()
             .min(area.height.saturating_sub(bottom_height));
-        let history_height = u16::try_from(
-            self.active_viewport_lines(area.width.max(1)).len(),
-        )
-        .unwrap_or(u16::MAX)
-        .min(area.height.saturating_sub(bottom_height).saturating_sub(subagent_height));
+        let history_height = u16::try_from(self.active_viewport_lines(area.width.max(1)).len())
+            .unwrap_or(u16::MAX)
+            .min(
+                area.height
+                    .saturating_sub(bottom_height)
+                    .saturating_sub(subagent_height),
+            );
         let [history_area, subagent_area, bottom_area] = Layout::vertical([
             Constraint::Length(history_height),
             Constraint::Length(subagent_height),


### PR DESCRIPTION
## Summary

Fix the 3-line gap between the message output area and the composer (dialog box) in the TUI.

## Root Cause

Three issues in `crates/tui/src/chatwidget/render.rs`:

1. **`desired_height` added +2 extra rows** — the viewport was always 2 rows taller than the actual content sum
2. **Bottom pane height clamping `saturating_sub(1)`** — shaved 1 row off the bottom pane even when the viewport was exactly sized
3. **`Constraint::Min(1)` for history arena** — forced at least 1 empty row even with no messages, because this ratatui fork guarantees Min constraints their minimum

## Changes

- Use exact `Constraint::Length(history_height)` computed from actual viewport line count instead of `Constraint::Min(1)`
- Remove `+ 2` padding in `desired_height`
- Remove `saturating_sub(1)` clamping on bottom height

The three changes work together to ensure viewport height exactly equals the sum of content heights with no leftover blank rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)